### PR TITLE
Add TitleDescriptionModel

### DIFF
--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -30,14 +30,23 @@ class TimeStampedModel(models.Model):
         abstract = True
 
 
-class TitleSlugDescriptionModel(models.Model):
+class TitleDescriptionModel(models.Model):
+    """ TitleDescriptionModel
+    An abstract base class model that provides title and description fields.
+    """
+    title = models.CharField(_('title'), max_length=255)
+    description = models.TextField(_('description'), blank=True, null=True)
+
+    class Meta:
+        abstract = True
+
+
+class TitleSlugDescriptionModel(TitleDescriptionModel):
     """ TitleSlugDescriptionModel
     An abstract base class model that provides title and description fields
     and a self-managed "slug" field that populates from the title.
     """
-    title = models.CharField(_('title'), max_length=255)
     slug = AutoSlugField(_('slug'), populate_from='title')
-    description = models.TextField(_('description'), blank=True, null=True)
 
     class Meta:
         abstract = True

--- a/docs/model_extensions.rst
+++ b/docs/model_extensions.rst
@@ -9,3 +9,8 @@ Current Database Model Extensions
 
 * *TimeStampedModel* - TimeStampedModel An abstract base class model that
   provides self-managed "created" and "modified" fields.
+* *TitleDescriptionModel* - An abstract base class model that provides
+  "title" and "description" fields.
+* *TitleSlugDescriptionModel* - An abstract base class model that provides
+  "title" and "description" fields and a self-managed "slug" field
+  that populates from the title.


### PR DESCRIPTION
- It is useful to have `title`, `description` fields without slug field. Separate out `title` and `description` to separate model. 
- Add documentation about `TitleDescriptionModel` and `TitleSlugDescriptionModel`.