### PR TITLE
update module_name to model_name

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -5,6 +5,7 @@ import six
 import operator
 from six.moves import reduce
 
+import django
 from django.http import HttpResponse, HttpResponseNotFound
 from django.conf import settings
 from django.db import models
@@ -60,7 +61,12 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
                 return self.admin_site.admin_view(view)(*args, **kwargs)
             return update_wrapper(wrapper, view)
 
-        info = self.model._meta.app_label, self.model._meta.model_name
+        # model._meta.module_name is deprecated in django version 1.7 and removed in django version 1.8.
+        # It is replaced by model._meta.model_name
+        if django.VERSION < (1, 7):
+            info = self.model._meta.app_label, self.model._meta.module_name
+        else:
+            info = self.model._meta.app_label, self.model._meta.model_name
 
         urlpatterns = patterns('', url(r'foreignkey_autocomplete/$', wrap(self.foreignkey_autocomplete), name='%s_%s_autocomplete' % info))
         urlpatterns += super(ForeignKeyAutocompleteAdmin, self).get_urls()

--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -60,7 +60,7 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
                 return self.admin_site.admin_view(view)(*args, **kwargs)
             return update_wrapper(wrapper, view)
 
-        info = self.model._meta.app_label, self.model._meta.module_name
+        info = self.model._meta.app_label, self.model._meta.model_name
 
         urlpatterns = patterns('', url(r'foreignkey_autocomplete/$', wrap(self.foreignkey_autocomplete), name='%s_%s_autocomplete' % info))
         urlpatterns += super(ForeignKeyAutocompleteAdmin, self).get_urls()


### PR DESCRIPTION
in Django 1.8, the alias module_name was removed, the correct usage is model_name. See: https://docs.djangoproject.com/en/1.8/releases/1.8/#features-removed-in-1-8
