### PR TITLE
Fixed `update_permissions` on django 1.7

### DIFF
--- a/django_extensions/management/commands/update_permissions.py
+++ b/django_extensions/management/commands/update_permissions.py
@@ -1,6 +1,25 @@
 from django.core.management.base import BaseCommand
-from django.db.models import get_models, get_app
-from django.contrib.auth.management import create_permissions
+from django.contrib.auth.management import create_permissions as _create_permissions
+
+try:
+    from django.apps import apps as django_apps
+    get_models = lambda: None
+    get_app = django_apps.get_app_config
+    get_all_apps = django_apps.get_app_configs
+
+    def create_permissions(app, models, verbosity):
+        _create_permissions(app, verbosity)
+
+except ImportError:
+    from django.db.models import get_models, get_app
+    django_apps = None
+
+    def get_all_apps():
+        apps = set()
+        for model in get_models():
+            apps.add(get_app(model._meta.app_label))
+        return apps
+    create_permissions = _create_permissions
 
 
 class Command(BaseCommand):
@@ -8,14 +27,12 @@ class Command(BaseCommand):
     help = 'reloads permissions for specified apps, or all apps if no args are specified'
 
     def handle(self, *args, **options):
+        apps = set()
         if not args:
-            apps = []
-            for model in get_models():
-                apps.append(get_app(model._meta.app_label))
+            apps = get_all_apps()
         else:
-            apps = []
             for arg in args:
-                apps.append(get_app(arg))
-        for app in apps:
-            create_permissions(app, get_models(), int(options.get('verbosity', 0)))
+                apps.add(get_app(arg))
 
+        for app in apps:
+            create_permissions(app, get_models(), int(options.get('verbosity', 3)))

--- a/django_extensions/tests/__init__.py
+++ b/django_extensions/tests/__init__.py
@@ -6,7 +6,7 @@ from django_extensions.tests.uuid_field import (UUIDFieldTest,
                                                 PostgreSQLUUIDFieldTest)
 from django_extensions.tests.shortuuid_field import ShortUUIDFieldTest
 from django_extensions.tests.fields import AutoSlugFieldTest
-from django_extensions.tests.management_command import CommandTest, ShowTemplateTagsTests
+from django_extensions.tests.management_command import CommandTest, ShowTemplateTagsTests, UpdatePermissionsTests
 from django_extensions.tests.test_templatetags import TemplateTagsTests
 from django_extensions.tests.test_clean_pyc import CleanPycTests
 from django_extensions.tests.test_compile_pyc import CompilePycTests
@@ -14,7 +14,7 @@ from django_extensions.tests.test_compile_pyc import CompilePycTests
 __test_classes__ = [
     DumpScriptTests, JsonFieldTest, UUIDFieldTest, AutoSlugFieldTest, CommandTest,
     ShowTemplateTagsTests, TruncateLetterTests, TemplateTagsTests, ShortUUIDFieldTest,
-    PostgreSQLUUIDFieldTest, CleanPycTests, CompilePycTests
+    PostgreSQLUUIDFieldTest, CleanPycTests, CompilePycTests, UpdatePermissionsTests
 ]
 
 try:

--- a/django_extensions/tests/management_command.py
+++ b/django_extensions/tests/management_command.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import logging
 
 try:
@@ -58,3 +59,19 @@ class ShowTemplateTagsTests(TestCase):
         self.assertIn('django_extensions', output)
         # let's check at least one
         self.assertIn('truncate_letters', output)
+
+
+class UpdatePermissionsTests(TestCase):
+    def test_works(self):
+        from django.db import models
+
+        class PermModel(models.Model):
+            class Meta:
+                app_label = 'django_extensions'
+                permissions = (('test_permission', 'test_permission'),)
+
+        original_stdout = sys.stdout
+        out = sys.stdout = StringIO()
+        call_command('update_permissions', stdout=out, verbosity=3)
+        sys.stdout = original_stdout
+        self.assertIn("Can change perm model", out.getvalue())


### PR DESCRIPTION
Django 1.7 changed the way they do "applications" as such, the API changed.

This patch adds a test to make sure that the `update_permissions` command actually works, and also fixes the command for django 1.7.
