### PR TITLE
Added support for django 1.4 timezones

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -15,7 +15,7 @@ try:
     from django.utils.timezone import now as datetime_now
 except ImportError:
     import datetime
-    datetime_now = datetime.datetime.utcnow
+    datetime_now = datetime.datetime.now
 
 
 class AutoSlugField(SlugField):


### PR DESCRIPTION
I hope I did not miss any code that relied on this but it worked for me quite good and is django1.3 compatible.  I did not touch the mongodb compatibility code as this has no visible timezone support for me.
