### PR TITLE
Don't use $ because it's declared as a global elsewhere and gets set to undefined

### DIFF
--- a/django_extensions/static/django_extensions/js/jquery.ajaxQueue.js
+++ b/django_extensions/static/django_extensions/js/jquery.ajaxQueue.js
@@ -44,16 +44,16 @@ $(function(){
  */
 
 
-(function($) {
+(function(jQuery) {
 
-	var ajax = $.ajax;
+	var ajax = jQuery.ajax;
 
 	var pendingRequests = {};
 
 	var synced = [];
 	var syncedData = [];
 
-	$.ajax = function(settings) {
+	jQuery.ajax = function(settings) {
 		// create settings for compatibility with ajaxSetup
 		settings = jQuery.extend(settings, jQuery.extend({}, jQuery.ajaxSettings, settings));
 


### PR DESCRIPTION
Looks like jquery.ajaxQueue.js is still referencing jQuery on line 58. Throwing the error: "TypeError: Cannot read property 'ajaxSettings' of undefined". It's also odd because $ is also undefined at that point too. I assume it's because $ is defined as a global elsewhere and being set to undefined.
