### PR TITLE
tox: upgraded Django dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,12 +28,12 @@ deps = Django==1.4.8
 
 [testenv:py26_django15]
 basepython = python2.6
-deps = https://www.djangoproject.com/download/1.5c2/tarball/
+deps = Django==1.5.4
 
 [testenv:py27_django15]
 basepython = python2.7
-deps = https://www.djangoproject.com/download/1.5c2/tarball/
+deps = Django==1.5.4
 
 [testenv:py33_django15]
 basepython = python3.3
-deps = https://www.djangoproject.com/download/1.5c2/tarball/
+deps = Django==1.5.4


### PR DESCRIPTION
1.4.x: from 1.4.5 to 1.4.8
1.5.x: from 1.5c2 (unreleased) to 1.5.4
