### PR TITLE
Use isort to sort imports

### DIFF
--- a/django_extensions/admin/widgets.py
+++ b/django_extensions/admin/widgets.py
@@ -1,12 +1,11 @@
-import six
 import django
-
+import six
 from django import forms
 from django.contrib.admin.sites import site
+from django.contrib.admin.widgets import ForeignKeyRawIdWidget
+from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.text import Truncator
-from django.template.loader import render_to_string
-from django.contrib.admin.widgets import ForeignKeyRawIdWidget
 
 
 class ForeignKeySearchInput(ForeignKeyRawIdWidget):

--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -1,10 +1,11 @@
 import sys
+import warnings
+
 import six
-from django.db import models
-from django.core.exceptions import ImproperlyConfigured
 from django import forms
 from django.conf import settings
-import warnings
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
 
 try:
     from keyczar import keyczar

--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -10,11 +10,13 @@ more information.
      extra = json.JSONField()
 """
 from __future__ import absolute_import
-import six
+
 from decimal import Decimal
-from django.db import models
+
+import six
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
+from django.db import models
 
 try:
     # Django >= 1.7

--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -3,8 +3,10 @@ Django Extensions abstract base model classes.
 """
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from django_extensions.db.fields import (ModificationDateTimeField,
-                                         CreationDateTimeField, AutoSlugField)
+
+from django_extensions.db.fields import (
+    AutoSlugField, CreationDateTimeField, ModificationDateTimeField,
+)
 
 try:
     from django.utils.timezone import now as datetime_now

--- a/django_extensions/jobs/daily/cache_cleanup.py
+++ b/django_extensions/jobs/daily/cache_cleanup.py
@@ -5,8 +5,10 @@ Can be run as a cronjob to clean out old data from the database (only expired
 sessions at the moment).
 """
 
-import six
 from contextlib import contextmanager
+
+import six
+
 from django_extensions.management.jobs import DailyJob
 
 

--- a/django_extensions/management/base.py
+++ b/django_extensions/management/base.py
@@ -3,7 +3,6 @@ import sys
 from django.core.management.base import BaseCommand
 from django.utils.log import getLogger
 
-
 logger = getLogger('django.commands')
 
 

--- a/django_extensions/management/commands/admin_generator.py
+++ b/django_extensions/management/commands/admin_generator.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import optparse
 import re
 import sys
-import optparse
 
-from django.db.models.loading import get_models
-from django.db import models
-from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import models
+from django.db.models.loading import get_models
 
 from django_extensions.management.color import color_style
 from django_extensions.management.utils import signalcommand

--- a/django_extensions/management/commands/clean_pyc.py
+++ b/django_extensions/management/commands/clean_pyc.py
@@ -1,9 +1,10 @@
-import os
 import fnmatch
-from django.core.management.base import NoArgsCommand, CommandError
-from django.conf import settings
+import os
 from optparse import make_option
 from os.path import join as _j
+
+from django.conf import settings
+from django.core.management.base import CommandError, NoArgsCommand
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/compile_pyc.py
+++ b/django_extensions/management/commands/compile_pyc.py
@@ -6,6 +6,7 @@ from os.path import join as _j
 
 from django.conf import settings
 from django.core.management.base import CommandError, NoArgsCommand
+
 from django_extensions.management.utils import signalcommand
 
 

--- a/django_extensions/management/commands/create_app.py
+++ b/django_extensions/management/commands/create_app.py
@@ -1,16 +1,18 @@
 import os
 import re
 import sys
-import django_extensions
+from optparse import make_option
+
 from django import VERSION
 from django.conf import settings
-from django.db import connection
 from django.core.management.base import CommandError, LabelCommand
-from django.template import Template, Context
+from django.db import connection
+from django.template import Context, Template
+
+import django_extensions
+from django_extensions.management.utils import _make_writeable, signalcommand
 from django_extensions.settings import REPLACEMENTS
 from django_extensions.utils.dia2django import dia2django
-from django_extensions.management.utils import _make_writeable, signalcommand
-from optparse import make_option
 
 
 class Command(LabelCommand):

--- a/django_extensions/management/commands/create_command.py
+++ b/django_extensions/management/commands/create_command.py
@@ -1,8 +1,10 @@
 import os
 import sys
-from django.core.management.base import AppCommand
-from django_extensions.management.utils import _make_writeable, signalcommand
 from optparse import make_option
+
+from django.core.management.base import AppCommand
+
+from django_extensions.management.utils import _make_writeable, signalcommand
 
 
 class Command(AppCommand):

--- a/django_extensions/management/commands/create_jobs.py
+++ b/django_extensions/management/commands/create_jobs.py
@@ -1,6 +1,8 @@
 import os
 import sys
+
 from django.core.management.base import AppCommand
+
 from django_extensions.management.utils import _make_writeable, signalcommand
 
 

--- a/django_extensions/management/commands/create_template_tags.py
+++ b/django_extensions/management/commands/create_template_tags.py
@@ -3,6 +3,7 @@ import sys
 from optparse import make_option
 
 from django.core.management.base import AppCommand
+
 from django_extensions.management.utils import _make_writeable, signalcommand
 
 

--- a/django_extensions/management/commands/describe_form.py
+++ b/django_extensions/management/commands/describe_form.py
@@ -1,4 +1,5 @@
-from django.core.management.base import LabelCommand, CommandError
+from django.core.management.base import CommandError, LabelCommand
+
 from django_extensions.management.utils import signalcommand
 
 try:

--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -1,9 +1,10 @@
 import logging
 from optparse import make_option
-from six.moves import configparser, input
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from six.moves import configparser, input
+
 from django_extensions.management.utils import signalcommand
 
 try:

--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -29,25 +29,27 @@ Improvements:
 
 """
 
-import sys
 import datetime
-import six
+import sys
 from optparse import make_option
 
 import django
-from django.db.models import AutoField, BooleanField, FileField, ForeignKey, DateField, DateTimeField
-from django.core.exceptions import ObjectDoesNotExist
-from django.core.management.base import BaseCommand
-
+import six
 # conditional import, force_unicode was renamed in Django 1.5
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand
+from django.db.models import (
+    AutoField, BooleanField, DateField, DateTimeField, FileField, ForeignKey,
+)
+
+from django_extensions.management.utils import signalcommand
 
 try:
     from django.utils.encoding import smart_unicode, force_unicode  # NOQA
 except ImportError:
     from django.utils.encoding import smart_text as smart_unicode, force_text as force_unicode  # NOQA
 
-from django_extensions.management.utils import signalcommand
 
 
 def orm_item_locator(orm_obj):

--- a/django_extensions/management/commands/export_emails.py
+++ b/django_extensions/management/commands/export_emails.py
@@ -1,11 +1,12 @@
-from django.core.management.base import BaseCommand, CommandError
-from django_extensions.compat import get_user_model
-from django.contrib.auth.models import Group
+from csv import writer
 from optparse import make_option
 from sys import stdout
-from csv import writer
-import six
 
+import six
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand, CommandError
+
+from django_extensions.compat import get_user_model
 from django_extensions.management.utils import signalcommand
 
 FORMATS = [

--- a/django_extensions/management/commands/find_template.py
+++ b/django_extensions/management/commands/find_template.py
@@ -1,7 +1,7 @@
-from django.core.management.base import LabelCommand
-from django.template import loader
-from django.template import TemplateDoesNotExist
 import sys
+
+from django.core.management.base import LabelCommand
+from django.template import TemplateDoesNotExist, loader
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/generate_secret_key.py
+++ b/django_extensions/management/commands/generate_secret_key.py
@@ -1,4 +1,5 @@
 from random import choice
+
 from django.core.management.base import NoArgsCommand
 
 from django_extensions.management.utils import signalcommand

--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -1,11 +1,12 @@
-import six
 import sys
-from optparse import make_option, NO_DEFAULT
-from django.core.management.base import BaseCommand, CommandError
+from optparse import NO_DEFAULT, make_option
+
+import six
 from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
 from django_extensions.management.modelviz import generate_dot
 from django_extensions.management.utils import signalcommand
-
 
 try:
     import pygraphviz

--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -1,11 +1,12 @@
-from django_extensions.management.utils import setup_logger, signalcommand
-from django.core.management.base import BaseCommand, CommandError
+import asyncore
+import sys
+from logging import getLogger
 from optparse import make_option
 from smtpd import SMTPServer
-import sys
-import asyncore
-from logging import getLogger
 
+from django.core.management.base import BaseCommand, CommandError
+
+from django_extensions.management.utils import setup_logger, signalcommand
 
 logger = getLogger(__name__)
 

--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -1,8 +1,11 @@
 from __future__ import with_statement
-from django.core.management.base import BaseCommand
-from django.conf import settings
+
 import os
 import re
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
 from django_extensions.management.utils import signalcommand
 
 ANNOTATION_RE = re.compile("\{?#[\s]*?(TODO|FIXME|BUG|HACK|WARNING|NOTE|XXX)[\s:]?(.+)")

--- a/django_extensions/management/commands/passwd.py
+++ b/django_extensions/management/commands/passwd.py
@@ -1,7 +1,9 @@
-from django.core.management.base import BaseCommand, CommandError
-from django_extensions.management.utils import signalcommand
-from django_extensions.compat import get_user_model
 import getpass
+
+from django.core.management.base import BaseCommand, CommandError
+
+from django_extensions.compat import get_user_model
+from django_extensions.management.utils import signalcommand
 
 
 class Command(BaseCommand):

--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -1,14 +1,16 @@
-import os
-import pip
-import sys
 import json
-
+import os
+import sys
 from distutils.version import LooseVersion
-from django.core.management.base import NoArgsCommand
-from django_extensions.management.color import color_style
 from optparse import make_option
+
+import pip
+from django.core.management.base import NoArgsCommand
 from pip.req import parse_requirements
+
+from django_extensions.management.color import color_style
 from django_extensions.management.utils import signalcommand
+
 try:
     from urllib.parse import urlparse
     from urllib.error import HTTPError

--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -5,9 +5,11 @@ print_settings
 Django command similar to 'diffsettings' but shows all active Django settings.
 """
 
-from django.core.management.base import BaseCommand, CommandError
-from django.conf import settings
 from optparse import make_option
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
 from django_extensions.management.utils import signalcommand
 
 

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
-from django_extensions.compat import importlib
+from django_extensions.compat import get_user_model, importlib
 from django_extensions.management.utils import signalcommand
-from django_extensions.compat import get_user_model
 
 try:
     from django.contrib.sessions.backends.base import VALID_KEY_CHARS  # Django 1.5

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -5,8 +5,8 @@ import logging
 from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import CommandError, BaseCommand
-from six.moves import input, configparser
+from django.core.management.base import BaseCommand, CommandError
+from six.moves import configparser, input
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/runjob.py
+++ b/django_extensions/management/commands/runjob.py
@@ -1,5 +1,7 @@
-from django.core.management.base import LabelCommand
 from optparse import make_option
+
+from django.core.management.base import LabelCommand
+
 from django_extensions.management.jobs import get_job, print_jobs
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/runjobs.py
+++ b/django_extensions/management/commands/runjobs.py
@@ -1,5 +1,7 @@
-from django.core.management.base import LabelCommand
 from optparse import make_option
+
+from django.core.management.base import LabelCommand
+
 from django_extensions.management.jobs import get_jobs, print_jobs
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/runprofileserver.py
+++ b/django_extensions/management/commands/runprofileserver.py
@@ -9,11 +9,14 @@ Credits for kcachegrind support taken from lsprofcalltree.py go to:
  Johan Dahlin
 """
 
-from django.core.management.base import BaseCommand, CommandError
-from optparse import make_option
-from datetime import datetime
-from django.conf import settings
 import sys
+from datetime import datetime
+from optparse import make_option
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from django_extensions.management.utils import signalcommand
 
 try:
     from django.contrib.staticfiles.handlers import StaticFilesHandler
@@ -21,7 +24,6 @@ try:
 except ImportError as e:
     USE_STATICFILES = False
 
-from django_extensions.management.utils import signalcommand
 
 try:
     any

--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -5,7 +5,8 @@ from optparse import make_option
 from django.conf import settings
 
 from django_extensions.compat import importlib
-from django_extensions.management.email_notifications import EmailNotificationCommand
+from django_extensions.management.email_notifications import \
+    EmailNotificationCommand
 from django_extensions.management.utils import signalcommand
 
 

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -1,18 +1,19 @@
+import logging
 import os
 import re
+import socket
 import sys
 import time
-import socket
-import logging
-
 from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django_extensions.management.utils import setup_logger, RedirectHandler,\
-    signalcommand
-from django_extensions.management.technical_response import null_technical_500_response
 
+from django_extensions.management.technical_response import \
+    null_technical_500_response
+from django_extensions.management.utils import (
+    RedirectHandler, setup_logger, signalcommand,
+)
 
 try:
     if 'django.contrib.staticfiles' in settings.INSTALLED_APPS:

--- a/django_extensions/management/commands/set_default_site.py
+++ b/django_extensions/management/commands/set_default_site.py
@@ -4,7 +4,7 @@ set_default_site.py
 import socket
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import CommandError, NoArgsCommand
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/set_fake_emails.py
+++ b/django_extensions/management/commands/set_fake_emails.py
@@ -10,8 +10,8 @@ from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import CommandError, NoArgsCommand
-from django_extensions.management.utils import signalcommand
 
+from django_extensions.management.utils import signalcommand
 
 DEFAULT_FAKE_EMAIL = '%(username)s@example.com'
 

--- a/django_extensions/management/commands/set_fake_passwords.py
+++ b/django_extensions/management/commands/set_fake_passwords.py
@@ -9,7 +9,7 @@ set_fake_passwords.py
 from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import CommandError, NoArgsCommand
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -1,11 +1,11 @@
 import os
-import six
 import time
 import traceback
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand
+import six
 from django.conf import settings
+from django.core.management.base import NoArgsCommand
 
 from django_extensions.management.shells import import_objects
 from django_extensions.management.utils import signalcommand

--- a/django_extensions/management/commands/show_templatetags.py
+++ b/django_extensions/management/commands/show_templatetags.py
@@ -1,9 +1,10 @@
-import os
-import six
 import inspect
+import os
+
+import six
 from django.conf import settings
-from django.core.management.base import BaseCommand
 from django.core.management import color
+from django.core.management.base import BaseCommand
 from django.template.base import get_library
 from django.utils import termcolors
 

--- a/django_extensions/management/commands/show_urls.py
+++ b/django_extensions/management/commands/show_urls.py
@@ -1,17 +1,16 @@
-import re
 import functools
+import re
 from optparse import make_option
 
 from django.conf import settings
-from django.core.exceptions import ViewDoesNotExist
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
-from django.core.management.base import BaseCommand, CommandError
 from django.contrib.admindocs.views import simplify_regex
+from django.core.exceptions import ViewDoesNotExist
+from django.core.management.base import BaseCommand, CommandError
+from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.utils.translation import activate
 
 from django_extensions.management.color import color_style
 from django_extensions.management.utils import signalcommand
-
 
 FMTR = {
     'dense': "{url}\t{module}\t{url_name}\t{decorator}",

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -4,6 +4,7 @@ from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+
 from django_extensions.management.utils import signalcommand
 
 

--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -20,17 +20,16 @@ KNOWN ISSUES:
      positives or false negatives.
 """
 
-import six
 import sys
 from optparse import make_option
 
 import django
+import six
+from django.core.management import CommandError, sql as _sql
 from django.core.management.base import BaseCommand
-from django.core.management import sql as _sql
-from django.core.management import CommandError
 from django.core.management.color import no_style
-from django.db import transaction, connection
-from django.db.models.fields import IntegerField, AutoField
+from django.db import connection, transaction
+from django.db.models.fields import AutoField, IntegerField
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/sync_s3.py
+++ b/django_extensions/management/commands/sync_s3.py
@@ -57,20 +57,17 @@ TODO:
 """
 import datetime
 import email
+import gzip
 import mimetypes
-from optparse import make_option
 import os
 import time
-import gzip
+from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from django_extensions.compat import StringIO
 from django_extensions.management.utils import signalcommand
-
-
-
 
 # Make sure boto is available
 try:

--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -10,10 +10,10 @@ and anything extra will of been deleted.
 
 import os
 import sys
-import six
 from contextlib import contextmanager
 from functools import wraps
 
+import six
 from django.core.management.base import BaseCommand
 from django.core.management.color import no_style
 from django.db import connection, transaction

--- a/django_extensions/management/commands/unreferenced_files.py
+++ b/django_extensions/management/commands/unreferenced_files.py
@@ -1,5 +1,6 @@
-from collections import defaultdict
 import os
+from collections import defaultdict
+
 from django.conf import settings
 from django.core.management.base import NoArgsCommand
 from django.db import models

--- a/django_extensions/management/commands/update_permissions.py
+++ b/django_extensions/management/commands/update_permissions.py
@@ -1,5 +1,6 @@
+from django.contrib.auth.management import \
+    create_permissions as _create_permissions
 from django.core.management.base import BaseCommand
-from django.contrib.auth.management import create_permissions as _create_permissions
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/validate_templates.py
+++ b/django_extensions/management/commands/validate_templates.py
@@ -1,11 +1,14 @@
 import os
 from optparse import make_option
+
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management.color import color_style
 from django.template.base import add_to_builtins
 from django.template.loaders.filesystem import Loader
-from django_extensions.utils import validatingtemplatetags
+
 from django_extensions.management.utils import signalcommand
+from django_extensions.utils import validatingtemplatetags
+
 
 #
 # TODO: Render the template with fake request object ?

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -7,15 +7,18 @@ Based on:
   Adapted to be used with django-extensions
 """
 
-import os
-import six
 import datetime
-from django.utils.translation import activate as activate_language
-from django.utils.safestring import mark_safe
-from django.template import Context, loader, Template
+import os
+
+import six
 from django.db import models
 from django.db.models import get_models
-from django.db.models.fields.related import ForeignKey, OneToOneField, ManyToManyField, RelatedField
+from django.db.models.fields.related import (
+    ForeignKey, ManyToManyField, OneToOneField, RelatedField,
+)
+from django.template import Context, Template, loader
+from django.utils.safestring import mark_safe
+from django.utils.translation import activate as activate_language
 
 try:
     from django.db.models.fields.generic import GenericRelation

--- a/django_extensions/management/shells.py
+++ b/django_extensions/management/shells.py
@@ -1,6 +1,7 @@
-import six
 import traceback
+
 import django
+import six
 
 
 class ObjectImportError(Exception):

--- a/django_extensions/management/utils.py
+++ b/django_extensions/management/utils.py
@@ -1,10 +1,11 @@
-from django.conf import settings
+import logging
 import os
 import sys
-import logging
-from django_extensions.management.signals import pre_command, post_command
+
+from django.conf import settings
 
 from django_extensions.compat import importlib
+from django_extensions.management.signals import post_command, pre_command
 
 
 def get_project_root():

--- a/django_extensions/mongodb/fields/encrypted.py
+++ b/django_extensions/mongodb/fields/encrypted.py
@@ -1,10 +1,10 @@
 """
 Encrypted fields from Django Extensions, modified for use with mongoDB
 """
-from mongoengine.base import BaseField
-from django.core.exceptions import ImproperlyConfigured
 from django import forms
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from mongoengine.base import BaseField
 
 try:
     from keyczar import keyczar

--- a/django_extensions/mongodb/fields/json.py
+++ b/django_extensions/mongodb/fields/json.py
@@ -10,9 +10,10 @@ more information.
      extra = json.JSONField()
 """
 
-import six
 import datetime
 from decimal import Decimal
+
+import six
 from django.conf import settings
 from django.utils import simplejson
 from mongoengine.fields import StringField

--- a/django_extensions/mongodb/models.py
+++ b/django_extensions/mongodb/models.py
@@ -2,11 +2,15 @@
 Django Extensions abstract base mongoengine Document classes.
 """
 import datetime
-from mongoengine.document import Document
-from mongoengine.fields import StringField, IntField, DateTimeField
-from mongoengine.queryset import QuerySetManager
+
 from django.utils.translation import ugettext_lazy as _
-from django_extensions.mongodb.fields import ModificationDateTimeField, CreationDateTimeField, AutoSlugField
+from mongoengine.document import Document
+from mongoengine.fields import DateTimeField, IntField, StringField
+from mongoengine.queryset import QuerySetManager
+
+from django_extensions.mongodb.fields import (
+    AutoSlugField, CreationDateTimeField, ModificationDateTimeField,
+)
 
 
 class TimeStampedModel(Document):

--- a/django_extensions/settings.py
+++ b/django_extensions/settings.py
@@ -1,4 +1,5 @@
 import os
+
 from django.conf import settings
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/django_extensions/templatetags/highlighting.py
+++ b/django_extensions/templatetags/highlighting.py
@@ -30,9 +30,12 @@ Example:
 """
 
 from django import template
-from django.template import Template, Context, Node, Variable, TemplateSyntaxError
+from django.template import (
+    Context, Node, Template, TemplateSyntaxError, Variable,
+)
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
+
 try:
     from pygments import highlight as pyghighlight
     from pygments.lexers import get_lexer_by_name

--- a/django_extensions/templatetags/widont.py
+++ b/django_extensions/templatetags/widont.py
@@ -1,5 +1,7 @@
 import re
+
 from django.template import Library
+
 try:
     from django.utils.encoding import force_text
 except ImportError:

--- a/django_extensions/utils/dia2django.py
+++ b/django_extensions/utils/dia2django.py
@@ -9,12 +9,13 @@
 #  Python 2.4.4 (#2, Jul 17 2007, 11:56:54)
 #  [GCC 4.1.3 20070629 (prerelease) (Debian 4.1.2-13)] on linux2
 
-import re
-import six
-import sys
-import gzip
 import codecs
+import gzip
+import re
+import sys
 from xml.dom.minidom import *  # NOQA
+
+import six
 
 dependclasses = ["User", "Group", "Permission", "Message"]
 

--- a/django_extensions/utils/text.py
+++ b/django_extensions/utils/text.py
@@ -1,5 +1,4 @@
 import six
-
 from django.utils.functional import allow_lazy
 
 # conditional import, force_unicode was renamed in Django 1.5

--- a/django_extensions/utils/validatingtemplatetags.py
+++ b/django_extensions/utils/validatingtemplatetags.py
@@ -1,6 +1,7 @@
-from django.template.base import Library, Node
 from django.template import defaulttags
+from django.template.base import Library, Node
 from django.templatetags import future
+
 register = Library()
 
 error_on_old_style_url_tag = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,11 @@ ignore=E123,E128,E265,E501,E731,W601
 [pytest]
 addopts=--cov django_extensions
 norecursedirs=venv* .tox .eggs build dist django_extensions.egg-info
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_third_party = django
+known_first_party = django_extensions
+multi_line_output = 5

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ Based entirely on Django's own ``setup.py``.
 """
 import os
 import sys
-from distutils.command.install_data import install_data
 from distutils.command.install import INSTALL_SCHEMES
+from distutils.command.install_data import install_data
+
 try:
     from setuptools import setup
 except ImportError:

--- a/tests/test_autoslug_fields.py
+++ b/tests/test_autoslug_fields.py
@@ -1,12 +1,11 @@
-import pytest
-
 import django
+import pytest
 from django.db import models
 from django.test import TestCase
+
 from django_extensions.db.fields import AutoSlugField
 
 from .testapp.models import ChildSluggedTestModel, SluggedTestModel
-
 
 if django.VERSION >= (1, 7):
     from django.db import migrations  # NOQA

--- a/tests/test_clean_pyc.py
+++ b/tests/test_clean_pyc.py
@@ -1,10 +1,11 @@
 import fnmatch
 import os
 import shutil
-import six
 
+import six
 from django.core.management import call_command
 from django.test import TestCase
+
 from django_extensions.management.utils import get_project_root
 
 

--- a/tests/test_compile_pyc.py
+++ b/tests/test_compile_pyc.py
@@ -1,9 +1,10 @@
 import fnmatch
 import os
-import six
 
+import six
 from django.core.management import call_command
 from django.test import TestCase
+
 from django_extensions.management.utils import get_project_root
 
 

--- a/tests/test_dumpscript.py
+++ b/tests/test_dumpscript.py
@@ -1,7 +1,7 @@
 import ast
-import six
 import sys
 
+import six
 from django.core.management import call_command
 from django.test import TestCase
 

--- a/tests/test_encrypted_fields.py
+++ b/tests/test_encrypted_fields.py
@@ -1,15 +1,13 @@
 import tempfile
 from contextlib import contextmanager
 
-import pytest
-
 import django
+import pytest
 from django.conf import settings
 from django.db import connection, models
 from django.test import TestCase
 
 from .testapp.models import Secret
-
 
 # Only perform encrypted fields tests if keyczar is present. Resolves
 # http://github.com/django-extensions/django-extensions/issues/#issue/17

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -3,12 +3,12 @@ import logging
 import os
 import sys
 
-from django.core.management import (call_command,
-                                    find_commands,
-                                    load_command_class)
+from django.core.management import (
+    call_command, find_commands, load_command_class,
+)
 from django.test import TestCase
 
-from django_extensions.compat import importlib, StringIO
+from django_extensions.compat import StringIO, importlib
 
 
 class MockLoggingHandler(logging.Handler):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from django_extensions.db.models import ActivatorModel
 
 from .testapp.models import Post

--- a/tests/test_shortuuid_field.py
+++ b/tests/test_shortuuid_field.py
@@ -1,12 +1,9 @@
 import six
-
 from django.test import TestCase
 
 from .testapp.models import (
-    ShortUUIDTestAgregateModel,
-    ShortUUIDTestManyToManyModel,
-    ShortUUIDTestModel_field,
-    ShortUUIDTestModel_pk,
+    ShortUUIDTestAgregateModel, ShortUUIDTestManyToManyModel,
+    ShortUUIDTestModel_field, ShortUUIDTestModel_pk,
 )
 
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,6 +1,6 @@
 import six
-
 from django.test import TestCase
+
 from django_extensions.templatetags.widont import widont, widont_html
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import six
-
 from django.test import TestCase
+
 from django_extensions.utils.text import truncate_letters
 
 

--- a/tests/test_uuid_field.py
+++ b/tests/test_uuid_field.py
@@ -1,14 +1,13 @@
 import re
-import six
 import uuid
 
+import six
 from django.test import TestCase
+
 from django_extensions.db.fields import PostgreSQLUUIDField
 
 from .testapp.models import (
-    UUIDTestAgregateModel,
-    UUIDTestManyToManyModel,
-    UUIDTestModel_field,
+    UUIDTestAgregateModel, UUIDTestManyToManyModel, UUIDTestModel_field,
     UUIDTestModel_pk,
 )
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,10 +1,10 @@
 from django.db import models
 
-from django_extensions.db.models import ActivatorModel
-from django_extensions.db.fields import AutoSlugField
-from django_extensions.db.fields import UUIDField
-from django_extensions.db.fields import ShortUUIDField
+from django_extensions.db.fields import (
+    AutoSlugField, ShortUUIDField, UUIDField,
+)
 from django_extensions.db.fields.json import JSONField
+from django_extensions.db.models import ActivatorModel
 
 
 class Secret(models.Model):


### PR DESCRIPTION
The settings are stored in the setup.cfg file, and are inspired from
django package which recently did it in this
[commit](https://github.com/django/django/commit/0ed7d155635da9f79d4dd67e4889087d3673c6da
)

There are much more options possible, however I think it's better to
stay near django approach as this package is made for django.