### PR TITLE
Allow to specify the settings you want to see

### DIFF
--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -48,7 +48,8 @@ Current Command Extensions
 
 * *passwd* - Makes it easy to reset a user's password.
 
-* `print_settings`_ - Similar to ``diffsettings`` but shows *all* active Django settings.
+* `print_settings`_ - Similar to ``diffsettings`` but shows *selected*
+  active Django settings or *all* if no args passed.
 
 * *print_user_for_session* - Print the user information for the provided
   session key. this is very helpful when trying to track down the person who

--- a/docs/print_settings.rst
+++ b/docs/print_settings.rst
@@ -1,7 +1,7 @@
 print_settings
 ==============
 
-:synopsis: Django managment command similar to ``diffsettings`` but shows *all* active Django settings.
+:synopsis: Django managment command similar to ``diffsettings`` but shows *selected* active Django settings or *all* if no args passed.
 
 
 Introduction
@@ -9,7 +9,7 @@ Introduction
 
 Django comes with a ``diffsettings`` command that shows how your project's
 settings differ from the Django defaults.  Sometimes it is useful to just see
-*all* the settings that are in effect for your project. This is particularly
+the settings that are in effect for your project. This is particularly
 true if you have a more complex system for settings than just a single
 :file:`settings.py` file. For example, you might have settings files that
 import other settings file, such as dev, test, and production settings files
@@ -28,6 +28,11 @@ Some variations::
 
     $ python manage.py print_settings --format=json
     $ python manage.py print_settings --format=yaml    # Requires PyYAML
+
+Show just selected settings::
+
+    $ python manage.py print_settings DEBUG INSTALLED_APPS
+    $ python manage.py print_settings DEBUG INSTALLED_APPS --format=pprint
 
 For more info, take a look at the built-in help::
 


### PR DESCRIPTION
Now, print_settings accepts settings variable names and just print
those variables:

$ python manage.py print_settings DEBUG MEDIA_URL
DEBUG                                    = True
MEDIA_URL                                = '/media/'
$

or:

$ python manage.py print_settings DEBUG MEDIA_URL --format=pprint
{'DEBUG': True, 'MEDIA_URL': '/media/'}
$
