### PR TITLE
making management command template pep8 compliant

### DIFF
--- a/django_extensions/conf/command_template/management/commands/sample.py.tmpl
+++ b/django_extensions/conf/command_template/management/commands/sample.py.tmpl
@@ -1,5 +1,6 @@
 from django.core.management.base import {{ base_command }}
 
+
 class Command({{ base_command }}):
     help = "My shiny new management command."
 


### PR DESCRIPTION
> E302 expected 2 blank lines, found 1
> (Surround top-level function and class definitions with two blank lines.)

> W292 no newline at end of file

I know it's not a big fix, but it's something :D it was really bugging me