### PR TITLE
Feature/565 pre post command

### DIFF
--- a/django_extensions/management/commands/admin_generator.py
+++ b/django_extensions/management/commands/admin_generator.py
@@ -10,6 +10,7 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 
 from django_extensions.management.color import color_style
+from django_extensions.management.utils import signalcommand
 
 # Configurable constants
 MAX_LINE_WIDTH = getattr(settings, 'MAX_LINE_WIDTH', 78)
@@ -303,6 +304,7 @@ class Command(BaseCommand):
     )
     can_import_settings = True
 
+    @signalcommand
     def handle(self, *args, **kwargs):
         self.style = color_style()
 

--- a/django_extensions/management/commands/clean_pyc.py
+++ b/django_extensions/management/commands/clean_pyc.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from optparse import make_option
 from os.path import join as _j
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
@@ -18,6 +20,7 @@ class Command(NoArgsCommand):
 
     requires_model_validation = False
 
+    @signalcommand
     def handle_noargs(self, **options):
         project_root = options.get("path", getattr(settings, 'BASE_DIR', None))
         if not project_root:

--- a/django_extensions/management/commands/clear_cache.py
+++ b/django_extensions/management/commands/clear_cache.py
@@ -4,11 +4,14 @@
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(BaseCommand):
     """A simple management command which clears the site-wide cache."""
     help = 'Fully clear site-wide cache.'
 
+    @signalcommand
     def handle(self, *args, **kwargs):
         cache.clear()
         self.stdout.write('Cache has been cleared!\n')

--- a/django_extensions/management/commands/compile_pyc.py
+++ b/django_extensions/management/commands/compile_pyc.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from optparse import make_option
 from os.path import join as _j
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
@@ -16,6 +18,7 @@ class Command(NoArgsCommand):
 
     requires_model_validation = False
 
+    @signalcommand
     def handle_noargs(self, **options):
         project_root = options.get("path", None)
         if not project_root:

--- a/django_extensions/management/commands/create_app.py
+++ b/django_extensions/management/commands/create_app.py
@@ -8,7 +8,7 @@ from django.core.management.base import CommandError, LabelCommand
 from django.template import Template, Context
 from django_extensions.settings import REPLACEMENTS
 from django_extensions.utils.dia2django import dia2django
-from django_extensions.management.utils import _make_writeable
+from django_extensions.management.utils import _make_writeable, signalcommand
 from optparse import make_option
 
 
@@ -31,6 +31,7 @@ class Command(LabelCommand):
     requires_model_validation = False
     can_import_settings = True
 
+    @signalcommand
     def handle_label(self, label, **options):
         project_dir = os.getcwd()
         project_name = os.path.split(project_dir)[-1]

--- a/django_extensions/management/commands/create_command.py
+++ b/django_extensions/management/commands/create_command.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from django.core.management.base import AppCommand
-from django_extensions.management.utils import _make_writeable
+from django_extensions.management.utils import _make_writeable, signalcommand
 from optparse import make_option
 
 
@@ -23,6 +23,7 @@ class Command(AppCommand):
     # necessarily been created.
     can_import_settings = True
 
+    @signalcommand
     def handle_app(self, app, **options):
         app_dir = os.path.dirname(app.__file__)
         copy_template('command_template', app_dir, options.get('command_name'), '%sCommand' % options.get('base_command'))

--- a/django_extensions/management/commands/create_jobs.py
+++ b/django_extensions/management/commands/create_jobs.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from django.core.management.base import AppCommand
-from django_extensions.management.utils import _make_writeable
+from django_extensions.management.utils import _make_writeable, signalcommand
 
 
 class Command(AppCommand):
@@ -14,6 +14,7 @@ class Command(AppCommand):
     # necessarily been created.
     can_import_settings = True
 
+    @signalcommand
     def handle_app(self, app, **options):
         app_dir = os.path.dirname(app.__file__)
         copy_template('jobs_template', app_dir)

--- a/django_extensions/management/commands/create_template_tags.py
+++ b/django_extensions/management/commands/create_template_tags.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from django.core.management.base import AppCommand
-from django_extensions.management.utils import _make_writeable
+from django_extensions.management.utils import _make_writeable, signalcommand
 from optparse import make_option
 
 
@@ -23,6 +23,7 @@ class Command(AppCommand):
     # necessarily been created.
     can_import_settings = True
 
+    @signalcommand
     def handle_app(self, app, **options):
         app_dir = os.path.dirname(app.__file__)
         tag_library_name = options.get('tag_library_name')

--- a/django_extensions/management/commands/describe_form.py
+++ b/django_extensions/management/commands/describe_form.py
@@ -1,5 +1,6 @@
 from django.core.management.base import LabelCommand, CommandError
 from django.utils.encoding import force_unicode
+from django_extensions.management.utils import signalcommand
 
 
 class Command(LabelCommand):
@@ -9,6 +10,7 @@ class Command(LabelCommand):
 
     can_import_settings = True
 
+    @signalcommand
     def handle_label(self, label, **options):
         return describe_form(label)
 

--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -41,11 +41,13 @@ from django.core.management.base import BaseCommand
 
 # conditional import, force_unicode was renamed in Django 1.5
 from django.contrib.contenttypes.models import ContentType
+
 try:
     from django.utils.encoding import smart_unicode, force_unicode  # NOQA
 except ImportError:
     from django.utils.encoding import smart_text as smart_unicode, force_text as force_unicode  # NOQA
 
+from django_extensions.management.utils import signalcommand
 
 def orm_item_locator(orm_obj):
     """
@@ -89,6 +91,7 @@ class Command(BaseCommand):
     help = 'Dumps the data as a customised python script.'
     args = '[appname ...]'
 
+    @signalcommand
     def handle(self, *app_labels, **options):
 
         # Get the models we want to export

--- a/django_extensions/management/commands/export_emails.py
+++ b/django_extensions/management/commands/export_emails.py
@@ -9,6 +9,8 @@ from sys import stdout
 from csv import writer
 import six
 
+from django_extensions.management.utils import signalcommand
+
 FORMATS = [
     'address',
     'emails',
@@ -41,6 +43,7 @@ class Command(BaseCommand):
     can_import_settings = True
     encoding = 'utf-8'  # RED_FLAG: add as an option -DougN
 
+    @signalcommand
     def handle(self, *args, **options):
         if len(args) > 1:
             raise CommandError("extra arguments supplied")

--- a/django_extensions/management/commands/find_template.py
+++ b/django_extensions/management/commands/find_template.py
@@ -3,6 +3,8 @@ from django.template import loader
 from django.template import TemplateDoesNotExist
 import sys
 
+from django_extensions.management.utils import signalcommand
+
 
 def get_template_path(path):
     try:
@@ -26,6 +28,7 @@ class Command(LabelCommand):
     args = "[template_path]"
     label = 'template path'
 
+    @signalcommand
     def handle_label(self, template_path, **options):
         path = get_template_path(template_path)
         if path is None:

--- a/django_extensions/management/commands/generate_secret_key.py
+++ b/django_extensions/management/commands/generate_secret_key.py
@@ -1,11 +1,14 @@
 from random import choice
 from django.core.management.base import NoArgsCommand
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(NoArgsCommand):
     help = "Generates a new SECRET_KEY that can be used in a project settings file."
 
     requires_model_validation = False
 
+    @signalcommand
     def handle_noargs(self, **options):
         return ''.join([choice('abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)') for i in range(50)])

--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -4,6 +4,7 @@ from optparse import make_option, NO_DEFAULT
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from django_extensions.management.modelviz import generate_dot
+from django_extensions.management.utils import signalcommand
 
 
 try:
@@ -62,6 +63,7 @@ class Command(BaseCommand):
 
     can_import_settings = True
 
+    @signalcommand
     def handle(self, *args, **options):
         self.options_from_settings(options)
 

--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -1,4 +1,4 @@
-from django_extensions.management.utils import setup_logger
+from django_extensions.management.utils import setup_logger, signalcommand
 from django.core.management.base import BaseCommand, CommandError
 from optparse import make_option
 from smtpd import SMTPServer
@@ -40,6 +40,7 @@ class Command(BaseCommand):
 
     requires_model_validation = False
 
+    @signalcommand
     def handle(self, addrport='', *args, **options):
         if args:
             raise CommandError('Usage is mail_debug %s' % self.args)

--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 import os
 import re
+from django_extensions.management.utils import signalcommand
 
 ANNOTATION_RE = re.compile("\{?#[\s]*?(TODO|FIXME|BUG|HACK|WARNING|NOTE|XXX)[\s:]?(.+)")
 ANNOTATION_END_RE = re.compile("(.*)#\}(.*)")
@@ -13,6 +14,7 @@ class Command(BaseCommand):
     args = 'tag'
     label = 'annotation tag (TODO, FIXME, BUG, HACK, WARNING, NOTE, XXX)'
 
+    @signalcommand
     def handle(self, *args, **options):
         # don't add django internal code
         apps = filter(lambda app: not app.startswith('django.contrib'), settings.INSTALLED_APPS)

--- a/django_extensions/management/commands/passwd.py
+++ b/django_extensions/management/commands/passwd.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand, CommandError
+from django_extensions.management.utils import signalcommand
 try:
     from django.contrib.auth import get_user_model  # Django 1.5
 except ImportError:
@@ -11,6 +12,7 @@ class Command(BaseCommand):
 
     requires_model_validation = False
 
+    @signalcommand
     def handle(self, *args, **options):
         if len(args) > 1:
             raise CommandError("need exactly one or zero arguments for username")

--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -8,6 +8,7 @@ from django.core.management.base import NoArgsCommand
 from django_extensions.management.color import color_style
 from optparse import make_option
 from pip.req import parse_requirements
+from django_extensions.management.utils import signalcommand
 try:
     from urllib.parse import urlparse
     from urllib.error import HTTPError
@@ -45,6 +46,7 @@ class Command(NoArgsCommand):
     )
     help = "Scan pip requirement files for out-of-date packages."
 
+    @signalcommand
     def handle_noargs(self, **options):
         self.style = color_style()
 

--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -8,6 +8,7 @@ Django command similar to 'diffsettings' but shows all active Django settings.
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from optparse import make_option
+from django_extensions.management.utils import signalcommand
 
 
 class Command(BaseCommand):
@@ -22,6 +23,7 @@ class Command(BaseCommand):
                     help='Specifies indent level for JSON and YAML'),
     )
 
+    @signalcommand
     def handle(self, *args, **options):
         a_dict = {}
 

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django_extensions.management.utils import signalcommand
 
 try:
     from django.contrib.auth import get_user_model  # Django 1.5
@@ -22,6 +23,7 @@ class Command(BaseCommand):
 
     can_import_settings = True
 
+    @signalcommand
     def handle(self, *args, **options):
         if len(args) > 1:
             raise CommandError("extra arguments supplied")

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 from six.moves import input, configparser
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
@@ -35,6 +37,7 @@ class Command(BaseCommand):
     )
     help = "Resets the database for this project."
 
+    @signalcommand
     def handle(self, *args, **options):
         """
         Resets the database for this project.

--- a/django_extensions/management/commands/runjob.py
+++ b/django_extensions/management/commands/runjob.py
@@ -1,6 +1,7 @@
 from django.core.management.base import LabelCommand
 from optparse import make_option
 from django_extensions.management.jobs import get_job, print_jobs
+from django_extensions.management.utils import signalcommand
 
 
 class Command(LabelCommand):
@@ -34,6 +35,7 @@ class Command(LabelCommand):
             traceback.print_exc()
             print("END TRACEBACK\n")
 
+    @signalcommand
     def handle(self, *args, **options):
         app_name = None
         job_name = None

--- a/django_extensions/management/commands/runjobs.py
+++ b/django_extensions/management/commands/runjobs.py
@@ -1,6 +1,7 @@
 from django.core.management.base import LabelCommand
 from optparse import make_option
 from django_extensions.management.jobs import get_jobs, print_jobs
+from django_extensions.management.utils import signalcommand
 
 
 class Command(LabelCommand):
@@ -66,6 +67,7 @@ class Command(LabelCommand):
             elif when == 'yearly':
                 signals.run_yearly_jobs.send(sender=app, app=app)
 
+    @signalcommand
     def handle(self, *args, **options):
         when = None
         if len(args) > 1:

--- a/django_extensions/management/commands/runprofileserver.py
+++ b/django_extensions/management/commands/runprofileserver.py
@@ -21,6 +21,8 @@ try:
 except ImportError as e:
     USE_STATICFILES = False
 
+from django_extensions.management.utils import signalcommand
+
 try:
     any
 except NameError:
@@ -135,6 +137,7 @@ class Command(BaseCommand):
     help = "Starts a lightweight Web server with profiling enabled."
     args = '[optional port number, or ipaddr:port]'
 
+    @signalcommand
     def handle(self, addrport='', *args, **options):
         import django
         import socket

--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -4,12 +4,13 @@ from optparse import make_option
 from django_extensions.management.email_notifications import EmailNotificationCommand
 from django.conf import settings
 
-
 try:
     import importlib
 except ImportError:
     print("Runscript needs the importlib module to work. You can install it via 'pip install importlib'")
     sys.exit(1)
+
+from django_extensions.management.utils import signalcommand
 
 
 def vararg_callback(option, opt_str, opt_value, parser):
@@ -45,6 +46,7 @@ class Command(EmailNotificationCommand):
     help = 'Runs a script in django context.'
     args = "script [script ...]"
 
+    @signalcommand
     def handle(self, *scripts, **options):
         NOTICE = self.style.SQL_TABLE
         NOTICE2 = self.style.SQL_FIELD

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -8,7 +8,8 @@ from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django_extensions.management.utils import setup_logger, RedirectHandler
+from django_extensions.management.utils import setup_logger, RedirectHandler,\
+    signalcommand
 from django_extensions.management.technical_response import null_technical_500_response
 
 
@@ -73,6 +74,7 @@ class Command(BaseCommand):
     # Validation is called explicitly each time the server is reloaded.
     requires_model_validation = False
 
+    @signalcommand
     def handle(self, addrport='', *args, **options):
         import django
 

--- a/django_extensions/management/commands/set_default_site.py
+++ b/django_extensions/management/commands/set_default_site.py
@@ -6,6 +6,8 @@ from optparse import make_option
 
 from django.core.management.base import NoArgsCommand, CommandError
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
@@ -18,6 +20,7 @@ class Command(NoArgsCommand):
     )
     help = "Set parameters of the default django.contrib.sites Site"
 
+    @signalcommand
     def handle_noargs(self, **options):
         from django.contrib.sites.models import Site
 

--- a/django_extensions/management/commands/set_fake_emails.py
+++ b/django_extensions/management/commands/set_fake_emails.py
@@ -13,6 +13,8 @@ from django.core.management.base import NoArgsCommand, CommandError
 
 DEFAULT_FAKE_EMAIL = '%(username)s@example.com'
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(NoArgsCommand):
     option_list = NoArgsCommand.option_list + (
@@ -34,6 +36,7 @@ class Command(NoArgsCommand):
     help = '''DEBUG only: give all users a new email based on their account data ("%s" by default). Possible parameters are: username, first_name, last_name''' % (DEFAULT_FAKE_EMAIL, )
     requires_model_validation = False
 
+    @signalcommand
     def handle_noargs(self, **options):
         if not settings.DEBUG:
             raise CommandError('Only available in debug mode')

--- a/django_extensions/management/commands/set_fake_passwords.py
+++ b/django_extensions/management/commands/set_fake_passwords.py
@@ -11,6 +11,8 @@ from optparse import make_option
 from django.conf import settings
 from django.core.management.base import NoArgsCommand, CommandError
 
+from django_extensions.management.utils import signalcommand
+
 DEFAULT_FAKE_PASSWORD = 'password'
 
 
@@ -24,6 +26,7 @@ class Command(NoArgsCommand):
     help = 'DEBUG only: sets all user passwords to a common value ("%s" by default)' % (DEFAULT_FAKE_PASSWORD, )
     requires_model_validation = False
 
+    @signalcommand
     def handle_noargs(self, **options):
         if not settings.DEBUG:
             raise CommandError('Only available in debug mode')

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -8,6 +8,7 @@ from django.core.management.base import NoArgsCommand
 from django.conf import settings
 
 from django_extensions.management.shells import import_objects
+from django_extensions.management.utils import signalcommand
 
 
 class Command(NoArgsCommand):
@@ -39,6 +40,7 @@ class Command(NoArgsCommand):
     )
     help = "Like the 'shell' command but autoloads the models of all installed Django apps."
 
+    @signalcommand
     def handle_noargs(self, **options):
         use_kernel = options.get('kernel', False)
         use_notebook = options.get('notebook', False)

--- a/django_extensions/management/commands/show_templatetags.py
+++ b/django_extensions/management/commands/show_templatetags.py
@@ -7,6 +7,8 @@ from django.core.management import color
 from django.template import get_library
 from django.utils import termcolors
 
+from django_extensions.management.utils import signalcommand
+
 try:
     from django.utils.encoding import smart_text
 except ImportError:
@@ -66,6 +68,7 @@ class Command(BaseCommand):
     def add_result(self, s, depth=0):
         self.results += '%s\n' % s.rjust(depth * 4 + len(s))
 
+    @signalcommand
     def handle(self, *args, **options):
         if args:
             appname, = args

--- a/django_extensions/management/commands/show_urls.py
+++ b/django_extensions/management/commands/show_urls.py
@@ -10,6 +10,7 @@ from django.contrib.admindocs.views import simplify_regex
 from django.utils.translation import activate
 
 from django_extensions.management.color import color_style
+from django_extensions.management.utils import signalcommand
 
 
 FMTR = {
@@ -75,6 +76,7 @@ class Command(BaseCommand):
 
     help = "Displays all of the url matching routes for the project."
 
+    @signalcommand
     def handle(self, *args, **options):
         if args:
             appname, = args

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -6,6 +6,8 @@ from optparse import make_option
 from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
@@ -25,6 +27,7 @@ The envisioned use case is something like this:
     requires_model_validation = False
     can_import_settings = True
 
+    @signalcommand
     def handle(self, *args, **options):
         router = options.get('router')
         dbinfo = settings.DATABASES.get(router)

--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -32,6 +32,8 @@ from django.core.management.color import no_style
 from django.db import transaction, connection
 from django.db.models.fields import IntegerField, AutoField
 
+from django_extensions.management.utils import signalcommand
+
 try:
     from django.core.management.base import OutputWrapper
     HAS_OUTPUTWRAPPER = True
@@ -932,6 +934,7 @@ to check/debug ur models compared to the real database tables and columns."""
         super(Command, self).__init__(*args, **kwargs)
         self.exit_code = 1
 
+    @signalcommand
     def handle(self, *app_labels, **options):
         from django.db import models
         from django.conf import settings

--- a/django_extensions/management/commands/sync_s3.py
+++ b/django_extensions/management/commands/sync_s3.py
@@ -72,6 +72,8 @@ except ImportError:
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from django_extensions.management.utils import signalcommand
+
 # Make sure boto is available
 try:
     import boto
@@ -149,6 +151,7 @@ class Command(BaseCommand):
 
     can_import_settings = True
 
+    @signalcommand
     def handle(self, *args, **options):
         if not HAS_BOTO:
             raise ImportError("The boto Python library is not installed.")

--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -14,6 +14,8 @@ import six
 from django.core.management.base import BaseCommand
 from django.core.management.color import no_style
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(BaseCommand):
     """ syncdata command """
@@ -49,6 +51,7 @@ class Command(BaseCommand):
 
                 print("Deleted %s %s" % (str(num_deleted), type_deleted))
 
+    @signalcommand
     def handle(self, *fixture_labels, **options):
         """ Main method of a Django command """
         from django.db.models import get_apps

--- a/django_extensions/management/commands/unreferenced_files.py
+++ b/django_extensions/management/commands/unreferenced_files.py
@@ -5,10 +5,13 @@ from django.core.management.base import NoArgsCommand
 from django.db import models
 from django.db.models.loading import cache
 
+from django_extensions.management.utils import signalcommand
+
 
 class Command(NoArgsCommand):
     help = "Prints a list of all files in MEDIA_ROOT that are not referenced in the database."
 
+    @signalcommand
     def handle_noargs(self, **options):
 
         if settings.MEDIA_ROOT == '':

--- a/django_extensions/management/commands/update_permissions.py
+++ b/django_extensions/management/commands/update_permissions.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.contrib.auth.management import create_permissions as _create_permissions
-from django_extensions.management.signals import pre_command, post_command
+
+from django_extensions.management.utils import signalcommand
 
 try:
     from django.apps import apps as django_apps
@@ -27,9 +28,8 @@ class Command(BaseCommand):
     args = '<app app ...>'
     help = 'reloads permissions for specified apps, or all apps if no args are specified'
 
+    @signalcommand
     def handle(self, *args, **options):
-        pre_command.send(self.__class__)
-        
         apps = set()
         if not args:
             apps = get_all_apps()
@@ -39,6 +39,3 @@ class Command(BaseCommand):
 
         for app in apps:
             create_permissions(app, get_models(), int(options.get('verbosity', 3)))
-
-        post_command.send(self.__class__)
-

--- a/django_extensions/management/commands/validate_templates.py
+++ b/django_extensions/management/commands/validate_templates.py
@@ -5,6 +5,7 @@ from django.core.management.color import color_style
 from django.template.base import add_to_builtins
 from django.template.loaders.filesystem import Loader
 from django_extensions.utils import validatingtemplatetags
+from django_extensions.management.utils import signalcommand
 
 #
 # TODO: Render the template with fake request object ?
@@ -25,6 +26,7 @@ class Command(BaseCommand):
                     default=[], help="Append these paths to TEMPLATE_DIRS")
     )
 
+    @signalcommand
     def handle(self, *args, **options):
         from django.conf import settings
         style = color_style()

--- a/django_extensions/management/signals.py
+++ b/django_extensions/management/signals.py
@@ -11,5 +11,5 @@ run_weekly_jobs = Signal()
 run_monthly_jobs = Signal()
 run_yearly_jobs = Signal()
 
-pre_command = Signal()
-post_command = Signal()
+pre_command = Signal(providing_args=["args", "kwargs"])
+post_command = Signal(providing_args=["args", "kwargs", "outcome"])

--- a/django_extensions/management/utils.py
+++ b/django_extensions/management/utils.py
@@ -2,6 +2,7 @@ from django.conf import settings
 import os
 import sys
 import logging
+from django_extensions.management.signals import pre_command, post_command
 
 try:
     from importlib import import_module
@@ -67,3 +68,13 @@ class RedirectHandler(logging.Handler):
 
     def emit(self, record):
         self.logger.handle(record)
+
+
+def signalcommand(func):
+    """A decorator for management command handle defs that sends out a pre/post signal."""
+    def inner(self, *args, **kwargs):
+        pre_command.send(self.__class__, args=args, kwargs=kwargs)
+        ret = func(self, *args, **kwargs)
+        post_command.send(self.__class__, args=args, kwargs=kwargs, outcome=ret)
+        return ret
+    return inner

--- a/django_extensions/tests/__init__.py
+++ b/django_extensions/tests/__init__.py
@@ -6,15 +6,17 @@ from django_extensions.tests.uuid_field import (UUIDFieldTest,
                                                 PostgreSQLUUIDFieldTest)
 from django_extensions.tests.shortuuid_field import ShortUUIDFieldTest
 from django_extensions.tests.fields import AutoSlugFieldTest
-from django_extensions.tests.management_command import CommandTest, ShowTemplateTagsTests, UpdatePermissionsTests
+from django_extensions.tests.management_command import CommandTest, \
+    ShowTemplateTagsTests, UpdatePermissionsTests, CommandSignalTests
 from django_extensions.tests.test_templatetags import TemplateTagsTests
 from django_extensions.tests.test_clean_pyc import CleanPycTests
 from django_extensions.tests.test_compile_pyc import CompilePycTests
 
 __test_classes__ = [
-    DumpScriptTests, JsonFieldTest, UUIDFieldTest, AutoSlugFieldTest, CommandTest,
-    ShowTemplateTagsTests, TruncateLetterTests, TemplateTagsTests, ShortUUIDFieldTest,
-    PostgreSQLUUIDFieldTest, CleanPycTests, CompilePycTests, UpdatePermissionsTests
+    DumpScriptTests, JsonFieldTest, UUIDFieldTest, AutoSlugFieldTest, 
+    CommandTest, ShowTemplateTagsTests, TruncateLetterTests, TemplateTagsTests, 
+    ShortUUIDFieldTest, PostgreSQLUUIDFieldTest, CleanPycTests, CompilePycTests,
+    UpdatePermissionsTests, CommandSignalTests
 ]
 
 try:

--- a/django_extensions/tests/management_command.py
+++ b/django_extensions/tests/management_command.py
@@ -75,3 +75,33 @@ class UpdatePermissionsTests(TestCase):
         call_command('update_permissions', stdout=out, verbosity=3)
         sys.stdout = original_stdout
         self.assertIn("Can change perm model", out.getvalue())
+
+
+class CommandSignalTests(TestCase):
+    pre = None
+    post = None
+
+    def test_works(self):
+        from django_extensions.management.signals import post_command, \
+            pre_command
+        from django_extensions.management.commands.show_templatetags import \
+            Command
+
+        def pre(sender, **kwargs):
+            CommandSignalTests.pre = dict(**kwargs)
+
+        def post(sender, **kwargs):
+            CommandSignalTests.post = dict(**kwargs)
+
+        pre_command.connect(pre, Command)
+        post_command.connect(post, Command)
+
+        out = StringIO()
+        call_command('show_templatetags', stdout=out)
+
+        self.assertIn('args', CommandSignalTests.pre)
+        self.assertIn('kwargs', CommandSignalTests.pre)
+
+        self.assertIn('args', CommandSignalTests.post)
+        self.assertIn('kwargs', CommandSignalTests.post)
+        self.assertIn('outcome', CommandSignalTests.post)

--- a/docs/command_signals.rst
+++ b/docs/command_signals.rst
@@ -1,0 +1,91 @@
+Command Signals
+===============
+
+:synopsis: Signals fired before and after a command is executed.
+
+A signal is thrown pre/post each management command allowing your application 
+to hook into each commands execution.
+
+
+Basic Example
+-------------
+
+An example hooking into show_templatetags:
+
+::
+
+  from django_extensions.management.signals import pre_command, post_command
+  from django_extensions.management.commands.show_templatetags import Command
+  
+  def pre_receiver(sender, args, kwargs):
+    # I'm executed prior to the management command
+  
+  def post_receiver(sender, args, kwargs, outcome):
+    # I'm executed after the management command
+  
+  pre_command.connect(pre_receiver, Command)
+  post_command.connect(post_receiver, Command)
+
+
+Custom Permissions For All Models
+---------------------------------
+ 
+You can use the post signal to hook into the ``update_permissions`` command so that 
+you can add your own permissions to each model.
+ 
+For instance, lets say you want to add ``list`` and ``view`` permissions to 
+each model. You could do this by adding them to the ``permissions`` tuple inside
+your models ``Meta`` class but this gets pretty tedious.
+ 
+An easier solution is to hook into the ``update_permissions`` call, as follows;
+ 
+::
+
+  from django.db.models.signals import post_syncdb
+  from django.contrib.contenttypes.models import ContentType
+  from django.contrib.auth.models import Permission
+  from django_extensions.management.signals import post_command
+  from django_extensions.management.commands.update_permissions import Command as UpdatePermissionsCommand
+  
+  def add_permissions(sender, **kwargs):
+    """
+    Add view and list permissions to all content types.
+    """
+    # for each of our content types
+    for content_type in ContentType.objects.all():
+      
+      for action in ['view', 'list']:
+        # build our permission slug
+        codename = "%s_%s" % (action, content_type.model)
+        
+        try:
+          Permission.objects.get(content_type=content_type, codename=codename)
+          # Already exists, ignore
+        except Permission.DoesNotExist:
+          # Doesn't exist, add it
+          Permission.objects.create(content_type=content_type,
+                        codename=codename,
+                        name="Can %s %s" % (action, content_type.name))
+          print "Added %s permission for %s" % (action, content_type.name)
+  post_command.connect(add_permissions, UpdatePermissionsCommand)
+ 
+Each time ``update_permissions`` is called ``add_permissions`` will be called which 
+ensures there are view and list permissions to all content types.
+
+
+Using pre/post signals on your own commands
+-------------------------------------------
+ 
+The signals are implemented using a decorator on the handle method of a management command, 
+thus using this functionality in your own application is trivial:
+
+::
+
+  from django_extensions.management.utils import signalcommand
+   
+  class Command(BaseCommand):
+   
+    @signalcommand
+    def handle(self, *args, **kwargs):
+      ...
+      ...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Contents
    installation_instructions
    command_extensions
    command_extension_ideas
+   command_signals
    admin_extensions
    shell_plus
    create_app


### PR DESCRIPTION
After feedback provided on #565 I've implemented the following;
- Better solution that uses a decorator to send pre/post signals
- Decorated all management commands with the @signalcommand
- Documented basic and more advanced usage, with a specific example to add custom permissions (which is what I originally intended the functionality for).
- Added basic test
