### PR TITLE
Ignore FileFields/ImageFields without an associated file in unreferenced_files cmd

### DIFF
--- a/django_extensions/management/commands/unreferenced_files.py
+++ b/django_extensions/management/commands/unreferenced_files.py
@@ -37,7 +37,9 @@ class Command(NoArgsCommand):
             all = model.objects.all().iterator()
             for object in all:
                 for field in model_dict[model]:
-                    referenced.append(os.path.abspath(getattr(object, field.name).path))
+                    target_file = getattr(object, field.name)
+                    if target_file:
+                        referenced.append(os.path.abspath(target_file.path))
 
         # Print each file in MEDIA_ROOT that is not referenced in the database
         for m in media:


### PR DESCRIPTION
Small, quick fix: the `unreferenced_files` management command shouldn't error out if a FileField or ImageFIeld allows blank/null=True and has no file associated.
