### PR TITLE
Return the first random string if RandomCharField is not unique (#752).

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -295,7 +295,9 @@ class RandomCharField(UniqueFieldMixin, CharField):
 
         random_chars = self.random_char_generator(population)
         if not self.unique:
-            return random_chars
+            new = six.next(random_chars)
+            setattr(model_instance, self.attname, new)
+            return new
 
         return super(RandomCharField, self).find_unique(
             model_instance,


### PR DESCRIPTION
`random_chars` is a generator so we need to take the first value from it if we
do not care about uniqueness.