### PR TITLE
Added a parameter to get_db_prep_save calls to squash deprecation warnings in newest Django release

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -25,7 +25,7 @@ class BaseEncryptedField(models.Field):
 
         return retval
 
-    def get_db_prep_value(self, value):
+    def get_db_prep_value(self, value, connection):
         if not value.startswith(self.prefix):
             value = self.prefix + self.crypt.Encrypt(value)
         return value

--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -75,7 +75,7 @@ class JSONField(models.TextField):
         else:
             return value
 
-    def get_db_prep_save(self, value):
+    def get_db_prep_save(self, value, connection):
         """Convert our JSON object to a string before we save"""
         if not value:
             return super(JSONField, self).get_db_prep_save("")


### PR DESCRIPTION
add connection parameter to get_db_prep_save calls to avoid deprecation warnings in Django >= 1.3 ref: http://docs.djangoproject.com/en/dev/releases/1.2-alpha-1/#get-db-prep-methods-on-field
