### PR TITLE
admin_generator: remove requires_model_validation

### DIFF
--- a/django_extensions/management/commands/admin_generator.py
+++ b/django_extensions/management/commands/admin_generator.py
@@ -304,7 +304,6 @@ class Command(BaseCommand):
     )
     can_import_settings = True
     requires_system_checks = True
-    requires_model_validation = True
 
     def handle(self, *args, **kwargs):
         self.style = color_style()


### PR DESCRIPTION
this fixes this traceback in Django 1.7:

Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/**init**.py", line 385, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/**init**.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/**init**.py", line 238, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/**init**.py", line 42, in load_command_class
    return module.Command()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 228, in **init**
    '"requires_system_checks".' % self.**class**.**name**)
django.core.exceptions.ImproperlyConfigured: Command Command defines both "requires_model_validation" and "requires_system_checks", which is illegal. Use only "requires_system_checks".
