### PR TITLE
Delegate the creation of conn_string to psycopg2

### DIFF
--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -125,17 +125,17 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             elif engine in ('postgresql_psycopg2', 'postgis'):
                 import psycopg2 as Database  # NOQA
 
-            conn_string = "dbname=template1"
+            conn_params = {'database': 'template1'}
             if user:
-                conn_string += " user=%s" % user
+                conn_params['user'] = user
             if password:
-                conn_string += " password='%s'" % password
+                conn_params['password'] = password
             if database_host:
-                conn_string += " host=%s" % database_host
+                conn_params['host'] = database_host
             if database_port:
-                conn_string += " port=%s" % database_port
+                conn_params['port'] = database_port
 
-            connection = Database.connect(conn_string)
+            connection = Database.connect(**conn_params)
             connection.set_isolation_level(0)  # autocommit false
             cursor = connection.cursor()
             drop_query = "DROP DATABASE IF EXISTS \"%s\";" % database_name

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -131,17 +131,17 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             elif engine in ('postgresql', 'postgresql_psycopg2', 'postgis'):
                 import psycopg2 as Database  # NOQA
 
-            conn_string = "dbname=template1"
+            conn_params = {'database': 'template1'}
             if user:
-                conn_string += " user=%s" % user
+                conn_params['user'] = user
             if password:
-                conn_string += " password='%s'" % password
+                conn_params['password'] = password
             if database_host:
-                conn_string += " host=%s" % database_host
+                conn_params['host'] = database_host
             if database_port:
-                conn_string += " port=%s" % database_port
+                conn_params['port'] = database_port
 
-            connection = Database.connect(conn_string)
+            connection = Database.connect(**conn_params)
             connection.set_isolation_level(0)  # autocommit false
             cursor = connection.cursor()
             drop_query = "DROP DATABASE \"%s\";" % database_name


### PR DESCRIPTION
Hello. 
I have a strange password for the postgresql database user: "2\\\\".
This password is not escaped in reset_db and drop_test_database command, that raise:
```
OperationalError: unterminated quoted string in connection info string
```