### PR TITLE
Fix handling of unicode verbose_names (fixes #737)

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -9,7 +9,8 @@ Based on:
 
 import datetime
 import os
-import sys
+
+from django.utils import encoding
 
 import six
 from django.db import models
@@ -54,19 +55,6 @@ def parse_file_or_list(arg):
     if ',' not in arg and os.path.isfile(arg):
         return [e.strip() for e in open(arg).readlines()]
     return [e.strip() for e in arg.split(',')]
-
-
-def get_decoded_string(s):
-    if sys.version < '3':
-        if isinstance(s, str):
-            return s.decode("utf-8")
-        else:
-            return s
-    else:
-        if isinstance(s, str):
-            return s
-        else:
-            return s.decode("utf-8")
 
 
 def generate_dot(app_labels, **kwargs):
@@ -152,14 +140,14 @@ def generate_dot(app_labels, **kwargs):
                 continue
 
             if verbose_names and appmodel._meta.verbose_name:
-                model['label'] = get_decoded_string(appmodel._meta.verbose_name)
+                model['label'] = encoding.force_bytes(appmodel._meta.verbose_name)
             else:
                 model['label'] = model['name']
 
             # model attributes
             def add_attributes(field):
                 if verbose_names and field.verbose_name:
-                    label = get_decoded_string(field.verbose_name)
+                    label = encoding.force_bytes(field.verbose_name)
 
                     if label.islower():
                         label = label.capitalize()

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -65,7 +65,7 @@ def get_decoded_string(s):
     else:
         if isinstance(s, str):
             return s
-        else: # bytes
+        else:
             return s.decode("utf-8")
 
 

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -9,6 +9,7 @@ Based on:
 
 import datetime
 import os
+import sys
 
 import six
 from django.db import models
@@ -53,6 +54,19 @@ def parse_file_or_list(arg):
     if ',' not in arg and os.path.isfile(arg):
         return [e.strip() for e in open(arg).readlines()]
     return [e.strip() for e in arg.split(',')]
+
+
+def get_decoded_string(s):
+    if sys.version < '3':
+        if isinstance(s, str):
+            return s.decode("utf-8")
+        elif isinstance(s, unicode):
+            return s
+    else:
+        if isinstance(s, str):
+            return s
+        else: # bytes
+            return s.decode("utf-8")
 
 
 def generate_dot(app_labels, **kwargs):
@@ -138,14 +152,15 @@ def generate_dot(app_labels, **kwargs):
                 continue
 
             if verbose_names and appmodel._meta.verbose_name:
-                model['label'] = appmodel._meta.verbose_name.decode("utf8")
+                model['label'] = get_decoded_string(appmodel._meta.verbose_name)
             else:
                 model['label'] = model['name']
 
             # model attributes
             def add_attributes(field):
                 if verbose_names and field.verbose_name:
-                    label = field.verbose_name.decode("utf8")
+                    label = get_decoded_string(field.verbose_name)
+
                     if label.islower():
                         label = label.capitalize()
                 else:

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -60,7 +60,7 @@ def get_decoded_string(s):
     if sys.version < '3':
         if isinstance(s, str):
             return s.decode("utf-8")
-        elif isinstance(s, unicode):
+        else:
             return s
     else:
         if isinstance(s, str):


### PR DESCRIPTION
Uses a function to handle string encoding/decoding depending on running Python's version. 

Fixes #737 