### PR TITLE
Changed in Django 1.5: cleanup is deprecated. Use clearsessions instead.

### DIFF
--- a/django_extensions/jobs/daily/daily_cleanup.py
+++ b/django_extensions/jobs/daily/daily_cleanup.py
@@ -13,7 +13,9 @@ class Job(DailyJob):
 
     def execute(self):
         from django.core import management
-        try:
-            management.call_command('clearsessions')
-        except management.CommandError:
-            management.call_command("cleanup")  # Django <1.5
+        from django import VERSION
+
+        if VERSION[:2] < (1, 5):
+            management.call_command("cleanup")
+        else:
+            management.call_command("clearsessions")


### PR DESCRIPTION
Currently django-extensions shows the following warning when running `python -W default manage.py runjobs daily`:

> /path/to/virtual/local/lib/python2.7/site-packages/django/core/management/commands/cleanup.py:10: PendingDeprecationWarning: The `cleanup` command has been deprecated in favor of `clearsessions`.
>   PendingDeprecationWarning)

This was [changed in Django 1.5](https://docs.djangoproject.com/en/1.5/ref/django-admin/#cleanup)
