### PR TITLE
Include LICENSE file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include django_extensions/conf *.tmpl
 recursive-include django_extensions/templates *.html
 recursive-include django_extensions/static *
 recursive-include docs *
+include LICENSE


### PR DESCRIPTION
LICENSE file is not present in tarball available on pypi. Providing it makes packaging and further distribution easier.
