### PR TITLE
reset_db fail in django master/1.9

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -4,6 +4,7 @@ originally from http://www.djangosnippets.org/snippets/828/ by dnordberg
 import logging
 from optparse import make_option
 
+import django
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from six.moves import configparser, input
@@ -125,9 +126,9 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             connection.query(create_query)
 
         elif engine in ('postgresql', 'postgresql_psycopg2', 'postgis'):
-            if engine == 'postgresql':
+            if engine == 'postgresql' and django.VERSION < (1, 9):
                 import psycopg as Database  # NOQA
-            elif engine in ('postgresql_psycopg2', 'postgis'):
+            elif engine in ('postgresql', 'postgresql_psycopg2', 'postgis'):
                 import psycopg2 as Database  # NOQA
 
             conn_string = "dbname=template1"


### PR DESCRIPTION
from django 1.9/master [documentation](https://docs.djangoproject.com/en/dev/ref/settings/#databases)
> Changed in Django Development version:
> The django.db.backends.postgresql backend is named django.db.backends.postgresql_psycopg2 in older releases. For backwards compatibility, the old name still works in newer versions

This will make reset_db failed:
```
You have requested a database reset.
This will IRREVERSIBLY DESTROY
ALL data in the database "django19".
Are you sure you want to do this?

Type 'yes' to continue, or 'no' to cancel: yes
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/ayik/Repositories/django/django/django/core/management/__init__.py", line 331, in execute_from_command_line
    utility.execute()
  File "/Users/ayik/Repositories/django/django/django/core/management/__init__.py", line 323, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/ayik/Repositories/django/django/django/core/management/base.py", line 353, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/ayik/Repositories/django/django/django/core/management/base.py", line 404, in execute
    output = self.handle(*args, **options)
  File "/Users/ayik/.virtualenvs/sakawuni/lib/python2.7/site-packages/django_extensions/management/utils.py", line 71, in inner
    ret = func(self, *args, **kwargs)
  File "/Users/ayik/.virtualenvs/sakawuni/lib/python2.7/site-packages/django_extensions/management/commands/reset_db.py", line 129, in handle
    import psycopg as Database  # NOQA
ImportError: No module named psycopg
```
 