### PR TITLE
add 'text/javascript' to GZIP_CONTENT_TYPES;

### DIFF
--- a/django_extensions/management/commands/sync_media_s3.py
+++ b/django_extensions/management/commands/sync_media_s3.py
@@ -61,7 +61,8 @@ class Command(BaseCommand):
     GZIP_CONTENT_TYPES = (
         'text/css',
         'application/javascript',
-        'application/x-javascript'
+        'application/x-javascript',
+        'text/javascript'
     )
 
     upload_count = 0


### PR DESCRIPTION
javascript files are not gzipped because their mime types in 'text/javascript' and not 'application/javascript'
