### PR TITLE
Fix tests for Django master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 	dj16: Django>=1.6,<1.7
 	dj17: Django>=1.7,<1.8
 	dj18: Django>=1.8,<1.9
-	djmaster: https://github.com/django/django/zipball/master
+	djmaster: https://github.com/django/django/archive/master.tar.gz
 	shortuuid==0.4
 	python-dateutil
 	pytest-django==2.8.0


### PR DESCRIPTION
There is a bug in pip that results in an unicode error. This is a workaround.

https://github.com/django/django/commit/bd059e3f8c6311dcaf8afe5e29ef373f7f84cf26#commitcomment-9896566