### PR TITLE
Enhance validate_templates to check url tags

### DIFF
--- a/django_extensions/management/commands/validate_templates.py
+++ b/django_extensions/management/commands/validate_templates.py
@@ -20,6 +20,8 @@ class Command(BaseCommand):
                     default=False, help="Break on first error."),
         make_option('--check-urls', '-u', action='store_true', dest='check_urls',
                     default=False, help="Check url tag view names are quoted appropriately"),
+        make_option('--force-new-urls', '-n', action='store_true', dest='force_new_urls',
+                    default=False, help="Error on usage of old style url tags (without {% load urls from future %}"),
         make_option('--include', '-i', action='append', dest='includes',
                     default=[], help="Append these paths to TEMPLATE_DIRS")
     )
@@ -51,7 +53,7 @@ class Command(BaseCommand):
                     filepath = os.path.join(root, filename)
                     if verbosity>1:
                         print filepath
-                    validatingtemplatetags.before_new_template()
+                    validatingtemplatetags.before_new_template(options.get('force_new_urls', False))
                     try:
                         template_loader.load_template(filename, [root])
                     except Exception, e:


### PR DESCRIPTION
We are migrating our url template tags across to the new form in anticipation of Django 1.5. This patch adds functionality to the validate_templates management command such that it can point out templates we have not yet converted to the new style, or ones where we are failing to quote view names.

The code here assumes if you are using new style url tags (i.e. have done {% load url from future %} then all unquoted view name parameters to {% url %} are in error. I believe this is a reasonable assumption for people who are in the process of porting existing apps to use the new template tag format.
