### PR TITLE
Update ActivatorModel to use timezone-aware datetime if available and active

### DIFF
--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -1,11 +1,16 @@
 """
 Django Extensions abstract base model classes.
 """
-import datetime
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields import (ModificationDateTimeField,
                                          CreationDateTimeField, AutoSlugField)
+
+try:
+    from django.utils.timezone import now as datetime_now
+except ImportError:
+    import datetime
+    datetime_now = datetime.datetime.now
 
 
 class TimeStampedModel(models.Model):
@@ -71,5 +76,5 @@ class ActivatorModel(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.activate_date:
-            self.activate_date = datetime.datetime.now()
+            self.activate_date = datetime_now()
         super(ActivatorModel, self).save(*args, **kwargs)


### PR DESCRIPTION
Without this, getting a RuntimeWarning: DateTimeField received a naive datetime (...) while time zone support is active.
