### PR TITLE
Fix `import json` for Django 1.7

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -9,7 +9,7 @@ more information.
  class LOL(models.Model):
      extra = json.JSONField()
 """
-
+from __future__ import absolute_import
 import six
 from decimal import Decimal
 from django.db import models


### PR DESCRIPTION
This is a followup to #356 and actually fixes `import json` for all of Python 2.6/2.7, though the bug only shows in Django 1.7.

Previous Django versions supplied `django.utils.simplejson`, which is where we try to import from first. Django 1.7 drops that module so the system `json` is attempted, but without absolute_import it imports itself (the current "json.py" file). Here's the error:

```
ERROR: testDefault (django_extensions.tests.json_field.JsonFieldTest)
...
  File "/home/dev/Documents/django-extensions/django_extensions/db/fields/json.py", line 35, in loads
    encoding=settings.DEFAULT_CHARSET
TypeError: loads() got an unexpected keyword argument 'parse_float'
```
