### PR TITLE
JSON field failing in django 1.3.1 

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -86,10 +86,10 @@ class JSONField(models.TextField):
     def get_db_prep_save(self, value, connection):
         """Convert our JSON object to a string before we save"""
         if not isinstance(value, (list, dict)):
-            return super(JSONField, self).get_db_prep_save("", connection)
+            return super(JSONField, self).get_db_prep_save("", connection=connection)
         else:
             return super(JSONField, self).get_db_prep_save(dumps(value),
-                                                           connection)
+                                                           connection=connection)
 
     def south_field_triple(self):
         "Returns a suitable description of this field for South."

--- a/django_extensions/tests/__init__.py
+++ b/django_extensions/tests/__init__.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django_extensions.tests.utils import UTILS_TRUNCATE_LETTERS_TESTS
 from django_extensions.tests.utils import UTILS_UUID_TESTS
+from django_extensions.tests.json_field import JsonFieldTest
 try:
     from django_extensions.tests.encrypted_fields import EncryptedFieldsTestCase
     from django_extensions.tests.models import Secret

--- a/django_extensions/tests/json_field.py
+++ b/django_extensions/tests/json_field.py
@@ -1,0 +1,30 @@
+import unittest
+
+
+from django.db import connection
+from django.conf import settings
+from django.core.management import call_command
+from django.db.models import loading
+from django.db import models
+from django_extensions.db.fields.json import JSONField
+
+
+class TestModel(models.Model):
+    a = models.IntegerField()
+    j_field = JSONField()
+
+class JsonFieldTest(unittest.TestCase):
+
+    def setUp(self):
+        self.old_installed_apps = settings.INSTALLED_APPS
+        settings.INSTALLED_APPS.append('django_extensions.tests')
+        loading.cache.loaded = False
+        call_command('syncdb', verbosity=0)
+
+    def tearDown(self):
+        settings.INSTALLED_APPS = self.old_installed_apps
+
+    def testCharFieldCreate(self):
+
+        j = TestModel.objects.create(a=6, j_field=dict(foo='bar'))
+        


### PR DESCRIPTION
Its possible I just wasn't using it correctly but the problem seems to have been introduced in:
https://github.com/django-extensions/django-extensions/commit/db549c0c6a0ac5ca963187bbded9aeb2e05daff8

Borrowed the idea from:
https://github.com/bradjasper/django-jsonfield/blob/master/jsonfield/fields.py

Also added a crappy test since I couldn't find any for JsonField

Seems to work in 1.3.1 and django-trunk now.
