### PR TITLE
Fixing shell_plus problem when auto-loading modules with empty `__module__` property.

### DIFF
--- a/django_extensions/management/shells.py
+++ b/django_extensions/management/shells.py
@@ -147,8 +147,10 @@ def import_objects(options, style):
             if "%s.%s" % (app_name, mod.__name__) in dont_load:
                 continue
 
-            load_models.setdefault(mod.__module__, [])
-            load_models[mod.__module__].append(mod.__name__)
+            if mod.__module__:
+                # Only add the module to the dict if `__module__` is not empty.
+                load_models.setdefault(mod.__module__, [])
+                load_models[mod.__module__].append(mod.__name__)
 
     if not quiet_load:
         print(style.SQL_TABLE("# Shell Plus Model Imports"))


### PR DESCRIPTION
Only add the a module to the `load_models` dict if `mod.__module__` is not empty. The `__module__` property can be empty for dynamically generated modules.