### PR TITLE
Add value format for print_settings

### DIFF
--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -50,6 +50,8 @@ class Command(BaseCommand):
         elif output_format == 'pprint':
             from pprint import pprint
             pprint(a_dict)
+        elif output_format == 'value':
+            print(a_dict.values()[0])
         else:
             self.print_simple(a_dict)
 

--- a/docs/print_settings.rst
+++ b/docs/print_settings.rst
@@ -26,6 +26,7 @@ The simplest way to run it is with no arguments::
 
 Some variations::
 
+    $ python manage.py print_settings --format=value
     $ python manage.py print_settings --format=json
     $ python manage.py print_settings --format=yaml    # Requires PyYAML
 


### PR DESCRIPTION
This allow to bridge django and bash scripts. Just call print_settings
with the wanted settings and get back the value.