### PR TITLE
fix for dbcolumn not used in few places

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -864,7 +864,7 @@ class PostgresqlSQLDiff(SQLDiff):
                 if tablespace == "":
                     tablespace = "public"
                 attname = field.db_column or field.attname
-                check_constraint = self.check_constraints.get((tablespace, table_name, attname    ), {}).get('pg_get_constraintdef', None)
+                check_constraint = self.check_constraints.get((tablespace, table_name, attname), {}).get('pg_get_constraintdef', None)
                 if check_constraint:
                     check_constraint = check_constraint.replace("((", "(")
                     check_constraint = check_constraint.replace("))", ")")


### PR DESCRIPTION
ForeignKey with dbColumn specified does not generate proper sqldiff, this fix will generate the proper column name. 

Example problematic model is : 

``` python
class TestSite(models.Model):
    SiteId = models.AutoField(primary_key=True)
    CreatedByUserId = models.ForeignKey("TestSite",db_column='ParentId')

    class Meta:
        db_table = "TestSite"
```
