### PR TITLE
Updating tox.ini to latest Django versions, updated docs for JSONField

### DIFF
--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -35,3 +35,5 @@ Current Database Model Field Extensions
 * *EncryptedTextField* - CharField which transparently encrypts its value as it goes in and out of the database.  Encryption is handled by `Keyczar <http://www.keyczar.org/>`_.  To use this field you must have Keyczar installed, have generated a primary encryption key, and have ``settings.ENCRYPTED_FIELD_KEYS_DIR`` set to the full path of your keys directory.
 
 * *ShortUUIDField* - CharField which transparently generates a UUID and pass it to base57. It result in shorter 22 characters values useful e.g. for concise, unambiguous URLS. It's possible to get shorter values with length parameter: they are not Universal Unique any more but probability of collision is still low
+
+* *JSONField* - a generic TextField that neatly serializes/unserializes JSON objects seamlessly

--- a/tox.ini
+++ b/tox.ini
@@ -14,67 +14,67 @@ commands = {envpython} setup.py test
 
 [testenv:py26_django14]
 basepython = python2.6
-deps = Django==1.4.12
+deps = Django==1.4.17
        shortuuid==0.4
        python-dateutil
 
 [testenv:py27_django14]
 basepython = python2.7
-deps = Django==1.4.12
+deps = Django==1.4.17
        shortuuid==0.4
        python-dateutil
 
 [testenv:py26_django15]
 basepython = python2.6
-deps = Django==1.5.7
+deps = Django==1.5.12
        shortuuid==0.4
        python-dateutil
 
 [testenv:py27_django15]
 basepython = python2.7
-deps = Django==1.5.7
+deps = Django==1.5.12
        shortuuid==0.4
        python-dateutil
 
 [testenv:py27_django16]
 basepython = python2.7
-deps = Django==1.6.4
+deps = Django==1.6.9
        shortuuid==0.4
        python-dateutil
 
 [testenv:py27_django17]
 basepython = python2.7
-deps = https://www.djangoproject.com/download/1.7b3/tarball/
+deps = Django==1.7.2
        shortuuid==0.4
        python-dateutil
 
 [testenv:py33_django15]
 basepython = python3.3
-deps = Django==1.5.7
+deps = Django==1.5.12
        shortuuid==0.4
        python-dateutil
 
 [testenv:py33_django16]
 basepython = python3.3
-deps = Django==1.6.4
+deps = Django==1.6.9
        shortuuid==0.4
        python-dateutil
 
 [testenv:py33_django17]
 basepython = python3.3
-deps = https://www.djangoproject.com/download/1.7b3/tarball/
+deps = Django==1.7.2
        shortuuid==0.4
        python-dateutil
 
 [testenv:py34_django16]
 basepython = python3.4
-deps = Django==1.6.4
+deps = Django==1.6.9
        shortuuid==0.4
        python-dateutil
 
 [testenv:py34_django17]
 basepython = python3.4
-deps = https://www.djangoproject.com/download/1.7b3/tarball/
+deps = Django==1.7.2
        shortuuid==0.4
        python-dateutil
 


### PR DESCRIPTION
Most importantly, the 1.7 references were to the 'b3' prelease.