### PR TITLE
Fixed bug on AutoSlugField with empty populate_from field

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -82,9 +82,8 @@ class AutoSlugField(SlugField):
             slug = self.separator.join(map(slug_for_field, self._populate_from))
             next = 2
         else:
-            # get slug from the current model instance and calculate next
-            # step from its number, clean-up
-            slug = self._slug_strip(getattr(model_instance, self.attname))
+            # get slug from the current model instance
+            slug = getattr(model_instance, self.attname)
             # model_instance is being modified, and overwrite is False,
             # so instead of doing anything, just return the current slug
             return slug

--- a/django_extensions/tests/fields.py
+++ b/django_extensions/tests/fields.py
@@ -61,3 +61,29 @@ class AutoSlugFieldTest(unittest.TestCase):
 
         m.save()
         self.assertEqual(m.slug, 'foo-2012')
+
+    def testSimpleSlugSource(self):
+        m = SluggedTestModel(title='-foo')
+        m.save()
+        self.assertEqual(m.slug, 'foo')
+
+        n = SluggedTestModel(title='-foo')
+        n.save()
+        self.assertEqual(n.slug, 'foo-2')
+
+        n.save()
+        self.assertEqual(n.slug, 'foo-2')
+
+    def testEmptySlugSource(self):
+        # regression test
+
+        m = SluggedTestModel(title='')
+        m.save()
+        self.assertEqual(m.slug, '-2')
+
+        n = SluggedTestModel(title='')
+        n.save()
+        self.assertEqual(n.slug, '-3')
+
+        n.save()
+        self.assertEqual(n.slug, '-3')


### PR DESCRIPTION
This test failed on the last assertion

```
    m = SluggedTestModel(title='')
    m.save()
    self.assertEqual(m.slug, '-2')

    n = SluggedTestModel(title='')
    n.save()
    self.assertEqual(n.slug, '-3')

    n.save()
    self.assertEqual(n.slug, '-3')
```
