### PR TITLE
Fixed a TypeError issue when running the 'update_permissions' command

### DIFF
--- a/django_extensions/management/commands/update_permissions.py
+++ b/django_extensions/management/commands/update_permissions.py
@@ -17,5 +17,5 @@ class Command(BaseCommand):
             for arg in args:
                 apps.append(get_app(arg))
         for app in apps:
-            create_permissions(app, get_models(), options.get('verbosity', 0))
+            create_permissions(app, get_models(), int(options.get('verbosity', 0)))
 


### PR DESCRIPTION
This patch prevents `./manage.py update_permissions` from failing with the following traceback:

``` python
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/user/.virtualenvs/project/lib/python3.3/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/home/user/.virtualenvs/project/lib/python3.3/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/user/.virtualenvs/project/lib/python3.3/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/user/.virtualenvs/project/lib/python3.3/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/home/user/.virtualenvs/project/lib/python3.3/site-packages/django_extensions/management/commands/update_permissions.py", line 23, in handle
    create_permissions(app, get_models(), options.get('verbosity', 0))
  File "/home/user/.virtualenvs/project/lib/python3.3/site-packages/django/contrib/auth/management/__init__.py", line 102, in create_permissions
    if verbosity >= 2:
TypeError: unorderable types: str() >= int()
```
