### PR TITLE
Random char field followup part deux

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -213,7 +213,7 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
 class RandomCharField(UniqueFieldMixin, CharField):
     """ RandomCharField
 
-    By default, sets editable=False, blank=True, db_index=False.
+    By default, sets editable=False, blank=True, unique=False.
 
     Required arguments:
 
@@ -222,7 +222,7 @@ class RandomCharField(UniqueFieldMixin, CharField):
 
     Optional arguments:
 
-    db_index
+    unqiue
         If set to True, duplicate entries are not allowed (default: False)
 
     lowercase
@@ -262,9 +262,9 @@ class RandomCharField(UniqueFieldMixin, CharField):
         self.include_punctuation = kwargs.pop('include_punctuation', False)
         self.check_is_bool('include_punctuation')
 
-        # Set db_index=False unless it's been set manually.
-        if 'db_index' not in kwargs:
-            kwargs['db_index'] = False
+        # Set unique=False unless it's been set manually.
+        if 'unique' not in kwargs:
+            kwargs['unique'] = False
 
         super(RandomCharField, self).__init__(*args, **kwargs)
 
@@ -294,7 +294,7 @@ class RandomCharField(UniqueFieldMixin, CharField):
             population += string.punctuation
 
         random_chars = self.random_char_generator(population)
-        if not self.db_index:
+        if not self.unique:
             return random_chars
 
         return super(RandomCharField, self).find_unique(
@@ -318,6 +318,7 @@ class RandomCharField(UniqueFieldMixin, CharField):
             'include_aphla': repr(self.include_alpha),
             'include_punctuation': repr(self.include_punctuation),
             'length': repr(self.length),
+            'unique': repr(self.unique),
         })
         del kwargs['max_length']
         # That's our definition!
@@ -337,6 +338,8 @@ class RandomCharField(UniqueFieldMixin, CharField):
             kwargs['include_digits'] = self.include_digits
         if self.include_punctuation is True:
             kwargs['include_punctuation'] = self.include_punctuation
+        if self.unique is True:
+            kwargs['unique'] = self.unique
         return name, path, args, kwargs
 
 

--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -17,7 +17,7 @@ Current Database Model Field Extensions
   a length of 8 thats yields 3.4 million possible combinations. A 12
   character field would yield about 2 billion. Below are some examples::
 
-    >>> RandomCharField(length=8, db_index=True)
+    >>> RandomCharField(length=8, unique=True)
     BVm9GEaE
 
     >>> RandomCharField(length=4, include_alpha=False)

--- a/tests/test_randomchar_field.py
+++ b/tests/test_randomchar_field.py
@@ -7,11 +7,13 @@ from django.test import TestCase
 
 from .testapp.models import (
     RandomCharTestModel,
-    RandomCharTestModelLower,
+    RandomCharTestModelLowercase,
+    RandomCharTestModelUppercase,
     RandomCharTestModelAlpha,
     RandomCharTestModelDigits,
     RandomCharTestModelPunctuation,
-    RandomCharTestModelLowerAlphaDigits,
+    RandomCharTestModelLowercaseAlphaDigits,
+    RandomCharTestModelUppercaseAlphaDigits,
 )
 
 if django.VERSION >= (1, 7):
@@ -28,11 +30,17 @@ class RandomCharFieldTest(TestCase):
         m.save()
         assert len(m.random_char_field) == 8, m.random_char_field
 
-    def testRandomCharFieldLower(self):
-        m = RandomCharTestModelLower()
+    def testRandomCharFieldLowercase(self):
+        m = RandomCharTestModelLowercase()
         m.save()
         for c in m.random_char_field:
             assert c.islower(), m.random_char_field
+
+    def testRandomCharFieldUppercase(self):
+        m = RandomCharTestModelUppercase()
+        m.save()
+        for c in m.random_char_field:
+            assert c.isupper(), m.random_char_field
 
     def testRandomCharFieldAlpha(self):
         m = RandomCharTestModelAlpha()
@@ -52,11 +60,17 @@ class RandomCharFieldTest(TestCase):
         for c in m.random_char_field:
             assert c in string.punctuation, m.random_char_field
 
-    def testRandomCharTestModelLowerAlphaDigits(self):
-        m = RandomCharTestModelLowerAlphaDigits()
+    def testRandomCharTestModelLowercaseAlphaDigits(self):
+        m = RandomCharTestModelLowercaseAlphaDigits()
         m.save()
         for c in m.random_char_field:
             assert c.isdigit() or (c.isalpha() and c.islower()), m.random_char_field
+
+    def testRandomCharTestModelUppercaseAlphaDigits(self):
+        m = RandomCharTestModelUppercaseAlphaDigits()
+        m.save()
+        for c in m.random_char_field:
+            assert c.isdigit() or (c.isalpha() and c.isupper()), m.random_char_field
 
     def testRandomCharTestModelDuplicate(self):
         m = RandomCharTestModel()

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -129,14 +129,14 @@ class ShortUUIDTestManyToManyModel(ShortUUIDTestModel_pk):
 
 
 class RandomCharTestModel(models.Model):
-    random_char_field = RandomCharField(length=8, db_index=True)
+    random_char_field = RandomCharField(length=8, unique=True)
 
     class Meta:
         app_label = 'django_extensions'
 
 
 class RandomCharTestModelAlphaDigits(models.Model):
-    random_char_field = RandomCharField(length=8, db_index=True)
+    random_char_field = RandomCharField(length=8, unique=True)
 
     class Meta:
         app_label = 'django_extensions'

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -135,16 +135,38 @@ class RandomCharTestModel(models.Model):
         app_label = 'django_extensions'
 
 
-class RandomCharTestModelLowerAlphaDigits(models.Model):
-    random_char_field = RandomCharField(length=8, lowercase=True, include_alpha=True)
+class RandomCharTestModelAlphaDigits(models.Model):
+    random_char_field = RandomCharField(length=8, db_index=True)
 
     class Meta:
         app_label = 'django_extensions'
-        verbose_name = 'lower alpha digits'
 
 
-class RandomCharTestModelLower(models.Model):
+class RandomCharTestModelLowercaseAlphaDigits(models.Model):
+    random_char_field = RandomCharField(length=8, lowercase=True)
+
+    class Meta:
+        app_label = 'django_extensions'
+        verbose_name = 'lowercase alpha digits'
+
+
+class RandomCharTestModelUppercaseAlphaDigits(models.Model):
+    random_char_field = RandomCharField(length=8, uppercase=True)
+
+    class Meta:
+        app_label = 'django_extensions'
+        verbose_name = 'uppercase alpha digits'
+
+
+class RandomCharTestModelLowercase(models.Model):
     random_char_field = RandomCharField(length=8, lowercase=True, include_digits=False)
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
+class RandomCharTestModelUppercase(models.Model):
+    random_char_field = RandomCharField(length=8, uppercase=True, include_digits=False)
 
     class Meta:
         app_label = 'django_extensions'


### PR DESCRIPTION
Hey Trbs,

I meant to do what you suggested and use unique instead of db_index. I also noticed if lowercase is set to false only uppercase characters are used now. I do not think that was the best way to have a uppercase only option as now there is no option for mixed case which should be the default as having uppercase only as the default reduces the possible character population by 26 characters a significant amount. I think what is best to have a uppercase option. So I added support for that. @dudanogueira does that sound right?