### PR TITLE
Fix for PostgreSQL databases with dashes in the name

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -129,7 +129,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             connection = Database.connect(conn_string)
             connection.set_isolation_level(0)  # autocommit false
             cursor = connection.cursor()
-            drop_query = 'DROP DATABASE %s;' % database_name
+            drop_query = "DROP DATABASE \"%s\";" % database_name
             logging.info('Executing... "' + drop_query + '"')
 
             try:
@@ -137,7 +137,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             except Database.ProgrammingError as e:
                 logging.info("Error: %s" % str(e))
 
-            create_query = "CREATE DATABASE %s" % database_name
+            create_query = "CREATE DATABASE \"%s\"" % database_name
             if owner:
                 create_query += " WITH OWNER = \"%s\" " % owner
             create_query += " ENCODING = 'UTF8'"


### PR DESCRIPTION
Fixes this error: psycopg2.ProgrammingError: syntax error at or near "-"
