### PR TITLE
adding new "describe_api" and "describe_admin" command

### DIFF
--- a/django_extensions/management/commands/describe_admin.py
+++ b/django_extensions/management/commands/describe_admin.py
@@ -1,5 +1,3 @@
-import itertools
-
 from django.core.management.base import AppCommand
 import django.db.models as django_models
 from django.db.models import get_models
@@ -112,9 +110,9 @@ def yield_list_filter(model):
     # BooleanField, DateField, ChoiceField,
     # and relationships fields that have a limited number of options
     candidate_fields = set(field for field in model._meta.fields if
-                        isinstance(field, (django_models.BooleanField,
-                                           django_models.DateField,
-                                           )))
+                           isinstance(field, (django_models.BooleanField,
+                                              django_models.DateField,
+                                              )))
     choice_fields = set(yield_choice_fields(model))
     for field in sorted(candidate_fields.union(choice_fields)):
             yield field.name
@@ -128,14 +126,3 @@ def yield_choice_fields(model, choice_max_size=25):
         # elif field.choices:
         if field.choices:
             yield field
-
-
-
-
-
-
-
-
-
-
-

--- a/django_extensions/management/commands/describe_api.py
+++ b/django_extensions/management/commands/describe_api.py
@@ -55,16 +55,18 @@ def yield_field_strings(model):
             options_str = ', ' + ', '.join(yield_field_options(field))
             if not options_str.strip(', '):
                 options_str = ''
-            yield FIELD_TEMPLATE.format(attribute_name=attribute_name, app_name=app_name,
-                foreign_model=foreign_model+RESOURCE_POSTFIX, options_str=options_str)
+            yield FIELD_TEMPLATE.format(attribute_name=attribute_name,
+                                        app_name=app_name,
+                                        foreign_model=foreign_model+RESOURCE_POSTFIX,
+                                        options_str=options_str)
 
 
 def yield_field_options(field):
     options = {'null': field.null,
-            'blank': field.blank,
-            'related_name': field.related_query_name().join("''"),
-            'help_text': bool(field.help_text) and repr(field.help_text) or '',
-            }
+               'blank': field.blank,
+               'related_name': field.related_query_name().join("''"),
+               'help_text': bool(field.help_text) and repr(field.help_text) or '',
+               }
     for key, val in options.items():
         if val:
             yield '='.join([key, str(val)])

--- a/django_extensions/management/commands/describe_fixture.py
+++ b/django_extensions/management/commands/describe_fixture.py
@@ -42,3 +42,4 @@ def yield_field_names(model):
         if not isinstance(field, db.models.fields.related.RelatedField):
             yield field.name
 
+


### PR DESCRIPTION
describe_api assumes the user uses the Tastypie framework

describe_api's features: 
- creates relations to the other resources based on the foreign keys in the models
- allows full filtering on all fields by default

describe_admin features:
- search fields, list_filter, list_display have good new defaults
- raw_id_fields is used for all relational fields to improve performance when using big tables
