### PR TITLE
Update reset_db.py

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -135,7 +135,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
 
             create_query = "CREATE DATABASE %s" % database_name
             if owner:
-                create_query += " WITH OWNER = %s " % owner
+                create_query += " WITH OWNER = \"%s\" " % owner
             create_query += " ENCODING = 'UTF8'"
 
             if engine == 'postgis':


### PR DESCRIPTION
Add support for db owner name containing .'s

Reset db command will throw a syntax error if db owner contains a . Adding a couple of quotes fixes it up.
