### PR TITLE
Ensure runserver_plus serves staticfiles

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -7,8 +7,14 @@ import sys
 import time
 
 try:
-    from django.contrib.staticfiles.handlers import StaticFilesHandler
-    USE_STATICFILES = 'django.contrib.staticfiles' in settings.INSTALLED_APPS
+    if 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
+        from django.contrib.staticfiles.handlers import StaticFilesHandler
+        USE_STATICFILES = True
+    elif 'staticfiles' in settings.INSTALLED_APPS:
+        from staticfiles.handlers import StaticFilesHandler  # noqa
+        USE_STATICFILES = True
+    else:
+        USE_STATICFILES = False
 except ImportError:
     USE_STATICFILES = False
 


### PR DESCRIPTION
From Django 1.3, staticfiles app had been merged into django codebase.
But, one can still install staticfiles app from its own repository to
make use of new features. In this case runserver_plus should serve
static files correctly.
