### PR TITLE
Updated to encrypted fields to truncate if necessary before encryption

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -75,8 +75,6 @@ class EncryptedCharField(BaseEncryptedField):
     __metaclass__ = models.SubfieldBase
 
     def __init__(self, max_length=None, *args, **kwargs):
-        if max_length:
-            max_length += len(self.prefix)
         super(EncryptedCharField, self).__init__(max_length=max_length, *args, **kwargs)
 
     def get_internal_type(self):


### PR DESCRIPTION
If an encrypted field exceeds the maximum length the DB supports it gets truncated by the database, only raising a warning and allowing execution to continue.
If an attempt is made to read that same field back, decryption fails on the truncated data, and not only has part of the data been lost, it is now completely unreadable.

This addresses that by reporting a more accurate size to the database layer when creating tables, and truncating as necessary before data is passed on to the database. Therefore data written will be successfully read back.

It also removes the particularly incorrect size adjustment done is the EncryptedCharField field, which assumed the length of the encrypted data is the same as unencrypted, which is incorrect given the initialization vector and base64 encoding.
