### PR TITLE
Make notes command python 2.5 compatible

### DIFF
--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 import os


### PR DESCRIPTION
This should close bug 151.
Without this fix, installing django-extensions under python2.5 causes setup.py to crash on the 'with' statement.
