### PR TITLE
Fix compatibility with python 2.6

### DIFF
--- a/django_extensions/management/utils.py
+++ b/django_extensions/management/utils.py
@@ -47,7 +47,7 @@ class RedirectHandler(logging.Handler):
     """Redirect logging sent to one logger (name) to another."""
     def __init__(self, name, level=logging.DEBUG):
         # Contemplate feasibility of copying a destination (allow original handler) and redirecting.
-        super(RedirectHandler, self).__init__(level)
+        logging.Handler.__init__(self, level)
         self.name = name
         self.logger = logging.getLogger(name)
 


### PR DESCRIPTION
logging.Handler is an old-style class in python 2.6 thus you cannot
use super() with it. Using old-style calling works, and should also
work in newer python versions.
