### PR TITLE
Use // instead of # for comments in dot template

### DIFF
--- a/django_extensions/templates/django_extensions/graph_models/digraph.dot
+++ b/django_extensions/templates/django_extensions/graph_models/digraph.dot
@@ -1,7 +1,7 @@
 {% block digraph %}digraph model_graph {
-  # Dotfile by Django-Extensions graph_models
-  # Created: {{ created_at }}
-  {% if cli_options %}# Cli Options: {{ cli_options }}{% endif %}
+  // Dotfile by Django-Extensions graph_models
+  // Created: {{ created_at }}
+  {% if cli_options %}// Cli Options: {{ cli_options }}{% endif %}
 
   {% block digraph_options %}fontname = "Helvetica"
   fontsize = 8
@@ -18,9 +18,9 @@
     fontsize = 8
   {% endblock %}]
 
-  # Labels
+  // Labels
 {% block labels %}{% for graph in graphs %}{% include "django_extensions/graph_models/label.dot" %}{% endfor %}{% endblock %}
 
-  # Relations
+  // Relations
 {% block relations %}{% for graph in graphs %}{% include "django_extensions/graph_models/relation.dot" %}{% endfor %}{% endblock %}
 }{% endblock %}


### PR DESCRIPTION
Comments using # and having leading whitespaces on dot file cause syntax
errors when trying to render it on an interactive viewer (xdot).

To replicate error:
- Create a Graphviz dot file using:
  
  python manage.py graph_models myappname > output.dot
- Open with xdot:
  
  xdot output.dot
  
  The following error will appear:
  
    Error: <stdin>:2: syntax error near line 2
    context:   >>>  # <<<  Dotfile by Django-Extensions graph_models
