### PR TITLE
Display execution time after query

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -1,6 +1,7 @@
 import os
 from django.core.management.base import NoArgsCommand
 from optparse import make_option
+from datetime import datetime
 
 
 class Command(NoArgsCommand):
@@ -41,14 +42,18 @@ class Command(NoArgsCommand):
 
             class PrintQueryWrapper(util.CursorDebugWrapper):
                 def execute(self, sql, params=()):
+                    starttime = datetime.now()
                     try:
                         return self.cursor.execute(sql, params)
                     finally:
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
+                        execution_time = datetime.now() - starttime
                         if sqlparse:
                             print sqlparse.format(raw_sql, reindent=True)
                         else:
                             print raw_sql
+                        print
+                        print 'Execution time: %fs' % execution_time.total_seconds()
                         print
 
             util.CursorDebugWrapper = PrintQueryWrapper


### PR DESCRIPTION
I adapted the pull request django-debug-toolbar/django-debug-toolbar#164 for django-extensions. It shows the execution time of each query after the SQL code.

![Screenshot](http://ich-wars-nicht.ch/tmp/screenshots/20120216_195740.png)
