### PR TITLE
get rid of RemovedInDjango19Warning in 'runjobs'

### DIFF
--- a/django_extensions/management/commands/runjobs.py
+++ b/django_extensions/management/commands/runjobs.py
@@ -48,7 +48,7 @@ class Command(LabelCommand):
             except ImportError:
                 pass
 
-        for app in [a.models_module for a in apps.get_app_configs()]:
+        for app in [a.models_module for a in apps.get_app_configs() if a.models_module is not None]:
             if verbosity > 1:
                 app_name = '.'.join(app.__name__.rsplit('.')[:-1])
                 print("Sending %s job signal for: %s" % (when, app_name))

--- a/django_extensions/management/commands/runjobs.py
+++ b/django_extensions/management/commands/runjobs.py
@@ -38,7 +38,7 @@ class Command(LabelCommand):
         """ Run jobs from the signals """
         # Thanks for Ian Holsman for the idea and code
         from django_extensions.management import signals
-        from django.db import models
+        from django.apps import apps
         from django.conf import settings
 
         verbosity = int(options.get('verbosity', 1))
@@ -48,7 +48,7 @@ class Command(LabelCommand):
             except ImportError:
                 pass
 
-        for app in models.get_apps():
+        for app in [a.models_module for a in apps.get_app_configs()]:
             if verbosity > 1:
                 app_name = '.'.join(app.__name__.rsplit('.')[:-1])
                 print("Sending %s job signal for: %s" % (when, app_name))


### PR DESCRIPTION
Previously, `python manage.py runjobs` gave three RemovedInDjango19Warning errors:

```
[...]/py3env/lib/python3.4/site-packages/django_extensions/management/commands/runjobs.py:51: RemovedInDjango19Warning: django.db.models.get_apps is deprecated.
  for app in models.get_apps():

[...]/py3env/lib/python3.4/importlib/_bootstrap.py:321: RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.
  return f(*args, **kwds)

[...]/py3env/lib/python3.4/site-packages/django/db/models/__init__.py:56: RemovedInDjango19Warning: [a.models_module for a in get_app_configs()] supersedes get_apps().
  return getattr(loading, function_name)(*args, **kwargs)
```