### PR TITLE
Add load commandclass test and compat file

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 def pytest_configure():
     import sys
-    import tempfile
 
     try:
         import django  # NOQA

--- a/django_extensions/compat.py
+++ b/django_extensions/compat.py
@@ -1,0 +1,16 @@
+import sys
+
+PY3 = sys.version_info[0] == 3
+OLD_PY2 = sys.version_info[:2] < (2, 7)
+
+if PY3:  # pragma: no cover
+    from io import StringIO  # NOQA
+    import importlib  # NOQA
+
+elif OLD_PY2:  # pragma: no cover
+    from cStringIO import StringIO  # NOQA
+    from django.utils import importlib  # NOQA
+
+else:  # pragma: no cover
+    from cStringIO import StringIO  # NOQA
+    import importlib  # NOQA

--- a/django_extensions/management/commands/compile_pyc.py
+++ b/django_extensions/management/commands/compile_pyc.py
@@ -1,11 +1,11 @@
-import os
 import fnmatch
+import os
 import py_compile
-from django.core.management.base import NoArgsCommand, CommandError
-from django.conf import settings
 from optparse import make_option
 from os.path import join as _j
 
+from django.conf import settings
+from django.core.management.base import CommandError, NoArgsCommand
 from django_extensions.management.utils import signalcommand
 
 

--- a/django_extensions/management/commands/create_template_tags.py
+++ b/django_extensions/management/commands/create_template_tags.py
@@ -1,8 +1,9 @@
 import os
 import sys
+from optparse import make_option
+
 from django.core.management.base import AppCommand
 from django_extensions.management.utils import _make_writeable, signalcommand
-from optparse import make_option
 
 
 class Command(AppCommand):

--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -1,12 +1,16 @@
 import logging
 from optparse import make_option
+from six.moves import configparser, input
 
 from django.conf import settings
-from django.core.management.base import CommandError, BaseCommand
-from django.db.backends.creation import TEST_DATABASE_PREFIX
-from six.moves import input, configparser
-
+from django.core.management.base import BaseCommand, CommandError
 from django_extensions.management.utils import signalcommand
+
+try:
+    from django.db.backends.base.creation import TEST_DATABASE_PREFIX
+except ImportError:
+    # Django < 1.7
+    from django.db.backends.creation import TEST_DATABASE_PREFIX
 
 
 class Command(BaseCommand):

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -1,6 +1,7 @@
-from importlib import import_module
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+
+from django_extensions.compat import importlib
 from django_extensions.management.utils import signalcommand
 
 try:
@@ -36,7 +37,7 @@ class Command(BaseCommand):
         if not set(key).issubset(set(VALID_KEY_CHARS)):
             raise CommandError("malformed session key")
 
-        engine = import_module(settings.SESSION_ENGINE)
+        engine = importlib.import_module(settings.SESSION_ENGINE)
 
         if not engine.SessionStore().exists(key):
             print("Session Key does not exist. Expired?")

--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -1,15 +1,11 @@
 import sys
 import traceback
 from optparse import make_option
-from django_extensions.management.email_notifications import EmailNotificationCommand
+
 from django.conf import settings
 
-try:
-    import importlib
-except ImportError:
-    print("Runscript needs the importlib module to work. You can install it via 'pip install importlib'")
-    sys.exit(1)
-
+from django_extensions.compat import importlib
+from django_extensions.management.email_notifications import EmailNotificationCommand
 from django_extensions.management.utils import signalcommand
 
 

--- a/django_extensions/management/commands/set_fake_emails.py
+++ b/django_extensions/management/commands/set_fake_emails.py
@@ -9,9 +9,9 @@ set_fake_emails.py
 from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand, CommandError
-
+from django.core.management.base import CommandError, NoArgsCommand
 from django_extensions.management.utils import signalcommand
+
 
 DEFAULT_FAKE_EMAIL = '%(username)s@example.com'
 

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -1,11 +1,9 @@
-import sys
 import socket
-
+import sys
 from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import CommandError, BaseCommand
-
+from django.core.management.base import BaseCommand, CommandError
 from django_extensions.management.utils import signalcommand
 
 

--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -275,9 +275,7 @@ class SQLDiff(object):
             kwargs['geography'] = True
 
         if '.' in reverse_type:
-            from django.utils import importlib
-            # TODO: when was importlib added to django.utils ? and do we
-            # need to add backwards compatibility code ?
+            from django_extensions.compat import importlib
             module_path, package_name = reverse_type.rsplit('.', 1)
             module = importlib.import_module(module_path)
             field_db_type = getattr(module, package_name)(**kwargs).db_type(connection=connection)

--- a/django_extensions/management/commands/sync_s3.py
+++ b/django_extensions/management/commands/sync_s3.py
@@ -62,17 +62,15 @@ from optparse import make_option
 import os
 import time
 import gzip
-try:
-    from cStringIO import StringIO
-    assert StringIO
-except ImportError:
-    from StringIO import StringIO
-
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from django_extensions.compat import StringIO
 from django_extensions.management.utils import signalcommand
+
+
+
 
 # Make sure boto is available
 try:

--- a/django_extensions/management/utils.py
+++ b/django_extensions/management/utils.py
@@ -4,14 +4,7 @@ import sys
 import logging
 from django_extensions.management.signals import pre_command, post_command
 
-try:
-    from importlib import import_module
-except ImportError:
-    try:
-        from django.utils.importlib import import_module
-    except ImportError:
-        def import_module(module):
-            return __import__(module, {}, {}, [''])
+from django_extensions.compat import importlib
 
 
 def get_project_root():
@@ -21,7 +14,7 @@ def get_project_root():
         module_str = settings.SETTINGS_MODULE
     else:
         module_str = django_settings_module.split(".")[0]
-    mod = import_module(module_str)
+    mod = importlib.import_module(module_str)
     return os.path.dirname(os.path.abspath(mod.__file__))
 
 

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
 import sys
 
-from django.core.management import call_command
+from django.core.management import (call_command,
+                                    find_commands,
+                                    load_command_class)
 from django.test import TestCase
 
 
@@ -15,7 +18,6 @@ try:
     import importlib  # NOQA
 except ImportError:
     from django.utils import importlib  # NOQA
-
 
 
 class MockLoggingHandler(logging.Handler):
@@ -107,3 +109,16 @@ class CommandSignalTests(TestCase):
         self.assertIn('args', CommandSignalTests.post)
         self.assertIn('kwargs', CommandSignalTests.post)
         self.assertIn('outcome', CommandSignalTests.post)
+
+
+class CommandClassTests(TestCase):
+    """Try to load every management commands to catch exceptions."""
+    def test_load_commands(self):
+        try:
+
+            management_dir = os.path.join('django_extensions', 'management')
+            commands = find_commands(management_dir)
+            for command in commands:
+                load_command_class('django_extensions', command)
+        except Exception as e:
+            self.fail("Can't load command class of {0}\n{1}".format(command, e))

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -8,16 +8,7 @@ from django.core.management import (call_command,
                                     load_command_class)
 from django.test import TestCase
 
-
-try:
-    from cStringIO import StringIO  # NOQA
-except ImportError:
-    from io import StringIO  # NOQA
-
-try:
-    import importlib  # NOQA
-except ImportError:
-    from django.utils import importlib  # NOQA
+from django_extensions.compat import importlib, StringIO
 
 
 class MockLoggingHandler(logging.Handler):
@@ -112,7 +103,7 @@ class CommandSignalTests(TestCase):
 
 
 class CommandClassTests(TestCase):
-    """Try to load every management commands to catch exceptions."""
+    """Try to load every management command to catch exceptions."""
     def test_load_commands(self):
         try:
 


### PR DESCRIPTION
I added a test to check if management command classes can be loaded in every environment.

To fix import errors revealed by this new test I added a `compat.py` file to gather compatibility code between python versions(and maybe also between django versions ). With this it could be simpler to remove unused compatibility code in the future.