### PR TITLE
Try to import update_wrapper from functools.

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -16,7 +16,10 @@ from django.db.models.query import QuerySet
 from django.utils.encoding import smart_str
 from django.utils.translation import ugettext as _
 from django.utils.text import get_text_list
-from django.utils.functional import update_wrapper
+try:
+    from functools import update_wrapper
+except ImportError:
+    from django.utils.functional import update_wrapper
 
 from django_extensions.admin.widgets import ForeignKeySearchInput
 


### PR DESCRIPTION
Django trunk is abandoning Python 2.4 support, and thus no longer includes update_wrapper in its functional library. Try to get it from functools first.

Opening a new pull request because my old one was tracking my master branch.
