### PR TITLE
Fixed reset_db in Django 1.8 and 1.9+ (fixes #699)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ venv*
 *.bak
 .DS_Store
 .eggs/
+.idea/
 .coverage
 

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -157,10 +157,14 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
                 create_query += " WITH OWNER = \"%s\" " % owner
             create_query += " ENCODING = 'UTF8'"
 
-            if engine == 'postgis':
-                # fetch postgis template name if it exists
-                from django.contrib.gis.db.backends.postgis.creation import PostGISCreation
-                postgis_template = PostGISCreation(connection).template_postgis
+            if engine == 'postgis' and django.VERSION < (1, 9):
+                # For PostGIS 1.5, fetch template name if it exists
+                if django.VERSION < (1, 8):
+                    from django.contrib.gis.db.backends.postgis.creation import PostGISCreation
+                    postgis_template = PostGISCreation(connection).template_postgis
+                else:
+                    from django.contrib.gis.db.backends.postgis.base import DatabaseWrapper
+                    postgis_template = DatabaseWrapper(dbinfo).template_postgis
                 if postgis_template is not None:
                     create_query += ' TEMPLATE = %s' % postgis_template
 


### PR DESCRIPTION
# Purpose
This PR is a fix for Issue #699
**'reset_db' fails with PostGIS: 'PostGISCreation' object has no attribute 'template_postgis'**

# Background
When using Django with PostGIS 1.5, the common practice was to create a spatial database template that could be reused (see [Django docs](https://docs.djangoproject.com/en/1.8/ref/contrib/gis/install/postgis/#post-installation)).  PostGIS 2.0 includes an extension for Postgres 9.1+, so the database template is no longer necessary.  Django 1.8 and below still support PostGIS 1.5, but Django 1.9 and above do not.

In Django 1.8, the `template_postgis` property was moved from `django.contrib.gis.db.backends.postgis.creation.PostGISCreation` to `django.contrib.gis.db.backends.postgis.base.DatabaseWrapper`.
See: https://github.com/django/django/commit/bac7664f274be834a09e037331889959f04a75e7

In Django 1.9, the property was then removed altogether when support for PostGIS 1.5 was dropped.
See: https://github.com/django/django/commit/26996e2d55719deb0a0b85c642c88658c929106c

# Changes
This PR checks the Django version before doing any work to look for a template name.  If it's 1.9+, we don't bother.  If it's 1.8, we create a `DatabaseWrapper` and get the template name from it.  Otherwise, we use the old behavior: create a `PostGISCreation` object and get the template name from it.

# See Also
PR #754 does a subset of this work, but is incomplete (it leaves `reset_db` broken in Django 1.8 when PostGIS 1.5 is used).