### PR TITLE
reset_db does not work with spatialite

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -92,7 +92,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (settings.DATABASE_NAME,))
         if password is None:
             password = settings.DATABASE_PASSWORD
 
-        if engine == 'sqlite3':
+        if engine in ('sqlite3', 'spatialite'):
             import os
             try:
                 logging.info("Unlinking sqlite3 database")


### PR DESCRIPTION
spatialite is geodjango backend for sqlite extensions with the same name spatialite, so basically it is the same as sqlite.
