### PR TITLE
reset_db postgres error

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -133,7 +133,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (settings.DATABASE_NAME,))
 
             database_name = options.get('dbname', 'template1')
             if options.get('dbname') == None:
-                database_name = 'template1'
+                database_name = settings.DATABASE_NAME
             conn_string = "dbname=%s" % database_name
             if settings.DATABASE_USER:
                 conn_string += " user=%s" % user


### PR DESCRIPTION
I just ran into this problem on webfaction where I dont't have a pg_hba.conf entry for my user.

This patch tells reset_db to use settings.DATBASE_NAME if --dbname isn't given as an option.
