### PR TITLE
runscript: use apps in INSTALLED_APPS to discover scripts

### DIFF
--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -38,8 +38,6 @@ class Command(BaseCommand):
     args = "script [script ...]"
 
     def handle(self, *scripts, **options):
-        from django.db.models import get_apps
-
         NOTICE = self.style.SQL_TABLE
         NOTICE2 = self.style.SQL_FIELD
         ERROR = self.style.ERROR


### PR DESCRIPTION
Change the runscript management command to use the INSTALLED_APPS settings variable to discover scripts to run. The old version only works with apps containing a models.py.
