### PR TITLE
fix python3 compatibility of unreferenced_files

### DIFF
--- a/django_extensions/management/commands/unreferenced_files.py
+++ b/django_extensions/management/commands/unreferenced_files.py
@@ -33,7 +33,7 @@ class Command(NoArgsCommand):
 
         # Get a list of all files referenced in the database
         referenced = []
-        for model in model_dict.iterkeys():
+        for model in model_dict:
             all = model.objects.all().iterator()
             for object in all:
                 for field in model_dict[model]:


### PR DESCRIPTION
`dict.iterkeys()` does not exist in python 3. 

With this patch, we replace `iterkeys()` with `for key in dictionary: pass` which is both pythonic and cross version compatible.
