### PR TITLE
Add docs for passing arguments to runscript

### DIFF
--- a/docs/runscript.rst
+++ b/docs/runscript.rst
@@ -63,3 +63,26 @@ Note: The command first checks for scripts in your apps i.e. *app_name/scripts*
 folder and runs them before checking for and running scripts in the
 *project_root/scripts* folder. You can have multiple scripts with the same name
 and they will all be run sequentially.
+
+Passing arguments
+-----------------
+
+You can pass arguments from the command line to your script by passing a comma-separated
+list of values with ``--script-args``. For example::
+
+  $ python manage.py runscript delete_all_polls --script-args=staleonly
+
+The list of argument values gets passed as arguments to your *run()* function. For
+example::
+
+  # scripts/delete_all_polls.py
+  
+  from Polls.models import Poll
+  
+  def run(*args):
+      # Get all polls
+      all_polls = Poll.object.all()
+      if 'staleonly' in args:
+          all_polls = all_polls.filter(active=False)
+      # Delete polls
+      all_polls.delete()


### PR DESCRIPTION
This adds some documentation for passing argument to runscript from the command
line.

I'm pretty sure this is how it works. If not, let me know and I can fix the PR.
