### PR TITLE
Adding `login_required` decorator presence check for views for `show_urls` output

### DIFF
--- a/django_extensions/management/commands/show_urls.py
+++ b/django_extensions/management/commands/show_urls.py
@@ -58,6 +58,8 @@ class Command(BaseCommand):
                     help="Show urls unsorted but same order as found in url patterns"),
         make_option("--language", "-l", dest="language",
                     help="Set the language code (useful for i18n_patterns)"),
+        make_option("--decorator", "-d", dest="decorator",
+                    help="Show the presence of given decorator on views")
     )
 
     help = "Displays all of the url matching routes for the project."
@@ -79,6 +81,10 @@ class Command(BaseCommand):
         if language is not None:
             activate(language)
 
+        decorator = options.get('decorator')
+        if decorator is None:
+            decorator = 'login_required'
+
         views = []
         for settings_mod in settings_modules:
             try:
@@ -97,14 +103,15 @@ class Command(BaseCommand):
                     func_name = '%s()' % func.__class__.__name__
                 else:
                     func_name = re.sub(r' at 0x[0-9a-f]+', '', repr(func))
-                views.append("%(url)s\t%(module)s.%(name)s\t%(url_name)s\t%(login_decorated)s" % {
+                views.append("%(url)s\t%(module)s.%(name)s\t%(url_name)s\t%(decorator)s" % {
                     'name': style.MODULE_NAME(func_name),
                     'module': style.MODULE(func.__module__),
                     'url_name': style.URL_NAME(url_name or ''),
                     'url': style.URL(simplify_regex(regex)),
-                    'login_decorated': 'login_required' in func.func_globals,
+                    'decorator': decorator if decorator in func.func_globals else '',
                 })
 
         if not options.get('unsorted', False):
             views = sorted(views)
+
         return "\n".join([v for v in views]) + "\n"


### PR DESCRIPTION
I have implemented this to check general decorator presence and would like feedback if something like this can be put into main project.

sample output of show_urls
Before
`/user/password/reset/done/ django.contrib.auth.views.password_reset_done   password_reset_done`
After
`/user/password/reset/done/ django.contrib.auth.views.password_reset_done   password_reset_done True`
