### PR TITLE
Using django-admin instead of manage.py for ipython notebook overwrites PYTHONPATH from environment

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import traceback
+from collections import OrderedDict
 from optparse import make_option
 
 import six
@@ -129,18 +130,22 @@ class Command(NoArgsCommand):
                 ks.argv.extend(ipython_arguments)
                 ks.display_name = display_name
 
-                manage_py_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+                manage_py_dir, manage_py = os.path.split(os.path.realpath(sys.argv[0]))
 
-                if os.path.isdir(manage_py_dir) and manage_py_dir != os.getcwd():
-                    pythonpath = ks.env.get("PYTHONPATH", "").split(":")
-                    pythonpath.append(manage_py_dir)
-                    ks.env["PYTHONPATH"] = ":".join(pythonpath)
+                if manage_py == 'manage.py' and os.path.isdir(manage_py_dir) and manage_py_dir != os.getcwd():
+                    pythonpath = os.environ.get('PYTHONPATH') or ks.env.get('PYTHONPATH') or ''
+                    pythonpath = pythonpath.split(':')
+                    if manage_py_dir not in pythonpath:
+                        pythonpath.append(manage_py_dir)
+
+                    ks.env['PYTHONPATH'] = ':'.join(filter(None, pythonpath))
 
                 kernel_dir = os.path.join(ksm.user_kernel_dir, 'django_extensions')
                 if not os.path.exists(kernel_dir):
                     os.makedirs(kernel_dir)
                 with open(os.path.join(kernel_dir, 'kernel.json'), 'w') as f:
                     f.write(ks.to_json())
+
 
             def run_notebook():
                 app = NotebookApp.instance()

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -132,7 +132,7 @@ class Command(NoArgsCommand):
                 manage_py_dir, manage_py = os.path.split(os.path.realpath(sys.argv[0]))
 
                 if manage_py == 'manage.py' and os.path.isdir(manage_py_dir) and manage_py_dir != os.getcwd():
-                    pythonpath = os.environ.get('PYTHONPATH') or ks.env.get('PYTHONPATH') or ''
+                    pythonpath = ks.env.get('PYTHONPATH', os.environ.get('PYTHONPATH', ''))
                     pythonpath = pythonpath.split(':')
                     if manage_py_dir not in pythonpath:
                         pythonpath.append(manage_py_dir)

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -2,7 +2,6 @@ import os
 import sys
 import time
 import traceback
-from collections import OrderedDict
 from optparse import make_option
 
 import six
@@ -145,7 +144,6 @@ class Command(NoArgsCommand):
                     os.makedirs(kernel_dir)
                 with open(os.path.join(kernel_dir, 'kernel.json'), 'w') as f:
                     f.write(ks.to_json())
-
 
             def run_notebook():
                 app = NotebookApp.instance()


### PR DESCRIPTION
PYTHONPATH set in environmental variable should not be discarded by `shell_plus` management command.

How to reproduce the bug:

    $ export PYTHONPATH="/www/django-project/"
    $ django-admin shell_plus --notebook

In this case `/www/django-project/` does not end up on sys.path. Instead the folder that contains `django-admin` binary will be added. 