### PR TITLE
Use django.jQuery for autocomplete.js if available

### DIFF
--- a/django_extensions/static/django_extensions/js/jquery.autocomplete.js
+++ b/django_extensions/static/django_extensions/js/jquery.autocomplete.js
@@ -1149,4 +1149,4 @@
         };
     };
 
-})(jQuery);
+})((typeof window.jQuery == 'undefined' && typeof window.django != 'undefined')? django.jQuery : jQuery);


### PR DESCRIPTION
Autocomplete.js throws error: 
Uncaught TypeError: Cannot read property 'fn' of undefined
