### PR TITLE
Fix #186 - find_template management command does not work

### DIFF
--- a/django_extensions/management/commands/find_template.py
+++ b/django_extensions/management/commands/find_template.py
@@ -1,13 +1,22 @@
 from django.core.management.base import LabelCommand
-from django.template.loader import find_template
+from django.template import loader
 from django.template import TemplateDoesNotExist
 import sys
 
 
 def get_template_path(path):
     try:
-        template = find_template(path)
-        return template[1].name
+        template = loader.find_template(path)
+        if template[1]:
+            return template[1].name
+        # work arround https://code.djangoproject.com/ticket/17199 issue
+        for template_loader in loader.template_source_loaders:
+            try:
+                source, origin = template_loader.load_template_source(path)
+                return origin
+            except TemplateDoesNotExist:
+                pass
+        raise TemplateDoesNotExist(path)
     except TemplateDoesNotExist:
         return None
 


### PR DESCRIPTION
find_template management command does not work

Django does not find_template does not return origin, see:
https://code.djangoproject.com/ticket/17199
