### PR TITLE
Django 1.7+ deprecation fixes

### DIFF
--- a/django_extensions/management/commands/clean_pyc.py
+++ b/django_extensions/management/commands/clean_pyc.py
@@ -19,7 +19,7 @@ class Command(NoArgsCommand):
     )
     help = "Removes all python bytecode compiled files from the project."
 
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle_noargs(self, **options):

--- a/django_extensions/management/commands/compile_pyc.py
+++ b/django_extensions/management/commands/compile_pyc.py
@@ -17,7 +17,7 @@ class Command(NoArgsCommand):
     )
     help = "Compile python bytecode files for the project."
 
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle_noargs(self, **options):

--- a/django_extensions/management/commands/create_app.py
+++ b/django_extensions/management/commands/create_app.py
@@ -31,7 +31,7 @@ class Command(LabelCommand):
     args = "APP_NAME"
     label = 'application name'
 
-    requires_model_validation = False
+    requires_system_checks = False
     can_import_settings = True
 
     @signalcommand

--- a/django_extensions/management/commands/create_command.py
+++ b/django_extensions/management/commands/create_command.py
@@ -20,7 +20,7 @@ class Command(AppCommand):
     args = "[appname]"
     label = 'application name'
 
-    requires_model_validation = False
+    requires_system_checks = False
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/create_jobs.py
+++ b/django_extensions/management/commands/create_jobs.py
@@ -11,7 +11,7 @@ class Command(AppCommand):
     args = "[appname]"
     label = 'application name'
 
-    requires_model_validation = False
+    requires_system_checks = False
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/create_template_tags.py
+++ b/django_extensions/management/commands/create_template_tags.py
@@ -18,7 +18,7 @@ class Command(AppCommand):
     args = "[appname]"
     label = 'application name'
 
-    requires_model_validation = False
+    requires_system_checks = False
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/generate_secret_key.py
+++ b/django_extensions/management/commands/generate_secret_key.py
@@ -8,7 +8,7 @@ from django_extensions.management.utils import signalcommand
 class Command(NoArgsCommand):
     help = "Generates a new SECRET_KEY that can be used in a project settings file."
 
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle_noargs(self, **options):

--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
     help = "Starts a test mail server for development."
     args = '[optional port number or ippaddr:port]'
 
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle(self, addrport='', *args, **options):

--- a/django_extensions/management/commands/passwd.py
+++ b/django_extensions/management/commands/passwd.py
@@ -9,7 +9,7 @@ from django_extensions.management.utils import signalcommand
 class Command(BaseCommand):
     help = "Clone of the UNIX program ``passwd'', for django.contrib.auth."
 
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle(self, *args, **options):

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
     args = '[optional port number, or ipaddr:port]'
 
     # Validation is called explicitly each time the server is reloaded.
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle(self, addrport='', *args, **options):

--- a/django_extensions/management/commands/set_fake_emails.py
+++ b/django_extensions/management/commands/set_fake_emails.py
@@ -34,7 +34,7 @@ class Command(NoArgsCommand):
                     help='Exclude users matching this group. (use comma seperation for multiple groups)'),
     )
     help = '''DEBUG only: give all users a new email based on their account data ("%s" by default). Possible parameters are: username, first_name, last_name''' % (DEFAULT_FAKE_EMAIL, )
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle_noargs(self, **options):

--- a/django_extensions/management/commands/set_fake_passwords.py
+++ b/django_extensions/management/commands/set_fake_passwords.py
@@ -24,7 +24,7 @@ class Command(NoArgsCommand):
                     help='Use this as default password.'),
     )
     help = 'DEBUG only: sets all user passwords to a common value ("%s" by default)' % (DEFAULT_FAKE_PASSWORD, )
-    requires_model_validation = False
+    requires_system_checks = False
 
     @signalcommand
     def handle_noargs(self, **options):

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -23,7 +23,7 @@ The envisioned use case is something like this:
     ./manage.py sqlcreate [--router=<routername>] | mysql -u <db_administrator> -p
     ./manage.py sqlcreate [--router=<routername>] | psql -U <db_administrator> -W"""
 
-    requires_model_validation = False
+    requires_system_checks = False
     can_import_settings = True
 
     @signalcommand

--- a/django_extensions/management/commands/sqldsn.py
+++ b/django_extensions/management/commands/sqldsn.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
 
     ./manage.py sqldsn [--router=<routername>] [--style=pgpass]"""
 
-    requires_model_validation = False
+    requires_system_checks = False
     can_import_settings = True
 
     def handle(self, *args, **options):

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 	dj15: Django>=1.5,<1.6
 	dj16: Django>=1.6,<1.7
 	dj17: Django>=1.7,<1.8
-	dj18: https://www.djangoproject.com/download/1.8b1/tarball/
+	dj18: Django>=1.8,<1.9
 	djmaster: https://github.com/django/django/zipball/master
 	shortuuid==0.4
 	python-dateutil


### PR DESCRIPTION
This PR adds fixes for Django 1.7+ replacing all occurrences of the [deprecated meta parameter](https://docs.djangoproject.com/en/dev/releases/1.7/#django-core-management-basecommand) `requires_model_validation` with the new `requires_system_checks`. This removes warning when running associated commands in Django 1.7+.

Note for an unknown reason, these fixes were [marked as done in the changelog](https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md#144) but the attributes were still used.

*Also, travis CI now uses Django 1.8 stable code for the tests.*