### PR TITLE
Add South support to encrypted fields

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -25,7 +25,7 @@ class BaseEncryptedField(models.Field):
 
         return retval
 
-    def get_db_prep_value(self, value):
+    def get_db_prep_value(self, value, connection, prepared=False):
         if value and not value.startswith(self.prefix):
             value = self.prefix + self.crypt.Encrypt(value)
         return value


### PR DESCRIPTION
A straight copy-paste of `south_field_triple(self)` function from `django_extensions.db.fields.json.JSONField` to `django_extensions.db.fields.encrypted.EncryptedTextField` and `django_extensions.db.fields.encrypted.EncryptedCharField`.
