### PR TITLE
autocomplete id field not filled since jquery.autocomplete update

### DIFF
--- a/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
+++ b/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
@@ -31,20 +31,22 @@
             };
         };
     });
+    $('#lookup_{{ name }}').bind('keyup', function(event) {
+        if ($(this).val()) {
+            if (event.keyCode == 27) {
+                reset();
+            }
+        }
+    });
     $('#lookup_{{ name }}').autocomplete('{{ search_path }}', {
         extraParams: {
             'search_fields': '{{ search_fields }}',
             'app_label': '{{ app_label }}',
             'model_name': '{{ model_name }}'
+        },
+        onItemSelect: function(item) {
+            $('#id_{{ name }}').val(item.data[0]);
         }
-    }).result(function(event, data, formatted) {
-        if (data) {
-            $('#id_{{ name }}').val(data[1]);
-        }
-    }).keyup(function(event){
-        if (event.keyCode == 27) {
-            reset();
-        };
     });
     var {{ name }}_value = $('#id_{{ name }}').val();
     function check() {
@@ -54,7 +56,7 @@
                 lookup({{ name }}_check);
             }
         }
-    }
+    };
     timeout = window.setInterval(check, 300);
 })((typeof window.jQuery == 'undefined' && typeof window.django != 'undefined')? django.jQuery : jQuery);
 </script>


### PR DESCRIPTION
Since the update of jquery.autocomplete, selecting an item from the autocompletion menu won't fill the id field as function result doesn't exist anymore.
