### PR TITLE
Using encrypted fields with asymetric keys

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -34,7 +34,9 @@ class BaseEncryptedField(models.Field):
         super(BaseEncryptedField, self).__init__(*args, **kwargs)
 
     def to_python(self, value):
-        if value and (value.startswith(self.prefix)):
+        if isinstance(self.crypt.primary_key, keyczar.keys.RsaPublicKey):
+            retval = value
+        elif value and (value.startswith(self.prefix)):
             retval = self.crypt.Decrypt(value[len(self.prefix):])
             if retval:
                 retval = retval.decode('utf-8')


### PR DESCRIPTION
Hi,

I added a quick check in the to_python method that checks to see if the key being used is an RSA public key.

This will allow people to use asymetric public/private keys on their servers, and will just return the ciphertext if using the public keys (i.e. in admin views, etc). (Instead of throwing an exception.)

Since the only asymetric algorithm keyczar supports for encryption is RSA, this single check should be sufficient to cover this use case.

IMPORTANT NOTE: If you plan on using RSA, keep in mind the way keyczar implements it means the data you're encrypting has to be less than the key length, so the data needs to be around 200 characters or less.

Also, I created another set of CharField and TextField using python-gnupg, which allows for asymmetric encryption using GnuPG, which gets around the length limit. Not sure if you'd be interested in adding them though, as they add a python library requirement (python-gnupg), and the application gnupg installed on a system (as well as specially setting up the key directory).

Best,
Kromem

P.S. This is my first pull request ever! I think I did everything necessary - simple add, and all tests passing. If not, let me know.
