### PR TITLE
support mysql options files in reset_db

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -9,6 +9,7 @@ from django.core.management.base import CommandError, BaseCommand
 from six.moves import input
 from ConfigParser import SafeConfigParser
 
+
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
         make_option('--noinput', action='store_false',


### PR DESCRIPTION
Django supports mysql option files
(see https://docs.djangoproject.com/en/dev/ref/databases/#connecting-to-the-database).

This commit adds support for pulling in connection data from a
mysql options file for `reset_db`. This code follows the priority
order as given in the documentation above:

> 1. OPTIONS.
> 2. NAME, USER, PASSWORD, HOST, PORT
> 3. MySQL option files.
