### PR TITLE
Django 1.4 WSGI_APPLICATION support

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -47,7 +47,10 @@ class Command(BaseCommand):
         except ImportError:
             USE_ADMINMEDIAHANDLER = False
 
-        from django.core.handlers.wsgi import WSGIHandler
+        try:
+            from django.core.servers.basehttp import get_internal_wsgi_application as WSGIHandler
+        except ImportError:
+            from django.core.handlers.wsgi import WSGIHandler
         try:
             from werkzeug import run_simple, DebuggedApplication
         except ImportError:


### PR DESCRIPTION
Django 1.4 adds a setting to specify the WSGI_APPLICATION. This allows
wsgi middlewares to be applied.

This patch uses
`django.core.servers.basehttp.get_internal_wsgi_application` in order to
respect the setting.
