### PR TITLE
Use imports from django.conf.urls for django >= 1.4 to avoid DepreciationWarning.

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -57,7 +57,10 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
     related_string_functions = {}
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        try:
+            from django.conf.urls import patterns, url
+        except ImportError: # django < 1.4
+            from django.conf.urls.defaults import patterns, url
 
         def wrap(view):
             def wrapper(*args, **kwargs):

--- a/django_extensions/conf/app_template/urls.py.tmpl
+++ b/django_extensions/conf/app_template/urls.py.tmpl
@@ -1,3 +1,6 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # django < 1.4
+    from django.conf.urls.defaults import *
 
 # place app url patterns here


### PR DESCRIPTION
Imports from django.conf.urls.defaults get depreciated with django 1.5. Instead, simply use django.conf.urls.
