### PR TITLE
Bugfix: Escaped database name for MySQL.

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -113,9 +113,9 @@ Type 'yes' to continue, or 'no' to cancel: """ % (settings.DATABASE_NAME,))
                 kwargs['port'] = int(settings.DATABASE_PORT)
 
             connection = Database.connect(**kwargs)
-            drop_query = 'DROP DATABASE IF EXISTS %s' % settings.DATABASE_NAME
+            drop_query = 'DROP DATABASE IF EXISTS `%s`' % settings.DATABASE_NAME
             utf8_support = options.get('no_utf8_support', False) and '' or 'CHARACTER SET utf8'
-            create_query = 'CREATE DATABASE %s %s' % (settings.DATABASE_NAME, utf8_support)
+            create_query = 'CREATE DATABASE `%s` %s' % (settings.DATABASE_NAME, utf8_support)
             logging.info('Executing... "' + drop_query + '"')
             connection.query(drop_query)
             logging.info('Executing... "' + create_query + '"')


### PR DESCRIPTION
MySQL will complain if the database name contain an special character such as dash if it is not escaped.

```
mysql> CREATE DATABASE my-db;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-db' at line 1
mysql> CREATE DATABASE `my-db`;
Query OK, 1 row affected (0.00 sec)
```
