### PR TITLE
Random char field followup

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -214,7 +214,7 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
 class RandomCharField(UniqueFieldMixin, CharField):
     """ RandomCharField
 
-    By default, sets editable=False, blank=True.
+    By default, sets editable=False, blank=True, db_index=False.
 
     Required arguments:
 
@@ -222,6 +222,9 @@ class RandomCharField(UniqueFieldMixin, CharField):
         Specifies the length of the field
 
     Optional arguments:
+
+    db_index
+        If set to True, duplicate entries are not allowed (default: False)
 
     lowercase
         If set to True, lowercase the alpha characters (default: False)
@@ -253,9 +256,9 @@ class RandomCharField(UniqueFieldMixin, CharField):
         self.include_punctuation = kwargs.pop('include_punctuation', False)
         self.check_is_bool('include_punctuation')
 
-        # Set db_index=True unless it's been set manually.
+        # Set db_index=False unless it's been set manually.
         if 'db_index' not in kwargs:
-            kwargs['db_index'] = True
+            kwargs['db_index'] = False
 
         super(RandomCharField, self).__init__(*args, **kwargs)
 
@@ -282,10 +285,14 @@ class RandomCharField(UniqueFieldMixin, CharField):
         if self.include_punctuation:
             population += string.punctuation
 
+        random_chars = self.random_char_generator(population)
+        if not self.db_index:
+            return random_chars
+
         return super(RandomCharField, self).find_unique(
             model_instance,
             model_instance._meta.get_field(self.attname),
-            self.random_char_generator(population),
+            random_chars,
         )
 
     def internal_type(self):

--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -1,7 +1,6 @@
 """
 Django Extensions additional model fields
 """
-import random
 import re
 import six
 import string
@@ -20,8 +19,9 @@ except ImportError:
     HAS_SHORT_UUID = False
 
 from django.core.exceptions import ImproperlyConfigured
-from django.template.defaultfilters import slugify
 from django.db.models import DateTimeField, CharField, SlugField
+from django.utils.crypto import get_random_string
+from django.template.defaultfilters import slugify
 
 try:
     from django.utils.timezone import now as datetime_now
@@ -37,7 +37,6 @@ except ImportError:
 
 
 MAX_UNIQUE_QUERY_ATTEMPTS = 100
-random_sample = random.SystemRandom().sample
 
 
 class UniqueFieldMixin(object):
@@ -264,7 +263,7 @@ class RandomCharField(UniqueFieldMixin, CharField):
 
     def random_char_generator(self, chars):
         for i in range(100):
-            yield ''.join(random_sample(chars, self.length))
+            yield ''.join(get_random_string(self.length, chars))
         raise RuntimeError('max random character attempts exceeded (%s)' %
             MAX_UNIQUE_QUERY_ATTEMPTS)
 

--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -17,7 +17,7 @@ Current Database Model Field Extensions
   a length of 8 thats yields 3.4 million possible combinations. A 12
   character field would yield about 2 billion. Below are some examples::
 
-    >>> RandomCharField(length=8)
+    >>> RandomCharField(length=8, db_index=True)
     BVm9GEaE
 
     >>> RandomCharField(length=4, include_alpha=False)

--- a/tests/test_randomchar_field.py
+++ b/tests/test_randomchar_field.py
@@ -68,7 +68,7 @@ class RandomCharFieldTest(TestCase):
         assert m.random_char_field == 'aaa'
 
     def testRandomCharTestModelAsserts(self):
-        with mock.patch('django_extensions.db.fields.random_sample') as mock_sample:
+        with mock.patch('django_extensions.db.fields.get_random_string') as mock_sample:
             mock_sample.return_value = 'aaa'
             m = RandomCharTestModel()
             m.save()

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -129,7 +129,7 @@ class ShortUUIDTestManyToManyModel(ShortUUIDTestModel_pk):
 
 
 class RandomCharTestModel(models.Model):
-    random_char_field = RandomCharField(length=8)
+    random_char_field = RandomCharField(length=8, db_index=True)
 
     class Meta:
         app_label = 'django_extensions'


### PR DESCRIPTION
This is some follow from the first pull request. db_index is now set to false. This is a saner default as short fields have a greater chance of the exhausting the available permutations . It has also been updated to use Django's get_random_string method. Just let me know if you have any questions. 

Thanks!,
  Derrick