### PR TITLE
fix for issue #561 removing empty lines (python 3)

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -77,7 +77,8 @@ class Command(BaseCommand):
         import django
 
         # Do not use default ending='\n', because StreamHandler() takes care of it
-        self.stderr.ending = None
+        if hasattr(self.stderr, 'ending'):
+            self.stderr.ending = None
 
         setup_logger(logger, self.stderr, filename=options.get('output_file', None))  # , fmt="[%(name)s] %(message)s")
         logredirect = RedirectHandler(__name__)


### PR DESCRIPTION
Extra lines are added because in python 3 StreamHandler() first writes message to stream and then writes delimiter ('\n'). Stream is wrapped with django's OutputWrapper(), which checks if message ends with ending ('\n' again) and if not appends it to message.
Not using default ending='\n' in django's OutputWrapper() should fix the issue.
