### PR TITLE
sqldiff: Two fixes for MySQL backend

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -139,7 +139,7 @@ class SQLDiff(object):
         self.unknown_db_fields = {}
         self.new_db_fields = set()
         self.null = {}
-        self.unsigned = {}
+        self.unsigned = set()
 
         self.DIFF_SQL = {
             'error': self.SQL_ERROR,
@@ -268,7 +268,7 @@ class SQLDiff(object):
         tablespace = field.db_tablespace
         if not tablespace:
             tablespace = "public"
-        if self.unsigned.get((tablespace, table_name, field.column), False):
+        if (tablespace, table_name, field.column) in self.unsigned:
             field_db_type = '%s %s' % (field_db_type, self.unsigned_suffix)
 
         return field_db_type
@@ -582,7 +582,7 @@ class MySQLDiff(SQLDiff):
                     AND column_type LIKE '%%unsigned'""", [table_name])
             for table_info in result:
                 key = (tablespace, table_name, table_info['column_name'])
-                self.unsigned[key] = True
+                self.unsigned.add(key)
 
     def load_auto_increment(self):
         for table_name in self.db_tables:


### PR DESCRIPTION
Two fixes for the MySQL sqldiff backend. Let me know if I you prefer I sparate these out.
1. Inspect AUTO_INCREMENT from the `information_schema` instead of assuming it is true for primary keys. This means a difference will not be detected when AUTO_INCREMENT is not set corret.
2. A small data type/memory optimization from a previous commit I had.
