### PR TITLE
Try to import json before simplejson

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -17,12 +17,12 @@ from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 
 try:
-    # Django <= 1.6 backwards compatibility
-    from django.utils import simplejson as json
-except ImportError:
     # Django >= 1.7
     import json
-
+except ImportError:
+    # Django <= 1.6 backwards compatibility
+    from django.utils import simplejson as json
+    
 
 def dumps(value):
     return DjangoJSONEncoder().encode(value)


### PR DESCRIPTION
Follow up for #479 and #356

So that we don't get the deprecation warning on django 1.6 and python >= 2.6 (since it supports json)
