### PR TITLE
sqldiff: Remove MySQL workaround, causes more issues then it solves.

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -537,13 +537,6 @@ class MySQLDiff(SQLDiff):
     # that this is way unreliable for MySQL atm.
     def get_field_db_type(self, description, field=None, table_name=None):
         from MySQLdb.constants import FIELD_TYPE
-        # weird bug? in mysql db-api where it returns three times the correct value for field length
-        # if i remember correctly it had something todo with unicode strings
-        # TODO: Fix this is a more meaningful and better understood manner
-        description = list(description)
-        if description[1] not in [FIELD_TYPE.TINY, FIELD_TYPE.SHORT]:  # exclude tinyints from conversion.
-            description[3] = description[3] / 3
-            description[4] = description[4] / 3
         db_type = super(MySQLDiff, self).get_field_db_type(description)
         if not db_type:
             return


### PR DESCRIPTION
Remove MySQL workaround for "weird bug". The original bug cannot be
tracked down nor reproduced. However, the workaround code produces
real bugs when detecting varchar display size. Removing the workaround
produces better, more accurate results for MySQL in many real test
scenarios.

Fixes #532
