### PR TITLE
Fixed typo in JSONField

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -69,7 +69,7 @@ class JSONField(models.TextField):
         if not default:
             kwargs['default'] = '{}'
         elif isinstance(default, (list, dict)):
-            kwargs['default'] = dump(value)
+            kwargs['default'] = dumps(default)
         models.TextField.__init__(self, *args, **kwargs)
 
     def to_python(self, value):


### PR DESCRIPTION
Fixes #27. Previous fix introduced a typo that caused a NameError when using a dict or list in the 'default' kwarg for JSONField.
