### PR TITLE
Add separate tests for non-unique RandomCharField.

### DIFF
--- a/tests/test_randomchar_field.py
+++ b/tests/test_randomchar_field.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 
 from .testapp.models import (
     RandomCharTestModel,
+    RandomCharTestModelUnique,
     RandomCharTestModelLowercase,
     RandomCharTestModelUppercase,
     RandomCharTestModelAlpha,
@@ -27,6 +28,11 @@ class RandomCharFieldTest(TestCase):
 
     def testRandomCharField(self):
         m = RandomCharTestModel()
+        m.save()
+        assert len(m.random_char_field) == 8, m.random_char_field
+
+    def testRandomCharFieldUnique(self):
+        m = RandomCharTestModelUnique()
         m.save()
         assert len(m.random_char_field) == 8, m.random_char_field
 
@@ -73,20 +79,20 @@ class RandomCharFieldTest(TestCase):
             assert c.isdigit() or (c.isalpha() and c.isupper()), m.random_char_field
 
     def testRandomCharTestModelDuplicate(self):
-        m = RandomCharTestModel()
+        m = RandomCharTestModelUnique()
         m.save()
         with mock.patch('django_extensions.db.fields.RandomCharField.random_char_generator') as func:
             func.return_value = iter([m.random_char_field, 'aaa'])
-            m = RandomCharTestModel()
+            m = RandomCharTestModelUnique()
             m.save()
         assert m.random_char_field == 'aaa'
 
     def testRandomCharTestModelAsserts(self):
         with mock.patch('django_extensions.db.fields.get_random_string') as mock_sample:
             mock_sample.return_value = 'aaa'
-            m = RandomCharTestModel()
+            m = RandomCharTestModelUnique()
             m.save()
 
-            m = RandomCharTestModel()
+            m = RandomCharTestModelUnique()
             with pytest.raises(RuntimeError):
                 m.save()

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -129,6 +129,13 @@ class ShortUUIDTestManyToManyModel(ShortUUIDTestModel_pk):
 
 
 class RandomCharTestModel(models.Model):
+    random_char_field = RandomCharField(length=8, unique=False)
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
+class RandomCharTestModelUnique(models.Model):
     random_char_field = RandomCharField(length=8, unique=True)
 
     class Meta:


### PR DESCRIPTION
This adds a test for #792 which covers a RandomCharField with `unique=False`.