### PR TITLE
Fixed issue with models containing self-relationships.

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -233,7 +233,12 @@ def generate_dot(app_labels, **kwargs):
                 if hasattr(field, 'related_query_name'):
                     label += ' (%s)' % field.related_query_name()
 
-                target_model = field.model if field.rel.to == 'self' else field.rel.to
+                # handle self-relationships
+                if field.rel.to == 'self':
+                    target_model = field.model 
+                else:
+                    target_model = field.rel.to
+
                 _rel = {
                     'target_app': target_model.__module__.replace('.', '_'),
                     'target': target_model.__name__,


### PR DESCRIPTION
When running ./manage graph_models on an app containing models with self relationships we get the following error:

"""
Traceback (most recent call last):
  File "./manage.py", line 14, in <module>
...
  File "/usr/local/lib/python2.6/dist-packages/django_extensions-0.8-py2.6.egg/django_extensions/management/commands/graph_models.py", line 41, in handle
    dotdata = generate_dot(args, **options)
  File "/usr/local/lib/python2.6/dist-packages/django_extensions-0.8-py2.6.egg/django_extensions/management/modelviz.py", line 258, in generate_dot
    add_relation(field, '[arrowhead=none, arrowtail=dot]')
  File "/usr/local/lib/python2.6/dist-packages/django_extensions-0.8-py2.6.egg/django_extensions/management/modelviz.py", line 237, in add_relation
    'target_app': field.rel.to.**module**.replace('.', '_'),
AttributeError: 'str' object has no attribute '__module__'
"""

In these cases, "field.rel.to" contains the string "self".
