### PR TITLE
Updated to use drop tables statements for Django 1.2+

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -51,13 +51,14 @@ class Command(BaseCommand):
                 del options[k]
         return options
 
-    def getConnection(self,*args,**options):
+    def getConnection(self, *args, **options):
         from django.db.utils import ConnectionHandler, DEFAULT_DB_ALIAS
         if not settings.DATABASES:
             if settings.DATABASE_ENGINE:
                 import warnings
                 warnings.warn(
-                    "settings.DATABASE_* is deprecated; use settings.DATABASES instead.",
+                    "settings.DATABASE_* is deprecated; use \
+                        settings.DATABASES instead.",
                     DeprecationWarning
                 )
 
@@ -73,7 +74,7 @@ class Command(BaseCommand):
                 'TEST_COLLATION': settings.TEST_DATABASE_COLLATION,
                 'TEST_NAME': settings.TEST_DATABASE_NAME,
             }
-        router = options.get('router',DEFAULT_DB_ALIAS)
+        router = options.get('router', DEFAULT_DB_ALIAS)
 
         connections = ConnectionHandler(settings.DATABASES)
         connection = connections[router]
@@ -104,23 +105,28 @@ Type 'yes' to continue, or 'no' to cancel: """ % (settings.DATABASE_NAME,))
             return
 
         if django.get_version() >= "1.2":
-            self.handle_gt_12(*args,**options)
+            self.handle_gt_12(*args, **options)
         else:
-            self.handle_lg_12(*args,**options)
+            self.handle_lg_12(*args, **options)
         if verbosity >= 2 or options.get('interactive'):
             print "Reset successful."
 
     def handle_gt_12(self, *args, **options):
-        connection = self.getConnection(*args,**options)
+        connection = self.getConnection(*args, **options)
         d_only = options['django_only']
-        drop_commands = sql.sql_flush( self.style, connection, only_django=d_only )
+        drop_commands = sql.sql_flush(
+            self.style,
+            connection,
+            only_django=d_only
+        )
         create_commands = []
         apps = get_apps()
         for app in apps:
-            create_commands.extend( sql.sql_create( app, self.style,connection ) )
-        connection.cursor().executemany( drop_commands , [] )
-        connection.cursor().executemany( create_commands , [] )
-        
+            create_commands.extend(
+                sql.sql_create(app, self.style, connection)
+            )
+        connection.cursor().executemany(drop_commands, [])
+        connection.cursor().executemany(create_commands, [])
 
     def handle_lt_12(self, *args, **options):
         """
@@ -218,4 +224,3 @@ Type 'yes' to continue, or 'no' to cancel: """ % (settings.DATABASE_NAME,))
 
         else:
             raise CommandError("Unknown database engine %s" % engine)
-


### PR DESCRIPTION
I changed the handling for django 1.2+ to use code found in sql_reset and sql_create. These commands return the drop tables statements and the create tables statements from the core backend introspection modules. While this should work with django < 1.2 with minimal effort  i've left the tried and tested code behind a switch as I currently cannot spare more time to do regression tests.

Bonus. I've cleaned it up to pep8 standards and cleaned up some options handling to use pythonic

<pre>
options.get('key', default)
</pre>

rather than cludgy 

<pre>
if value is None:
    value=default
</pre>


This should take care of issue #73
