### PR TITLE
add globbing to extra files

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -240,7 +240,7 @@ class Command(BaseCommand):
             self.addr if not self._raw_ipv6 else '[%s]' % self.addr, self.port)
         # glob `--extra-file` input
         extra_files = list(set(
-            itertools. chain.from_iterable(glob.glob(nested_file)
+            itertools.chain.from_iterable(glob.glob(nested_file)
             for nested_file in options.get('extra_files', None) or [])
         ))
         reloader_interval = options.get('reloader_interval', 1)

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -1,4 +1,6 @@
 import logging
+import glob
+import itertools
 import os
 import re
 import socket
@@ -236,7 +238,11 @@ class Command(BaseCommand):
         quit_command = (sys.platform == 'win32') and 'CTRL-BREAK' or 'CONTROL-C'
         bind_url = "http://%s:%s/" % (
             self.addr if not self._raw_ipv6 else '[%s]' % self.addr, self.port)
-        extra_files = options.get('extra_files', None) or []
+        # glob `--extra-file` input
+        extra_files = list(set(
+            itertools. chain.from_iterable(glob.glob(nested_file)
+            for nested_file in options.get('extra_files', None) or [])
+        ))
         reloader_interval = options.get('reloader_interval', 1)
 
         def inner_run():


### PR DESCRIPTION
# Example usage:

**Before:**

``` sh
$ django-admin runserver_plus --extra-file=app/templates/base.html --extra-file=app/templates/user_form.html
```

**After:**

``` sh
$ django-admin runserver_plus --extra-file=app/templates/*.html
```

or

``` sh
$ django-admin runserver_plus --extra-file=app/templates/*.html --extra-file=app/templates/layouts/*.html
```

or even

``` sh
$ django-admin runserver_plus --extra-file=app/templates/{*/,}*.html
```

ps.  Why am I watching HTML? crispy-forms.  There is a use case for this feature.
