### PR TITLE
Adding RUNSERVERPLUS_SERVER_ADDRESS_PORT to docs

### DIFF
--- a/docs/runserver_plus.rst
+++ b/docs/runserver_plus.rst
@@ -135,3 +135,17 @@ if you want to reuse existing certificates.
 To install OpenSSL::
 
   $ pip install pyOpenSSL
+
+Configuration
+^^^
+
+The `RUNSERVERPLUS_SERVER_ADDRESS_PORT` setting can be configured to specify
+which address and port the development server should bind to.
+
+If you find yourself frequently starting the server with::
+
+  $ python manage.py runserver_plus 0.0.0.0:8000 
+
+You can use use setting to default your development to an address/port::
+
+    RUNSERVERPLUS_SERVER_ADDRESS_PORT = '0.0.0.0:8000'


### PR DESCRIPTION
The RUNSERVERPLUS_SERVER_ADDRESS_PORT is a handy shortcut and I couldn't find it documented anywhere except on the code.

It was merged in #350.
