### PR TITLE
Corrected path to indicator.gif in jquery.autocomplete.css

### DIFF
--- a/django_extensions/static/django_extensions/css/jquery.autocomplete.css
+++ b/django_extensions/static/django_extensions/css/jquery.autocomplete.css
@@ -29,7 +29,7 @@
 }
 
 .acLoading {
-	background : url('indicator.gif') right center no-repeat;
+	background : url('../img/indicator.gif') right center no-repeat;
 }
 
 .acSelect {


### PR DESCRIPTION
I wasn't able to run collectstatic as indicator.gif couldn't be found (ValueError: The file 'django_extensions/css/indicator.gif' could not be found with [CachedStaticFilesStorage]) this change should fix that.
