### PR TITLE
Update sync data: Move dict outside loop to analyze all fixtures files before remove

### DIFF
--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -103,6 +103,7 @@ class Command(BaseCommand):
         object_count = 0
         objects_per_fixture = []
         models = set()
+        objects_to_keep = {}
 
         humanize = lambda dirname: dirname and "'%s'" % dirname or 'absolute path'
 
@@ -160,7 +161,6 @@ class Command(BaseCommand):
                             if verbosity > 0:
                                 print("Installing %s fixture '%s' from %s." % (format, fixture_name, humanize(fixture_dir)))
                             try:
-                                objects_to_keep = {}
                                 objects = serializers.deserialize(format, fixture)
                                 for obj in objects:
                                     object_count += 1
@@ -173,9 +173,6 @@ class Command(BaseCommand):
 
                                     models.add(class_)
                                     obj.save()
-
-                                if options.get('remove'):
-                                    self.remove_objects_not_in(objects_to_keep, verbosity)
 
                                 label_found = True
                             except (SystemExit, KeyboardInterrupt):
@@ -193,6 +190,9 @@ class Command(BaseCommand):
                     except:
                         if verbosity > 1:
                             print("No %s fixture '%s' in %s." % (format, fixture_name, humanize(fixture_dir)))
+
+        if options.get('remove'):
+            self.remove_objects_not_in(objects_to_keep, verbosity)
 
         # If any of the fixtures we loaded contain 0 objects, assume that an
         # error was encountered during fixture loading.


### PR DESCRIPTION
When you have fixtures related with the same model split in more than one fixture file is a problem sync them with syncdata because the command create and delete objects on every file iteration, so at the end of the execution you will have the last provided file well sync, but the previous data deleted.

My suggestion to fix the issue is move objects_to_keep dict definition out of the for loop and acum all the objects to keep for all the files on each iteration. Then after the end of the loop try to remove residual objects, based on all the accumulated objects.
