### PR TITLE
show_urls -f aligned: 3 spaces between columns

### DIFF
--- a/django_extensions/management/commands/show_urls.py
+++ b/django_extensions/management/commands/show_urls.py
@@ -143,7 +143,7 @@ class Command(BaseCommand):
             views = [row.split(',') for row in views]
             widths = [len(max(columns, key=len)) for columns in zip(*views)]
             views = [
-                ' '.join('{0:<{1}}'.format(cdata, width) for width, cdata in zip(widths, row))
+                '   '.join('{0:<{1}}'.format(cdata, width) for width, cdata in zip(widths, row))
                 for row in views
             ]
         elif format_style == 'table':


### PR DESCRIPTION
In the case of `show_urls -f aligned`, the space between columns should be 3 spaces. See this screenshot: https://i.imgur.com/VvfvboG.png . Now the output of `table` and `aligned` are nicely aligned below each other. Plus, the output of `aligned` is easier to read this way.
