### PR TITLE
Fixed rendering of code in the second example.

### DIFF
--- a/docs/admin_extensions.rst
+++ b/docs/admin_extensions.rst
@@ -40,6 +40,7 @@ in your admin.py file:
 If you are using django-reversion you should follow this code example:
 
 ::
+
     from django.contrib import admin
     from foo.models import MyVersionModel
     from reversion.admin import VersionAdmin


### PR DESCRIPTION
The second example needed one extra newline to render properly.
