### PR TITLE
app_name undefined fix.

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -296,7 +296,7 @@ class Command(NoArgsCommand):
             supported_backends = ['django.db.backends.postgresql_psycopg2']
             opt_name = 'fallback_application_name'
             default_app_name = 'django_shell'
-
+            app_name = default_app_name
             dbs = getattr(settings, 'DATABASES', [])
 
             # lookup over all the databases entry


### PR DESCRIPTION
Prevent app_name not defined error for non postgres backends