### PR TITLE
Ouput redirection for dumpscript

### DIFF
--- a/django_extensions/tests/test_dumpscript.py
+++ b/django_extensions/tests/test_dumpscript.py
@@ -10,7 +10,9 @@ from django.db.models import loading
 class DumpScriptTests(TestCase):
     def setUp(self):
         self.real_stdout = sys.stdout
+        self.real_stderr = sys.stderr
         sys.stdout = StringIO()
+        sys.stderr = StringIO()
 
         self.original_installed_apps = settings.INSTALLED_APPS
         settings.INSTALLED_APPS = list(settings.INSTALLED_APPS)
@@ -20,6 +22,7 @@ class DumpScriptTests(TestCase):
 
     def tearDown(self):
         sys.stdout = self.real_stdout
+        sys.stderr = self.real_stderr
         settings.INSTALLED_APPS.remove('django_extensions.tests')
         settings.INSTALLED_APPS = self.original_installed_apps
         loading.cache.loaded = False
@@ -31,3 +34,27 @@ class DumpScriptTests(TestCase):
         call_command('dumpscript', 'tests')
         self.assertTrue('Gabriel' in sys.stdout.getvalue())
 
+    #----------------------------------------------------------------------
+    def test_replaced_stdout(self):
+        # check if stdout can be replaced
+        sys.stdout = StringIO()
+        n = Name(name='Mike')
+        n.save()
+        tmp_out = StringIO()
+        call_command('dumpscript', 'tests', stdout=tmp_out)
+        self.assertTrue('Mike' in tmp_out.getvalue()) # script should go to tmp_out
+        self.assertFalse(sys.stdout.len) # there should not be any output to sys.stdout
+        tmp_out.close()
+
+    #----------------------------------------------------------------------
+    def test_replaced_stderr(self):
+        # check if stderr can be replaced, without changing stdout
+        n = Name(name='Fred')
+        n.save()
+        tmp_err = StringIO()
+        sys.stderr = StringIO()
+        call_command('dumpscript', 'tests', stderr=tmp_err)
+        self.assertTrue('Fred' in sys.stdout.getvalue()) # script should still go to stdout
+        self.assertTrue('Name' in tmp_err.getvalue()) # error output should go to tmp_err
+        self.assertFalse(sys.stderr.len) # there should not be any output to sys.stderr
+        tmp_err.close()


### PR DESCRIPTION
Django custom management commands usually offer a method to redirect the output of the command, when calling it using _call_command_. 

This did not work for _dumpscript *, because it was using print and sys.stderr instead of the stdout and stderr properties provided by Django's *BaseCommand_ class.

This patch corrects that and adds some basic tests to check if the redirection is working
