### PR TITLE
Add support for `extra_files` to runserver_plus

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -59,6 +59,8 @@ class Command(BaseCommand):
                     help="Print SQL queries as they're executed"),
         make_option('--cert', dest='cert_path', action="store", type="string",
                     help='To use SSL, specify certificate path.'),
+        make_option('--extra-files', dest='extra_files', action="store", type="string",
+                    help='auto-reload whenever the given file changes too'),
 
     )
     if USE_STATICFILES:
@@ -188,6 +190,7 @@ class Command(BaseCommand):
         quit_command = (sys.platform == 'win32') and 'CTRL-BREAK' or 'CONTROL-C'
         bind_url = "http://%s:%s/" % (
             self.addr if not self._raw_ipv6 else '[%s]' % self.addr, self.port)
+        extra_files = [options.get('extra_files')] if options.get('extra_files') else []
 
         def inner_run():
             print("Validating models...")
@@ -258,7 +261,8 @@ class Command(BaseCommand):
                 use_reloader=use_reloader,
                 use_debugger=True,
                 threaded=threaded,
-                ssl_context=ssl_context
+                ssl_context=ssl_context,
+                extra_files=extra_files
             )
         inner_run()
 


### PR DESCRIPTION
Werkzeug [provides](http://werkzeug.pocoo.org/docs/0.10/serving/) `extra_files` options to specify files whose changes, in addition to the default ones, should auto-reload the server. However, `runserver_plus` of `django_extensions` currently doesn't support this option.

This pull request adds support for the option.