### PR TITLE
Table inheritance support in sqldiff

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -48,9 +48,16 @@ def flatten(l, ltypes=(list, tuple)):
 
 
 def all_local_fields(meta):
-    all_fields = meta.local_fields[:]
-    for parent in meta.parents:
-        all_fields.extend(all_local_fields(parent._meta))
+    all_fields = []
+    if not meta.managed or meta.proxy:
+        for parent in meta.parents:
+            all_fields.extend(all_local_fields(parent._meta))
+    else:
+        for f in meta.local_fields:
+            col_type = f.db_type(connection=connection)
+            if col_type is None:
+                continue
+            all_fields.append(f)
     return all_fields
 
 


### PR DESCRIPTION
This patch adds inheritance support to sqldiff by recursing only if the model is a proxy model. Otherwise return local fields that are not ManyToManyFields. Additionally, models that are not managed should not return any fields whatsoever.
