### PR TITLE
Added ability to filter autocomplete query

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -113,6 +113,10 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
                     other_qs = other_qs.filter(reduce(operator.or_, or_queries))
                     queryset = queryset & other_qs
 
+                additional_filter = self.get_related_filter(model, request)
+                if additional_filter:
+                    queryset = queryset.filter(additional_filter)
+
                 if self.autocomplete_limit:
                     queryset = queryset[:self.autocomplete_limit]
 
@@ -126,6 +130,12 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
                     data = to_string_function(obj)
             return HttpResponse(data)
         return HttpResponseNotFound()
+
+    def get_related_filter(self, model, request):
+        """Given a model class and current request return an optional Q object
+        that should be applied as an additional filter for autocomplete query.
+        If no additional filtering is needed, this method should return
+        None."""
 
     def get_help_text(self, field_name, model_name):
         searchable_fields = self.related_search_fields.get(field_name, None)

--- a/docs/admin_extensions.rst
+++ b/docs/admin_extensions.rst
@@ -51,3 +51,22 @@ If you are using django-reversion you should follow this code example:
         ...
 
     admin.site.register(MyVersionModel, MyVersionModelAdmin)
+
+If you need to limit the autocomplete search, you can override the
+``get_related_filter`` method of the admin. For example if you want to allow
+non-superusers to attach attachments only to articles they own you can use::
+
+    class AttachmentAdmin(ForeignKeyAutocompleteAdmin):
+
+        ...
+
+        def get_related_filter(self, model, request):
+            user = request.user
+            if not issubclass(model, Article) or user.is_superuser():
+                return super(AttachmentAdmin, self).get_related_filter(
+                    model, request
+                )
+            return Q(owner=user)
+
+Note that this does not protect your application from malicious attempts to
+circumvent it (e.g. sending fabricated requests via cURL).


### PR DESCRIPTION
It might be handy for the developer who creates an admin form to add some arbitrary additional filtering for the autocomplete field. An obvious use case would be to limit the list of linkable objects according to some per-row permission rule. This PR contains a simple method that allows to add arbitrary filter depending on the model and request.