### PR TITLE
remove proxy models (not relevent for a database graph) from graph_models

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -206,6 +206,10 @@ def generate_dot(app_labels, **kwargs):
         })
 
         for appmodel in get_models(app):
+            # skip proxy classes drawing.
+            if hasattr(appmodel, '_meta') and appmodel._meta.proxy:
+                continue
+
             abstracts = [e.__name__ for e in appmodel.__bases__ if hasattr(e, '_meta') and e._meta.abstract]
 
             # collect all attribs of abstract superclasses


### PR DESCRIPTION
Remove proxy models (which are not relevent for a database graph) from graph_models.

As it may be a 'flavour' to draw proxy classes you may prefer to add an option to get this behaviour... but I assume it's a better default.
