### PR TITLE
Allow public-key-only encryption with encrypted fields

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -59,8 +59,8 @@ class BaseEncryptedField(models.Field):
             crypt_class_name = 'Crypter'
         else:
             raise ImproperlyConfigured(
-                    'ENCRYPTED_FIELD_MODE must be either DECRYPT_AND_ENCRYPT '
-                    'or ENCRYPT, not %s.' % crypt_type)
+                'ENCRYPTED_FIELD_MODE must be either DECRYPT_AND_ENCRYPT '
+                'or ENCRYPT, not %s.' % crypt_type)
         return getattr(keyczar, crypt_class_name)
 
     def to_python(self, value):


### PR DESCRIPTION
Currently, trying to instantiate an encrypted field using only public keys causes Keyczar to raise an exception:

```
keyczar.errors.KeyczarError: Unacceptable purpose: ENCRYPT
```

This is because Keyczar (version 0.71c) uses two different classes to do symmetric and asymmetric encryption/decryption. However, BaseEncryptedField always assumes the keys will be symmetric.

In production environments, it is desirable to distribute only public keys, since an attack that would compromise the database could also likely compromise the keys. By keeping the private keys off the production network, it is much more difficult (if not impossible) to decrypt compromised data.

This pull request adds a new Django setting, ENCRYPTED_FIELD_MODE, that allows BaseEncryptedField to use the correct Keyczar class. Behavior is unchanged if this setting is omitted, so this pull request is fully backwards compatible.

FWIW, the existing code seems to already have partial support for this:

```
if isinstance(self.crypt.primary_key, keyczar.keys.RsaPublicKey):
```
