### PR TITLE
Change JSONField to allow empty lists

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -71,7 +71,7 @@ class JSONField(models.TextField):
 
     def to_python(self, value):
         """Convert our string value to JSON after we load it from the DB"""
-        if not value:
+        if value is None or value == '':
             return {}
         elif isinstance(value, basestring):
             res = loads(value)

--- a/django_extensions/tests/json_field.py
+++ b/django_extensions/tests/json_field.py
@@ -28,4 +28,8 @@ class JsonFieldTest(unittest.TestCase):
     def testCharFieldCreate(self):
 
         j = TestModel.objects.create(a=6, j_field=dict(foo='bar'))
-        
+
+    def testEmptyList(self):
+        j = TestModel.objects.create(a=6, j_field=[])
+        self.assertIsInstance(j.j_field, list)
+        self.assertEquals(j.j_field, [])


### PR DESCRIPTION
Currently, JSONField.to_python(value) returns a dict if value is falsy. This makes it impossible to store empty lists:

```
>>> j = TestModel.objects.create(a=6, j_field=[])
>>> j.j_field
{}
```

I've changed it to return a dict only on None and empty strings, allowing empty lists:

```
>>> j = TestModel.objects.create(a=6, j_field=[])
>>> j.j_field
[]
```
