### PR TITLE
Fix: 'tuple' object has no attribute 'pop' when try add django_extension...

### DIFF
--- a/django_extensions/tests/test_dumpscript.py
+++ b/django_extensions/tests/test_dumpscript.py
@@ -2,23 +2,22 @@ import sys
 from StringIO import StringIO
 from django.test import TestCase
 from django.core.management import call_command
+from django.test.utils import override_settings
 from django_extensions.tests.models import Name
 
 from django.conf import settings
 from django.db.models import loading
 
+@override_settings(INSTALLED_APPS = settings.INSTALLED_APPS + ('django_extensions.tests',))
 class DumpScriptTests(TestCase):
     def setUp(self):
         self.real_stdout = sys.stdout
         sys.stdout = StringIO()
-
-        settings.INSTALLED_APPS += ('django_extensions.tests',)
         loading.cache.loaded = False
         call_command('syncdb', verbosity=0)
 
     def tearDown(self):
         sys.stdout = self.real_stdout
-        settings.INSTALLED_APPS.pop()
         loading.cache.loaded = False
 
     def test_runs(self):
@@ -27,3 +26,4 @@ class DumpScriptTests(TestCase):
         n.save()
         call_command('dumpscript', 'tests')
         self.assertTrue('Gabriel' in sys.stdout.getvalue())
+


### PR DESCRIPTION
Tests fails because INSTALLED_APPS isn't a list and doesn't have pop function.
