### PR TITLE
model graphs: show reverse relation names

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -240,6 +240,10 @@ def generate_dot(app_labels, **kwargs):
             else:
                 model['label'] = model['name']
 
+            # show reverse relation names
+            if hasattr(field, 'related_query_name'):
+                label += ' (%s)' % field.related_query_name()
+
             # model attributes
             def add_attributes(field):
                 if verbose_names and field.verbose_name:


### PR DESCRIPTION
It can be really confusing to see, for example, inside a `class Author(models.Model):` method: `self.corpus`,  since it's only defined elsewhere as:

```
class Blog(models.Model):
    author = models.ForeignKey(Author, verbose_name=_("Blog Author"), related_name="corpus")
```

So this patch puts the related name in brackets after the forward field name.
