### PR TITLE
Modified S3CreateError path to match pip version of boto

### DIFF
--- a/django_extensions/management/commands/sync_media_s3.py
+++ b/django_extensions/management/commands/sync_media_s3.py
@@ -247,7 +247,7 @@ class Command(BaseCommand):
                 key.name = file_key
                 key.set_contents_from_string(filedata, headers, replace=True)
                 key.set_acl('public-read')
-            except boto.s3.connection.S3CreateError, e:
+            except boto.exception.S3CreateError, e:
                 print "Failed: %s" % e
             except Exception, e:
                 print e


### PR DESCRIPTION
The exception catcher near the bottom of the sync_media_s3 command imports the S3CreateError from a location where it does not exist in the pip version of boto. I've flopped in the place where I see it.
