### PR TITLE
AutoSlugField can optionally accept duplicate slugs

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -44,6 +44,7 @@ class AutoSlugField(SlugField):
             self._populate_from = populate_from
         self.separator = kwargs.pop('separator',  u'-')
         self.overwrite = kwargs.pop('overwrite', False)
+        self.allow_duplicates = kwargs.pop('allow_duplicates', False)
         super(AutoSlugField, self).__init__(*args, **kwargs)
 
     def _slug_strip(self, value):
@@ -77,7 +78,7 @@ class AutoSlugField(SlugField):
             # step from its number, clean-up
             slug = self._slug_strip(getattr(model_instance, self.attname))
             next = slug.split(self.separator)[-1]
-            if next.isdigit():
+            if next.isdigit() and not self.allow_duplicates:
                 slug = self.separator.join(slug.split(self.separator)[:-1])
                 next = int(next)
             else:
@@ -90,6 +91,9 @@ class AutoSlugField(SlugField):
             slug = slug[:slug_len]
         slug = self._slug_strip(slug)
         original_slug = slug
+
+        if self.allow_duplicates:
+            return slug
 
         # exclude the current model instance from the queryset used in finding
         # the next valid slug


### PR DESCRIPTION
Sometimes slugs just don't need to be unique.  Stack Overflow, Reddit, eBay, Amazon, and many other high traffic websites use slugs to enhance the look of their URLs, but they still maintain a short unique key used to lookup data.  This allows for slugs to be changed without worrying about 404 errors due to the lookup key being changed.  It also allows for slightly faster lookups.

For this reason, I added an `allow_duplicates` argument to `AutoSlugField`.  This argument disables uniqueness comparisons to existing slug values and does not strip numbers off the end of the slug.  This argument is called `allow_duplicates` instead of `unique` because it does not actually control the uniqueness of the field at the database level.

This should fix issue #33.
