### PR TITLE
Template class verification and notification

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -272,7 +272,8 @@ def generate_dot(app_labels, **kwargs):
 
     if not isinstance(t, Template):
         raise Exception("Default Django template loader isn't used. "
-                "This can lead to the incorrect template rendering. Please, check the settings.")
+                        "This can lead to the incorrect template rendering. "
+                        "Please, check the settings.")
 
     c = Context({
         'created_at': now.strftime("%Y-%m-%d %H:%M"),


### PR DESCRIPTION
Management command 'graph_models'  assumes, that default django template loader is used. But there is some cases, when it's the wrong assumption (this [jinja2 adapter](https://github.com/GaretJax/coffin) is the example). So I think the verification and detailed message (if something wrong) are needed.
