### PR TITLE
Optional first argument to EncryptedCharField should be verbose name, not max length

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -82,8 +82,9 @@ class EncryptedTextField(BaseEncryptedField):
 class EncryptedCharField(BaseEncryptedField):
     __metaclass__ = models.SubfieldBase
 
-    def __init__(self, max_length=None, *args, **kwargs):
-        super(EncryptedCharField, self).__init__(max_length=max_length, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        # TODO - guarantee max_length in kwargs.
+        super(EncryptedCharField, self).__init__(*args, **kwargs)
 
     def get_internal_type(self):
         return "CharField"
@@ -101,4 +102,3 @@ class EncryptedCharField(BaseEncryptedField):
         args, kwargs = introspector(self)
         # That's our definition!
         return (field_class, args, kwargs)
-

--- a/django_extensions/tests/models.py
+++ b/django_extensions/tests/models.py
@@ -13,9 +13,9 @@ except ImportError:
 
 
 class Secret(models.Model):
-    name = EncryptedCharField(blank=True, max_length=255)
-    text = EncryptedTextField(blank=True)
+    name = EncryptedCharField("Name", blank=True, max_length=255)
+    text = EncryptedTextField("Text", blank=True)
+
 
 class Name(models.Model):
-     name = models.CharField(max_length=50)
-
+    name = models.CharField(max_length=50)


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/topics/db/models/#verbose-field-names ...
