### PR TITLE
Platform independent message for PyGraphviz

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         try:
             import pygraphviz
         except ImportError, e:
-            raise CommandError("need pygraphviz python module ( apt-get install python-pygraphviz )")
+            raise CommandError("You need to install pygraphviz python module")
 
         vizdata = ' '.join(dotdata.split("\n")).strip().encode('utf-8')
         version = pygraphviz.__version__.rstrip("-svn")


### PR DESCRIPTION
Since not all of us are Ubuntu/Debian users error messages like 
`[..] ( apt-get install python-pygraphviz )` is quite...strange, don't you think?
