### PR TITLE
Fixes django 1.7 migrations when using JSONField

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -94,7 +94,11 @@ class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
         """Convert our JSON object to a string before we save"""
         if value is None and self.null:
             return None
-        return super(JSONField, self).get_db_prep_save(dumps(value), connection=connection)
+        # default values come in as strings; only non-strings should be
+        # run through `dumps`
+        if not isinstance(value, six.string_types):
+            value = dumps(value)
+        return super(JSONField, self).get_db_prep_save(value, connection=connection)
 
     def south_field_triple(self):
         """Returns a suitable description of this field for South."""


### PR DESCRIPTION
Fixes django 1.7 migrations when adding a new JSONField to an existing model with existing data in the DB; the new field for the existing data would be quoted in the DB - ie. `"{}"` instead of `{}`.

However, I'm unsure how to write a test for this. This is only a problem during migrations. This fixes #593.