### PR TITLE
Append filename with .gz when it gzips, this way if you run sync_media_s...

### DIFF
--- a/django_extensions/management/commands/sync_media_s3.py
+++ b/django_extensions/management/commands/sync_media_s3.py
@@ -233,6 +233,7 @@ class Command(BaseCommand):
                 # and only if file is a common text type (not a binary file)
                 if file_size > 1024 and content_type in self.GZIP_CONTENT_TYPES:
                     filedata = self.compress_string(filedata)
+                    filename+='.gz'
                     headers['Content-Encoding'] = 'gzip'
                     if self.verbosity > 1:
                         print "\tgzipped: %dk to %dk" % \


### PR DESCRIPTION
...3 multiple times, once for regular upload and once again for a gzipped copy, there will be distinct file names. Currently if you run 1) ./manage.py sync_media_s3 mybucket and then 2) ./manage.py sync_media_s3 mybucket --gzip, all of the filenames in 1) are the same in 2) so all of the regular ones get replaced by gzipped copies. It would be better if we could keep the names different. Thanks!
