### PR TITLE
Added database alias output for shell_plus --print-sql

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -53,7 +53,7 @@ class Command(NoArgsCommand):
                         else:
                             print raw_sql
                         print
-                        print 'Execution time: %.6fs' % execution_time
+                        print 'Execution time: %.6fs [Database: %s]' % (execution_time, self.db.alias)
                         print
 
             util.CursorDebugWrapper = PrintQueryWrapper


### PR DESCRIPTION
With multiple databases, it was helpful to display the database used for the query.
