### PR TITLE
Add 'BUG' to notes command

### DIFF
--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -4,14 +4,14 @@ from django.conf import settings
 import os
 import re
 
-ANNOTATION_RE = re.compile("\{?#[\s]*?(TODO|FIXME|HACK|XXX)[\s:]?(.+)")
+ANNOTATION_RE = re.compile("\{?#[\s]*?(TODO|FIXME|HACK|BUG|XXX)[\s:]?(.+)")
 ANNOTATION_END_RE = re.compile("(.*)#\}(.*)")
 
 
 class Command(BaseCommand):
-    help = 'Show all annotations like TODO, FIXME, HACK or XXX in your py and HTML files.'
+    help = 'Show all annotations like TODO, FIXME, HACK, BUG or XXX in your py and HTML files.'
     args = 'tag'
-    label = 'annotation tag (TODO, FIXME, HACK, XXX)'
+    label = 'annotation tag (TODO, FIXME, HACK, BUG, XXX)'
 
     def handle(self, *args, **options):
         # don't add django internal code


### PR DESCRIPTION
Please consider adding the search for 'BUG:' to the 'notes' command.

I regularly use TODO to denote features or changes I would like to see in the future whereas BUG represents stuff I must fix before shipping.
