### PR TITLE
Add IPv6 support to runserver_plus

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -3,6 +3,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django_extensions.management.utils import setup_logger, RedirectHandler
 from optparse import make_option
 import os
+import re
+import socket
 import sys
 import time
 
@@ -18,6 +20,14 @@ try:
 except ImportError:
     USE_STATICFILES = False
 
+naiveip_re = re.compile(r"""^(?:
+(?P<addr>
+    (?P<ipv4>\d{1,3}(?:\.\d{1,3}){3}) |         # IPv4 address
+    (?P<ipv6>\[[a-fA-F0-9:]+\]) |               # IPv6 address
+    (?P<fqdn>[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*) # FQDN
+):)?(?P<port>\d+)$""", re.X)
+DEFAULT_PORT = "8000"
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -26,6 +36,8 @@ from django_extensions.management.technical_response import null_technical_500_r
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
+        make_option('--ipv6', '-6', action='store_true', dest='use_ipv6', default=False,
+                    help='Tells Django to use a IPv6 address.'),
         make_option('--noreload', action='store_false', dest='use_reloader', default=True,
                     help='Tells Django to NOT use the auto-reloader.'),
         make_option('--browser', action='store_true', dest='open_browser',
@@ -109,33 +121,46 @@ class Command(BaseCommand):
         from django.views import debug
         debug.technical_500_response = null_technical_500_response
 
-        if args:
-            raise CommandError('Usage is runserver %s' % self.args)
+        self.use_ipv6 = options.get('use_ipv6')
+        if self.use_ipv6 and not socket.has_ipv6:
+            raise CommandError('Your Python does not support IPv6.')
+        self._raw_ipv6 = False
         if not addrport:
-            addr = ''
-            port = '8000'
+            self.addr = ''
+            self.port = DEFAULT_PORT
         else:
-            try:
-                addr, port = addrport.split(':')
-            except ValueError:
-                addr, port = '', addrport
-        if not addr:
-            addr = '127.0.0.1'
-
-        if not port.isdigit():
-            raise CommandError("%r is not a valid port number." % port)
+            m = re.match(naiveip_re, addrport)
+            if m is None:
+                raise CommandError('"%s" is not a valid port number '
+                                   'or address:port pair.' % addrport)
+            self.addr, _ipv4, _ipv6, _fqdn, self.port = m.groups()
+            if not self.port.isdigit():
+                raise CommandError("%r is not a valid port number." %
+                                   self.port)
+            if self.addr:
+                if _ipv6:
+                    self.addr = self.addr[1:-1]
+                    self.use_ipv6 = True
+                    self._raw_ipv6 = True
+                elif self.use_ipv6 and not _fqdn:
+                    raise CommandError('"%s" is not a valid IPv6 address.'
+                                       % self.addr)
+        if not self.addr:
+            self.addr = '::1' if self.use_ipv6 else '127.0.0.1'
 
         threaded = options.get('threaded', False)
         use_reloader = options.get('use_reloader', True)
         open_browser = options.get('open_browser', False)
         cert_path = options.get("cert_path")
         quit_command = (sys.platform == 'win32') and 'CTRL-BREAK' or 'CONTROL-C'
+        bind_url = "http://%s:%s/" % (
+            self.addr if not self._raw_ipv6 else '[%s]' % self.addr, self.port)
 
         def inner_run():
             print("Validating models...")
             self.validate(display_num_errors=True)
             print("\nDjango version %s, using settings %r" % (django.get_version(), settings.SETTINGS_MODULE))
-            print("Development server is running at http://%s:%s/" % (addr, port))
+            print("Development server is running at %s" % (bind_url, ))
             print("Using the Werkzeug debugger (http://werkzeug.pocoo.org/)")
             print("Quit the server with %s." % quit_command)
             path = options.get('admin_media_path', '')
@@ -155,8 +180,7 @@ class Command(BaseCommand):
                     handler = StaticFilesHandler(handler)
             if open_browser:
                 import webbrowser
-                url = "http://%s:%s/" % (addr, port)
-                webbrowser.open(url)
+                webbrowser.open(bind_url)
             if cert_path:
                 """
                 OpenSSL is needed for SSL support.
@@ -195,8 +219,8 @@ class Command(BaseCommand):
             else:
                 ssl_context = None
             run_simple(
-                addr,
-                int(port),
+                self.addr,
+                int(self.port),
                 DebuggedApplication(handler, True),
                 use_reloader=use_reloader,
                 use_debugger=True,


### PR DESCRIPTION
The current version does not support commands like

```
runserver_plus [::]:8080 
runserver_plus example.org:8080
```

This is a backport from django/django@d7fa33af and django/django@6a32e253.

(Our use case: We run development servers in our private cloud, where they have only ipv6 global address. Testing changes with devices outside the local network is the simplest via ipv6.) 
