### PR TITLE
Strip quotes from constraints

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -566,7 +566,7 @@ class PostgresqlSQLDiff(SQLDiff):
                 if check_constraint:
                     check_constraint = check_constraint.replace("((", "(")
                     check_constraint = check_constraint.replace("))", ")")
-                    check_constraint = '("'.join([')' in e and '" '.join(e.split(" ", 1)) or e for e in check_constraint.split("(")])
+                    check_constraint = '("'.join([')' in e and '" '.join(p.strip('"') for p in e.split(" ", 1)) or e for e in check_constraint.split("(")])
                     # TODO: might be more then one constraint in definition ?
                     db_type += ' ' + check_constraint
                 null = self.null.get((tablespace, table_name, field.attname), 'fixme')


### PR DESCRIPTION
"order", "limit" and perhaps others are quoted so the error: `field 'order' parameters differ: db='integer CHECK (""order"" >= 0)', model='integer CHECK ("order" >= 0)'` was being received from comparing PostgreSQL constraints. To fix this, strip quotes.
