### PR TITLE
Fix check for missing import_helper module in dumpscript (Python 3.3+).

### DIFF
--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -640,7 +640,8 @@ try:
     # has no knowlodge of this class
     importer = type("DynamicImportHelper", (import_helper.ImportHelper, BasicImportHelper ) , {} )()
 except ImportError as e:
-    if str(e) == "No module named import_helper":
+    # From Python 3.3 we can check e.name - string match is for backward compatibility.
+    if 'import_helper' in str(e):
         importer = BasicImportHelper()
     else:
         raise


### PR DESCRIPTION
Since Python 3.3 the ImportError message has been changed from
"No module named foo" to "No module named 'foo'" (note the quotes).
This broke the check for a missing import_helper module when running
a script generated by the dumpscript management command.