### PR TITLE
'OPTIONS' is not always in the db config dict

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -329,7 +329,7 @@ class Command(NoArgsCommand):
                     if opt_name in options.keys():
                         app_name = dbs[db]['OPTIONS'][opt_name]
                     else:
-                        dbs[db]['OPTIONS'].update({opt_name: default_app_name})
+                        dbs[db].setdefault('OPTIONS', {}).update({opt_name: default_app_name})
                         app_name = default_app_name
 
             return app_name


### PR DESCRIPTION
I encountered this when using a db router.