### PR TITLE
support django-1.5 swappable model w bkwd compatiability

### DIFF
--- a/django_extensions/future_1_5.py
+++ b/django_extensions/future_1_5.py
@@ -1,0 +1,16 @@
+"""
+A forwards compatibility module.
+
+Implements some features of Django 1.5 related to the 'Custom User Model' feature
+when the application is run with a lower version of Django.
+"""
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import User
+
+User.USERNAME_FIELD = "username"
+User.get_username = lambda self: self.username
+
+
+def get_user_model():
+    return User

--- a/django_extensions/management/commands/export_emails.py
+++ b/django_extensions/management/commands/export_emails.py
@@ -1,5 +1,9 @@
 from django.core.management.base import BaseCommand, CommandError
-from django.contrib.auth.models import User, Group
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5
+except ImportError:
+    from django_extensions.future_1_5 import get_user_model
+from django.contrib.auth.models import Group
 from optparse import make_option
 from sys import stdout
 from csv import writer
@@ -52,6 +56,7 @@ class Command(BaseCommand):
         else:
             outfile = stdout
 
+        User = get_user_model()
         qs = User.objects.all().order_by('last_name', 'first_name', 'username', 'email')
         if group:
             qs = qs.filter(group__name=group).distinct()

--- a/django_extensions/management/commands/passwd.py
+++ b/django_extensions/management/commands/passwd.py
@@ -1,5 +1,8 @@
 from django.core.management.base import BaseCommand, CommandError
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5
+except ImportError:
+    from django_extensions.future_1_5 import get_user_model
 import getpass
 
 
@@ -17,6 +20,7 @@ class Command(BaseCommand):
         else:
             username = getpass.getuser()
 
+        User = get_user_model()
         try:
             u = User.objects.get(username=username)
         except User.DoesNotExist:

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -1,5 +1,8 @@
 from django.core.management.base import BaseCommand, CommandError
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5
+except ImportError:
+    from django_extensions.future_1_5 import get_user_model
 from django.contrib.sessions.models import Session
 import re
 
@@ -38,6 +41,7 @@ class Command(BaseCommand):
             print('No user associated with session')
             return
         print("User id: %s" % uid)
+        User = get_user_model()
         try:
             user = User.objects.get(pk=uid)
         except User.DoesNotExist:

--- a/django_extensions/management/commands/set_fake_emails.py
+++ b/django_extensions/management/commands/set_fake_emails.py
@@ -38,7 +38,11 @@ class Command(NoArgsCommand):
         if not settings.DEBUG:
             raise CommandError('Only available in debug mode')
 
-        from django.contrib.auth.models import User, Group
+        try:
+            from django.contrib.auth import get_user_model  # Django 1.5
+        except ImportError:
+            from django_extensions.future_1_5 import get_user_model
+        from django.contrib.auth.models import Group
         email = options.get('default_email', DEFAULT_FAKE_EMAIL)
         include_regexp = options.get('include_regexp', None)
         exclude_regexp = options.get('exclude_regexp', None)
@@ -47,6 +51,7 @@ class Command(NoArgsCommand):
         no_admin = options.get('no_admin', False)
         no_staff = options.get('no_staff', False)
 
+        User = get_user_model()
         users = User.objects.all()
         if no_admin:
             users = users.exclude(is_superuser=True)

--- a/django_extensions/management/commands/set_fake_passwords.py
+++ b/django_extensions/management/commands/set_fake_passwords.py
@@ -28,7 +28,11 @@ class Command(NoArgsCommand):
         if not settings.DEBUG:
             raise CommandError('Only available in debug mode')
 
-        from django.contrib.auth.models import User
+        try:
+            from django.contrib.auth import get_user_model  # Django 1.5
+        except ImportError:
+            from django_extensions.future_1_5 import get_user_model
+
         if options.get('prompt_passwd', False):
             from getpass import getpass
             passwd = getpass('Password: ')
@@ -37,6 +41,7 @@ class Command(NoArgsCommand):
         else:
             passwd = options.get('default_passwd', DEFAULT_FAKE_PASSWORD)
 
+        User = get_user_model()
         user = User()
         user.set_password(passwd)
         count = User.objects.all().update(password=user.password)


### PR DESCRIPTION
This implements support for swappable-user-models introduced in django 1.5, following a a from future idea taken from django-postman: https://bitbucket.org/psam/django-postman

Most importantly, this takes into account not to call get_user_model in the global scope which is a known issue.
