### PR TITLE
resetdb: fix reset_db would set OWNER = None with no db username for postgresql.

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -158,12 +158,12 @@ Type 'yes' to continue, or 'no' to cancel: """ % (settings.DATABASE_NAME,))
             create_query = "CREATE DATABASE %s" % settings.DATABASE_NAME
             if settings.DATABASE_USER:
                 create_query += " WITH OWNER = %s " % settings.DATABASE_USER
-            create_query += " ENCODING = 'UTF8' "
+            create_query += " ENCODING = 'UTF8'"
 
             if postgis.match(engine):
-                create_query += 'TEMPLATE = template_postgis '
+                create_query += ' TEMPLATE = template_postgis'
             if settings.DEFAULT_TABLESPACE:
-                create_query += 'TABLESPACE = %s;' % (settings.DEFAULT_TABLESPACE)
+                create_query += ' TABLESPACE = %s;' % settings.DEFAULT_TABLESPACE
             else:
                 create_query += ';'
             logging.info('Executing... "' + create_query + '"')


### PR DESCRIPTION
If you use postgresql, and you're lazy like I am and don't set a
username and let postgresql just use `$USER`, your `settings.DATABASE_USER`
will be `None`. This makes the existing code do this:

```
Executing... "CREATE DATABASE db_name WITH OWNER = None ENCODING = 'UTF8' ;"
```

Whiiiiicchhh... dies. For me, that looks like:

```
psycopg2.ProgrammingError: role "none" does not exist
```

This change omits WITH OWNER when there is no user.

As a side note, it looks like reset_db isn't using the options correctly from the command line if they're specified. But that's another PR.
