### PR TITLE
JSON field warning on django 1.3

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -69,12 +69,12 @@ class JSONField(models.TextField):
         else:
             return value
 
-    def get_db_prep_save(self, value):
+    def get_prep_save(self, value):
         """Convert our JSON object to a string before we save"""
         if not value:
-            return super(JSONField, self).get_db_prep_save("")
+            return super(JSONField, self).get_prep_save("")
         else:
-            return super(JSONField, self).get_db_prep_save(dumps(value))
+            return super(JSONField, self).get_prep_save(dumps(value))
 
     def south_field_triple(self):
         "Returns a suitable description of this field for South."


### PR DESCRIPTION
get_db_prep_value has been refactored to get_prep_value in dev version of django:
http://docs.djangoproject.com/en/dev/howto/custom-model-fields/#the-subfieldbase-metaclass

this currently raise a warning.
