### PR TITLE
Python 3 metaclass compatibility for Field subclasses.

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -93,9 +93,8 @@ class BaseEncryptedField(models.Field):
         return value
 
 
-class EncryptedTextField(BaseEncryptedField):
-    __metaclass__ = models.SubfieldBase
-
+class EncryptedTextField(six.with_metaclass(models.SubfieldBase,
+                                            BaseEncryptedField)):
     def get_internal_type(self):
         return 'TextField'
 
@@ -114,9 +113,8 @@ class EncryptedTextField(BaseEncryptedField):
         return (field_class, args, kwargs)
 
 
-class EncryptedCharField(BaseEncryptedField):
-    __metaclass__ = models.SubfieldBase
-
+class EncryptedCharField(six.with_metaclass(models.SubfieldBase,
+                                            BaseEncryptedField)):
     def __init__(self, *args, **kwargs):
         super(EncryptedCharField, self).__init__(*args, **kwargs)
 

--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -58,12 +58,9 @@ class JSONList(list):
         return dumps(self)
 
 
-class JSONField(models.TextField):
+class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
     """JSONField is a generic textfield that neatly serializes/unserializes
     JSON objects seamlessly.  Main thingy must be a dict object."""
-
-    # Used so to_python() is called
-    __metaclass__ = models.SubfieldBase
 
     def __init__(self, *args, **kwargs):
         default = kwargs.get('default')

--- a/django_extensions/tests/json_field.py
+++ b/django_extensions/tests/json_field.py
@@ -27,6 +27,10 @@ class JsonFieldTest(unittest.TestCase):
         j = TestModel.objects.create(a=6, j_field=dict(foo='bar'))
         self.assertEqual(j.a, 6)
 
+    def testDefault(self):
+        j = TestModel.objects.create(a=1)
+        self.assertEqual(j.j_field, {})
+
     def testEmptyList(self):
         j = TestModel.objects.create(a=6, j_field=[])
         self.assertTrue(isinstance(j.j_field, list))


### PR DESCRIPTION
This fixes fields' Python 3 support.

If you're using `JSONField` in Python 3, `to_python` is never called because the subclass is using Python 2's `__metaclass__` syntax.

I also changed `EncryptedTextField` and `EncryptedCharField` for future compatibility -- it doesn't seem python-keyczar supports Python 3 (at least the tests don't run).
