### PR TITLE
Fix: Issue #536

### DIFF
--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -714,7 +714,7 @@ def get_attribute_value(item, field, context, force=False):
         else:
             raise DoLater('(FK) %s.%s\n' % (item.__class__.__name__, field.name))
 
-    elif isinstance(field, (DateField, DateTimeField)):
+    elif isinstance(field, (DateField, DateTimeField)) and value is not None:
         return "dateutil.parser.parse(\"%s\")" % value.isoformat()
 
     # A normal field (e.g. a python built-in)


### PR DESCRIPTION
Issue #536: Following error condition triggers when there is None value for any DateField or DateTimeField. I.e. value == None

File "-/django_extensions/management/commands/dumpscript.py", line 718, in get_attribute_value
return "dateutil.parser.parse(\"%s\")" % value.isoformat()
AttributeError: 'NoneType' object has no attribute 'isoformat'

Fix: The proposed fix is to check the value against None before actually calling isoformat on the value.
