### PR TITLE
Update runscript.py to work on Python 3.4 withouyt __init__.py files

### DIFF
--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
             try:
                 importlib.import_module(mod)
                 t = __import__(mod, [], [], [" "])
-            except (ImportError, AttributeError):
+            except (ImportError, AttributeError) as e:
                 if str(e).startswith('No module named'):
                     return False
                 else:


### PR DESCRIPTION
Doesn't work on Python 3.4 with imp module (deprecated). Replaced with importlib as recommeded by the Python documentation. 

**IMPORTANT**: It failed to function with imp because I don't have **init**.py files in my modules.

I don't really know how to test for the python version and since when this new syntax is preferred. I can only say that it would be great if you could implement this for python version 3.4 (maybe even 3.3 ?).
