### PR TITLE
Force the result of filter into a list

### DIFF
--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
     @signalcommand
     def handle(self, *args, **options):
         # don't add django internal code
-        apps = filter(lambda app: not app.startswith('django.contrib'), settings.INSTALLED_APPS)
+        apps = [app for app in filter(lambda app: not app.startswith('django.contrib'), settings.INSTALLED_APPS)]
         template_dirs = getattr(settings, 'TEMPLATE_DIRS', [])
         if template_dirs:
             apps += template_dirs


### PR DESCRIPTION
Otherwise, this fails in python 3.4 on line 26 (`apps += template_dirs`) with:

    TypeError: unsupported operand type(s) for +=: 'filter' and 'list'