### PR TITLE
s3 error fix for non-standard region

### DIFF
--- a/django_extensions/management/commands/sync_media_s3.py
+++ b/django_extensions/management/commands/sync_media_s3.py
@@ -112,6 +112,7 @@ class Command(BaseCommand):
         else:
             self.AWS_ACCESS_KEY_ID = settings.AWS_ACCESS_KEY_ID
             self.AWS_SECRET_ACCESS_KEY = settings.AWS_SECRET_ACCESS_KEY
+        self.AWS_REGION = getattr(settings, 'AWS_REGION', 'us-east-1')
 
         if not hasattr(settings, 'AWS_BUCKET_NAME'):
             raise CommandError('Missing bucket name from settings file. Please' +
@@ -174,7 +175,11 @@ class Command(BaseCommand):
         """
         Opens connection to S3 returning bucket and key
         """
-        conn = boto.connect_s3(self.AWS_ACCESS_KEY_ID, self.AWS_SECRET_ACCESS_KEY)
+        conn = boto.connect_s3(
+            self.AWS_ACCESS_KEY_ID,
+            self.AWS_SECRET_ACCESS_KEY,
+            host=self.AWS_REGION,
+        )
         try:
             bucket = conn.get_bucket(self.AWS_BUCKET_NAME)
         except boto.exception.S3ResponseError:

--- a/docs/sync_media_s3.rst
+++ b/docs/sync_media_s3.rst
@@ -41,3 +41,4 @@ The keys are added to your settings.py file, for example::
   # settings.py
   AWS_ACCESS_KEY_ID = ''
   AWS_SECRET_ACCESS_KEY = ''
+  AWS_REGION = ''  # default to "us-east-1"


### PR DESCRIPTION
Problem 'socket.error: [Errno 32] Broken pipe' fixed when using a non-standard region.
Problem raised on boto with solution: https://github.com/boto/boto/issues/621

I implemented it for sync_media_s3, and updated the doc
