### PR TITLE
Fix ForeignAutoCompleteAdmin breakage

### DIFF
--- a/django_extensions/admin/widgets.py
+++ b/django_extensions/admin/widgets.py
@@ -93,4 +93,4 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
             'django_extensions/widgets/foreignkey_searchinput.html',
         ), context))
         output.reverse()
-        return mark_safe(six.u(''.join(output)))
+        return mark_safe(six.u('').join(output))


### PR DESCRIPTION
This is a fix for breakage in the recent 1.2.0 version. Using a ForeignAutoCompleteAdmin in Python 2.7 leads to 
TypeError: decoding Unicode is not supported
This fixes it. I didn't test with Python 3, since we don't use it yet, but it seems like a small enough fix.
