### PR TITLE
Fix TypeError: expected a character buffer object on passwd cmd use.

### DIFF
--- a/django_extensions/management/commands/passwd.py
+++ b/django_extensions/management/commands/passwd.py
@@ -35,4 +35,4 @@ class Command(BaseCommand):
         u.set_password(p1)
         u.save()
 
-        return "Password changed successfully for user", u.username
+        return "Password changed successfully for user " + u.username


### PR DESCRIPTION
big issue, small fix for passwd command.
