### PR TITLE
use kernelspec to pass IPython kernel args

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -121,11 +121,21 @@ class Command(NoArgsCommand):
                 except ImportError:
                     return traceback.format_exc()
 
+            def install_kernel_spec(app, ipython_arguments):
+                """install an IPython >= 3.0 kernelspec that loads django extensions"""
+                ksm = app.kernel_spec_manager
+                ks = ksm.get_kernel_spec('python')
+                ks.argv.extend(ipython_arguments)
+                ks.display_name = 'Django Admin'
+                kernel_dir = os.path.join(ksm.user_kernel_dir, 'django')
+                if not os.path.exists(kernel_dir):
+                    os.makedirs(kernel_dir)
+                with open(os.path.join(kernel_dir, 'kernel.json'), 'w') as f:
+                    f.write(ks.to_json())
+
             def run_notebook():
                 app = NotebookApp.instance()
                 ipython_arguments = getattr(settings, 'IPYTHON_ARGUMENTS', ['--ext', 'django_extensions.management.notebook_extension'])
-                if no_browser and '--no-browser' not in ipython_arguments:
-                    ipython_arguments.append('--no-browser')
                 if 'django_extensions.management.notebook_extension' not in ipython_arguments:
                     print(self.style.ERROR("""WARNING:
 IPython Notebook Extension 'django_extensions.management.notebook_extension' not
@@ -135,7 +145,23 @@ Django and will not automatically load your models.
 Please read the documentation carefully:
   http://django-extensions.readthedocs.org/en/latest/shell_plus.html#configuration
 """))
-                app.initialize(ipython_arguments)
+                notebook_arguments = getattr(settings, 'NOTEBOOK_ARGUMENTS', [])
+                if no_browser and '--no-browser' not in notebook_arguments:
+                    notebook_arguments.append('--no-browser')
+                if '--notebook-dir' not in notebook_arguments:
+                    notebook_arguments.extend(['--notebook-dir', '.'])
+
+                # IPython < 3 passes through kernel args from notebook CLI
+                from IPython import release
+                if release.version_info[0] < 3:
+                    notebook_arguments.extend(ipython_arguments)
+
+                app.initialize(notebook_arguments)
+                
+                # IPython >= 3 uses kernelspecs to specify kernel CLI args
+                if release.version_info[0] >= 3:
+                    install_kernel_spec(app, ipython_arguments)
+
                 app.start()
             return run_notebook
 


### PR DESCRIPTION
in IPython >= 3

This is not necessarily a proposal for merge, but an illustration for discussion of one of the possibilities in #631

- kernelspec is always created as 'django', so multiple django apps will all write the same file. Alternately, a kernelspec could be created in a distinct location for each django app.
- separates notebook and IPython args
- specifies `--notebook-dir` explicitly, in case a user has a default notebook path in config
- behavior should be unchanged for IPython < 3