### PR TITLE
Replace assertEquals with assertEqual

### DIFF
--- a/django_extensions/tests/json_field.py
+++ b/django_extensions/tests/json_field.py
@@ -25,9 +25,9 @@ class JsonFieldTest(unittest.TestCase):
 
     def testCharFieldCreate(self):
         j = TestModel.objects.create(a=6, j_field=dict(foo='bar'))
-        self.assertEquals(j.a, 6)
+        self.assertEqual(j.a, 6)
 
     def testEmptyList(self):
         j = TestModel.objects.create(a=6, j_field=[])
         self.assertTrue(isinstance(j.j_field, list))
-        self.assertEquals(j.j_field, [])
+        self.assertEqual(j.j_field, [])

--- a/django_extensions/tests/test_dumpscript.py
+++ b/django_extensions/tests/test_dumpscript.py
@@ -52,7 +52,7 @@ class DumpScriptTests(TestCase):
         tmp_out = StringIO()
         call_command('dumpscript', 'tests', stdout=tmp_out)
         self.assertTrue('Mike' in tmp_out.getvalue())  # script should go to tmp_out
-        self.assertEquals(0, len(sys.stdout.getvalue()))  # there should not be any output to sys.stdout
+        self.assertEqual(0, len(sys.stdout.getvalue()))  # there should not be any output to sys.stdout
         tmp_out.close()
 
     #----------------------------------------------------------------------
@@ -65,7 +65,7 @@ class DumpScriptTests(TestCase):
         call_command('dumpscript', 'tests', stderr=tmp_err)
         self.assertTrue('Fred' in sys.stdout.getvalue())  # script should still go to stdout
         self.assertTrue('Name' in tmp_err.getvalue())  # error output should go to tmp_err
-        self.assertEquals(0, len(sys.stderr.getvalue()))  # there should not be any output to sys.stderr
+        self.assertEqual(0, len(sys.stderr.getvalue()))  # there should not be any output to sys.stderr
         tmp_err.close()
 
     #----------------------------------------------------------------------

--- a/django_extensions/tests/utils.py
+++ b/django_extensions/tests/utils.py
@@ -14,10 +14,10 @@ except ImportError:
 
 class TruncateLetterTests(TestCase):
     def test_truncate_more_than_text_length(self):
-        self.assertEquals(u"hello tests", truncate_letters("hello tests", 100))
+        self.assertEqual(u"hello tests", truncate_letters("hello tests", 100))
 
     def test_truncate_text(self):
-        self.assertEquals(u"hello...", truncate_letters("hello tests", 5))
+        self.assertEqual(u"hello...", truncate_letters("hello tests", 5))
 
     def test_truncate_with_range(self):
         for i in range(10, -1, -1):
@@ -27,7 +27,7 @@ class TruncateLetterTests(TestCase):
             )
 
     def test_with_non_ascii_characters(self):
-        self.assertEquals(
+        self.assertEqual(
             u'\u5ce0 (\u3068\u3046\u3052 t\u014dg...',
             truncate_letters("峠 (とうげ tōge - mountain pass)", 10)
         )
@@ -37,7 +37,7 @@ class UUIDTests(TestCase):
     @skipIf(sys.version_info >= (2, 5, 0), 'uuid already in stdlib')
     def test_uuid3(self):
         # make a UUID using an MD5 hash of a namespace UUID and a name
-        self.assertEquals(
+        self.assertEqual(
             uuid.UUID('6fa459ea-ee8a-3ca4-894e-db77e160355e'),
             uuid.uuid3(uuid.NAMESPACE_DNS, 'python.org')
         )
@@ -45,7 +45,7 @@ class UUIDTests(TestCase):
     @skipIf(sys.version_info >= (2, 5, 0), 'uuid already in stdlib')
     def test_uuid5(self):
         # make a UUID using a SHA-1 hash of a namespace UUID and a name
-        self.assertEquals(
+        self.assertEqual(
             uuid.UUID('886313e1-3b8a-5372-9b90-0c9aee199e5d'),
             uuid.uuid5(uuid.NAMESPACE_DNS, 'python.org')
         )
@@ -55,21 +55,21 @@ class UUIDTests(TestCase):
         # make a UUID from a string of hex digits (braces and hyphens ignored)
         x = uuid.UUID('{00010203-0405-0607-0809-0a0b0c0d0e0f}')
         # convert a UUID to a string of hex digits in standard form
-        self.assertEquals('00010203-0405-0607-0809-0a0b0c0d0e0f', str(x))
+        self.assertEqual('00010203-0405-0607-0809-0a0b0c0d0e0f', str(x))
 
     @skipIf(sys.version_info >= (2, 5, 0), 'uuid already in stdlib')
     def test_uuid_bytes(self):
         # make a UUID from a string of hex digits (braces and hyphens ignored)
         x = uuid.UUID('{00010203-0405-0607-0809-0a0b0c0d0e0f}')
         # get the raw 16 bytes of the UUID
-        self.assertEquals(
+        self.assertEqual(
             '\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f',
             x.bytes
         )
 
     @skipIf(sys.version_info >= (2, 5, 0), 'uuid already in stdlib')
     def test_make_uuid_from_byte_string(self):
-        self.assertEquals(
+        self.assertEqual(
             uuid.UUID(bytes='\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f'),
             uuid.UUID('00010203-0405-0607-0809-0a0b0c0d0e0f')
         )

--- a/django_extensions/tests/uuid_field.py
+++ b/django_extensions/tests/uuid_field.py
@@ -37,19 +37,19 @@ class UUIDFieldTest(unittest.TestCase):
 
     def testUUIDFieldCreate(self):
         j = TestModel_field.objects.create(a=6, uuid_field=u'550e8400-e29b-41d4-a716-446655440000')
-        self.assertEquals(j.uuid_field, u'550e8400-e29b-41d4-a716-446655440000')
+        self.assertEqual(j.uuid_field, u'550e8400-e29b-41d4-a716-446655440000')
 
     def testUUIDField_pkCreate(self):
         j = TestModel_pk.objects.create(uuid_field=u'550e8400-e29b-41d4-a716-446655440000')
-        self.assertEquals(j.uuid_field, u'550e8400-e29b-41d4-a716-446655440000')
-        self.assertEquals(j.pk, u'550e8400-e29b-41d4-a716-446655440000')
+        self.assertEqual(j.uuid_field, u'550e8400-e29b-41d4-a716-446655440000')
+        self.assertEqual(j.pk, u'550e8400-e29b-41d4-a716-446655440000')
 
     def testUUIDField_pkAgregateCreate(self):
         j = TestAgregateModel.objects.create(a=6)
-        self.assertEquals(j.a, 6)
+        self.assertEqual(j.a, 6)
 
     def testUUIDFieldManyToManyCreate(self):
         j = TestManyToManyModel.objects.create(uuid_field=u'550e8400-e29b-41d4-a716-446655440010')
-        self.assertEquals(j.uuid_field, u'550e8400-e29b-41d4-a716-446655440010')
-        self.assertEquals(j.pk, u'550e8400-e29b-41d4-a716-446655440010')
+        self.assertEqual(j.uuid_field, u'550e8400-e29b-41d4-a716-446655440010')
+        self.assertEqual(j.pk, u'550e8400-e29b-41d4-a716-446655440010')
 


### PR DESCRIPTION
The reason behind this is the fact that assertEquals is deprecated in Python 3
