### PR TITLE
Doc `NOTEBOOK_ARGUMENTS` in `shell_plus`.

### DIFF
--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -70,6 +70,24 @@ uses a web browser as its user interface, as an alternative shell::
 
     $ ./manage.py shell_plus --notebook
 
+There are two settings that you can use to pass your custom options to the IPython
+Notebook in your Django settings.
+
+The first one is ``NOTEBOOK_ARGUMENTS`` that can be used to hold those options that available via::
+
+    $ ipython notebook -h
+
+For example::
+
+    NOTEBOOK_ARGUMENTS = [
+        '--ip=x.x.x.x',
+        '--port=xx',
+    ]
+
+Another one is ``IPYTHON_ARGUMENTS`` that for those options that available via::
+
+    $ ipython -h
+
 The Django settings module and database models are auto-loaded into the
 interactive shell's global namespace also for IPython Notebook.
 


### PR DESCRIPTION
It's 'unfair' that the `NOTEBOOK_ARGUMENTS` did not get mentioned in the docs.

For IPython >= 3.0, the args in `IPYTHON_ARGUMENTS` will not be extended to args in `NOTEBOOK_ARGUMENTS`, so it's better to tell users that the `NOTEBOOK_ARGUMENTS` can be used to hold these options that available via:

    $ ipython notebook -h