### PR TITLE
Fix testUUIDField_pkAgregateCreate against MySQL

### DIFF
--- a/django_extensions/tests/uuid_field.py
+++ b/django_extensions/tests/uuid_field.py
@@ -46,7 +46,7 @@ class UUIDFieldTest(unittest.TestCase):
         self.assertEqual(j.pk, six.u('550e8400-e29b-41d4-a716-446655440000'))
 
     def testUUIDField_pkAgregateCreate(self):
-        j = TestAgregateModel.objects.create(a=6)
+        j = TestAgregateModel.objects.create(a=6, uuid_field=u'550e8400-e29b-41d4-a716-446655440001')
         self.assertEqual(j.a, 6)
         self.assertIsInstance(j.pk, six.string_types)
         self.assertEqual(len(j.pk), 36)


### PR DESCRIPTION
Constraint against testmodel_pk.uuid_field requires uuid_field being set.

```
ALTER TABLE `extensions_testagregatemodel` ADD CONSTRAINT `testmodel_pk_ptr_id_refs_uuid_field_91eb2fe4` FOREIGN KEY (`testmodel_pk_ptr_id`) REFERENCES `extensions_testmodel_pk` (`uuid_field`);
CREATE TABLE `extensions_testmanytomanymodel_many` (
    `id` integer AUTO_INCREMENT NOT NULL PRIMARY KEY,
    `testmanytomanymodel_id` varchar(36) NOT NULL,
    `testmodel_field_id` integer NOT NULL,
    UNIQUE (`testmanytomanymodel_id`, `testmodel_field_id`)
);
```
