### PR TITLE
Fixed: ForeignKey admin called deprecated method

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -9,6 +9,7 @@ import django
 from django.http import HttpResponse, HttpResponseNotFound
 from django.conf import settings
 from django.db import models
+from django.apps import apps
 from django.db.models.query import QuerySet
 from django.utils.encoding import smart_str
 from django.utils.translation import ugettext as _
@@ -102,7 +103,7 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
                     return "%s__search" % field_name[1:]
                 else:
                     return "%s__icontains" % field_name
-            model = models.get_model(app_label, model_name)
+            model = apps.get_model(app_label, model_name)
             queryset = model._default_manager.all()
             data = ''
             if query:

--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -9,12 +9,20 @@ import django
 from django.http import HttpResponse, HttpResponseNotFound
 from django.conf import settings
 from django.db import models
-from django.apps import apps
 from django.db.models.query import QuerySet
 from django.utils.encoding import smart_str
 from django.utils.translation import ugettext as _
 from django.utils.text import get_text_list
 from django.contrib.admin import ModelAdmin
+
+get_model_compat = None
+
+try:
+    from django.apps import apps
+    get_model_compat = apps.get_model
+except ImportError:
+    # less than Django 1.7 the 'get_model' method is on the models module.
+    get_model_compat = models.get_model
 
 try:
     from functools import update_wrapper
@@ -103,7 +111,10 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
                     return "%s__search" % field_name[1:]
                 else:
                     return "%s__icontains" % field_name
-            model = apps.get_model(app_label, model_name)
+
+            # As of Django 1.7 the 'get_model' method was moved to 'apps'
+            model = get_model_compat(app_label, model_name)
+
             queryset = model._default_manager.all()
             data = ''
             if query:


### PR DESCRIPTION
When using the ForeignKeyAutocompleteAdmin field, the search-as-you-type functionality was calling a method, `models.get_model` that was removed in Django 1.9.

This commit fixes this by importing the django 'apps' model and replacing it with `apps.get_model`.