### PR TITLE
missing documentation for create_template_tags

### DIFF
--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -14,9 +14,8 @@ Current Command Extensions
   specified application.  This makes it easy to get started with adding a
   command extension to your application.
 
-* *create_template_tags* - Creates a command extension directory structure within the
-  specified application.  This makes it easy to get started with adding a
-  command extension to your application.
+* *create_template_tags* - Creates a template tag directory structure within the
+  specified application.
 
 * *create_jobs* - Creates a Django jobs command directory structure for the
   given app name in the current directory.  This is part of the impressive jobs


### PR DESCRIPTION
Sorry, a bit of the documentation for create_template_tags went missing.
