### PR TITLE
Programatically determine PostGIS template

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -143,7 +143,11 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             create_query += " ENCODING = 'UTF8'"
 
             if engine == 'postgis':
-                create_query += ' TEMPLATE = template_postgis'
+                # fetch postgis template name if it exists
+                from django.contrib.gis.db.backends.postgis.creation import PostGISCreation
+                postgis_template = PostGISCreation(connection).template_postgis
+                if postgis_template is not None:
+                    create_query += ' TEMPLATE = %s' % postgis_template
 
             if settings.DEFAULT_TABLESPACE:
                 create_query += ' TABLESPACE = %s;' % settings.DEFAULT_TABLESPACE


### PR DESCRIPTION
The name for the PostGIS template can be changed by setting the
POSTGIS_TEMPLATE setting. This commit allows for that.

Since PostGIS 2.0, the template is optional. This commit consequently
only issues the SQL CREATE statement if a template is used.

Fixes #489.

Tox tests pass on my machine, and I've confirmed I can again issue a `reset_db` statement for a PostGIS 2.1 database.
