### PR TITLE
Fix model loading for sentry

### DIFF
--- a/django_extensions/management/shells.py
+++ b/django_extensions/management/shells.py
@@ -153,7 +153,11 @@ def import_objects(options, style):
     if not quiet_load:
         print(style.SQL_TABLE("# Shell Plus Model Imports"))
     for app_mod, models in sorted(six.iteritems(load_models)):
-        app_name = app_mod.split('.')[-2]
+        try:
+            app_name = app_mod.split('.')[-2]
+        except IndexError:
+            # Some weird model naming scheme like in Sentry.
+            app_name = app_mod
         app_aliases = model_aliases.get(app_name, {})
         model_labels = []
 


### PR DESCRIPTION
Sentry has a weird model naming scheme where all model files are inside
a single directory called models and each 'app' models is in a file of
its own (I guess the authors thought this was a better idea when they
didn't have any views etc. but models only).

With the models directory begin in the import path, one can import by
        from useroption import UserOption
for example.

If there are no app names, use the file name as app name.

Fixes #519 
