### PR TITLE
Allow customizing IPython by passing command line argument

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -227,7 +227,8 @@ class Command(NoArgsCommand):
 
                 def run_ipython():
                     imported_objects = import_objects(options, self.style)
-                    start_ipython(argv=[], user_ns=imported_objects)
+                    ipython_arguments = getattr(settings, 'IPYTHON_ARGUMENTS', [])
+                    start_ipython(argv=ipython_arguments, user_ns=imported_objects)
                 return run_ipython
             except ImportError:
                 str_exc = traceback.format_exc()


### PR DESCRIPTION
Allow customizing IPython by passing command line argument using Django setting: IPYTHON_ARGUMENTS

Fixes django-extensions/django-extensions#685