### PR TITLE
ActivatorModel & TimeStampedModel: default orderings, smart enumerations, and fixed manager

### DIFF
--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -41,11 +41,11 @@ class ActivatorModelManager(models.Manager):
     """
     def active(self):
         """ Returns active instances of ActivatorModel: SomeModel.objects.active() """
-        return super(ActivatorModelManager, self).get_query_set().filter(status=ActivatorModel.ACTIVE_STATUS)
+        return self.get_query_set().filter(status=ActivatorModel.ACTIVE_STATUS)
 
     def inactive(self):
         """ Returns inactive instances of ActivatorModel: SomeModel.objects.inactive() """
-        return super(ActivatorModelManager, self).get_query_set().filter(status=ActivatorModel.INACTIVE_STATUS)
+        return self.get_query_set().filter(status=ActivatorModel.INACTIVE_STATUS)
 
 
 class ActivatorModel(models.Model):


### PR DESCRIPTION
These changes should (probably) not affect existing projects:
- `get_latest_by` & `ordering` defaults should help save typing in models which subclass ActivatorModel & TimeStampedModel
- [Smarter, cleaner choices](http://www.b-list.org/weblog/2007/nov/02/handle-choices-right-way/) for ActivatorModel
- When I [first wrote](https://github.com/tehfink/django-extensions/commit/00ffbe4aa0dbcb9743b39eec5790823a0684ff23) the `ActivatorModelManager`, I didn't try modifying the queryset of a model which inherits from it. This change allows the manager of a subclassed model to do that, and still use `active()` and `inactive()`
