### PR TITLE
Limit queryset for ForeignKeyAutocompleteAdmin field. Fixes #391

### DIFF
--- a/django_extensions/admin/widgets.py
+++ b/django_extensions/admin/widgets.py
@@ -1,4 +1,5 @@
 import six
+
 from django import forms
 from django.contrib.admin.sites import site
 from django.utils.safestring import mark_safe
@@ -65,8 +66,8 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
             'related_url': related_url,
             'search_path': self.search_path,
             'search_fields': ','.join(self.search_fields),
-            'model_name': model_name,
             'app_label': app_label,
+            'model_name': model_name,
             'label': label,
             'name': name,
         }

--- a/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
+++ b/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
@@ -6,19 +6,17 @@
 <script type="text/javascript">
 (function($) {
     // Show lookup input
-    $("#lookup_{{ name }}").show();
+    $('#lookup_{{ name }}').show();
     function reset() {
-        $('#id_{{ name }}').val('');
-        $('#lookup_{{ name }}').val('');
+        $('#id_{{ name }}, #lookup_{{ name }}').val('');
     };
     function lookup(query) {
         $.get('{{ search_path }}', {
             'search_fields': '{{ search_fields }}',
             'app_label': '{{ app_label }}',
             'model_name': '{{ model_name }}',
-            // TODO: 'limit': '{{ limit }}',        // Here we should set the limit set on the widget
             'object_pk': query
-        }, function(data){
+        }, function(data) {
             $('#lookup_{{ name }}').val(data);
             {{ name }}_value = query;
         });


### PR DESCRIPTION
@trbs I need help here. Seems reasonable to set the limit on the `ForeignKeyAutocompleteAdmin` fields so we can send the limit as a GET parameter for each request. Otherwise you can make the decision on where to get the limit value.
