### PR TITLE
Added --print-sql option to runserver_plus

### DIFF
--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             port = int(port)
 
         # Add console handler
-        setup_logger(logger, filename=options.get('output_file', None))
+        setup_logger(logger, stream=self.stdout, filename=options.get('output_file', None))
 
         def inner_run():
             quit_command = (sys.platform == 'win32') and 'CTRL-BREAK' or 'CONTROL-C'

--- a/django_extensions/management/utils.py
+++ b/django_extensions/management/utils.py
@@ -26,18 +26,30 @@ def _make_writeable(filename):
         os.chmod(filename, new_permissions)
 
 
-def setup_logger(logger, stream=sys.stdout, filename=None):
+def setup_logger(logger, stream, filename=None, fmt=None):
     """Sets up a logger (if no handlers exist) for console output,
     and file 'tee' output if desired."""
     if len(logger.handlers) < 1:
         console = logging.StreamHandler(stream)
         console.setLevel(logging.DEBUG)
-        console.setFormatter(logging.Formatter())
+        console.setFormatter(logging.Formatter(fmt))
         logger.addHandler(console)
         logger.setLevel(logging.DEBUG)
 
         if filename:
             outfile = logging.FileHandler(filename)
             outfile.setLevel(logging.INFO)
-            outfile.setFormatter(logging.Formatter())
+            outfile.setFormatter(logging.Formatter("%(asctime)s " + (fmt if fmt else '%(message)s')))
             logger.addHandler(outfile)
+
+
+class RedirectHandler(logging.Handler):
+    """Redirect logging sent to one logger (name) to another."""
+    def __init__(self, name, level=logging.DEBUG):
+        # Contemplate feasibility of copying a destination (allow original handler) and redirecting.
+        super(RedirectHandler, self).__init__(level)
+        self.name = name
+        self.logger = logging.getLogger(name)
+
+    def emit(self, record):
+        self.logger.handle(record)


### PR DESCRIPTION
Added a --print-sql option to runserver_plus, using Python logging for output to console/file and capturing output from both werkzeug and django.db.backends (using modified PrintQueryWrapper)
