### PR TITLE
Abstract models that don't have explicit relationships defined are failing. This commit at least gives the user a useful exception to figure out the issue.

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -19,6 +19,7 @@ __contributors__ = [
     "Justin Findlay <jfindlay@gmail.com>",
     "Alexander Houben <alexander@houben.ch>",
     "Joern Hees <gitdev@joernhees.de>",
+    "Kevin Cherepski <cherepski@gmail.com>",
 ]
 
 import os
@@ -197,9 +198,12 @@ def generate_dot(app_labels, **kwargs):
                         related_query_name = related_query_name.replace('_', ' ').capitalize()
                     label += ' (%s)' % related_query_name
 
-                # handle self-relationships
-                if field.rel.to == 'self':
-                    target_model = field.model
+                # handle self-relationships and lazy-relationships
+                if isinstance(field.rel.to, basestring) :
+                    if field.rel.to == 'self':
+                        target_model = field.model
+                    else:
+                        raise Exception("Lazy relationship for model (%s) must be explicit for field (%s)" % (field.model.__name__, field.name))
                 else:
                     target_model = field.rel.to
 


### PR DESCRIPTION
I ran into an issue where I had an abstract class that contained an implicit lazy relationship (string) which was raising the exception,
Traceback (most recent call last):
  File "manage.py", line 14, in <module>
    execute_manager(settings)
  File "/srv/www/mei1151_eventdb/virtpy/lib/python2.6/site-packages/django/core/management/**init**.py", line 459, in execute_manager
    utility.execute()
  File "/srv/www/mei1151_eventdb/virtpy/lib/python2.6/site-packages/django/core/management/**init**.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/www/mei1151_eventdb/virtpy/lib/python2.6/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(_args, *_options.**dict**)
  File "/srv/www/mei1151_eventdb/virtpy/lib/python2.6/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(_args, *_options)
  File "/srv/www/mei1151_eventdb/virtpy/lib/python2.6/site-packages/django_extensions/management/commands/graph_models.py", line 73, in handle
    dotdata = generate_dot(args, cli_options=cli_options, **options)
  File "/srv/www/mei1151_eventdb/virtpy/lib/python2.6/site-packages/django_extensions/management/modelviz.py", line 232, in generate_dot
    add_relation(field, '[arrowhead=none, arrowtail=dot, dir=both]')
  File "/srv/www/mei1151_eventdb/virtpy/lib/python2.6/site-packages/django_extensions/management/modelviz.py", line 211, in add_relation
    'target_app': target_model.**module**.replace('.', '_'),
AttributeError: 'str' object has no attribute '__module__'

field.rel.to contains the string lazy relationship from the abstract model foriegnkey field which causes the above exception to be raised.
