### PR TITLE
Fix compatibility with Django 1.10+

### DIFF
--- a/django_extensions/compat.py
+++ b/django_extensions/compat.py
@@ -4,6 +4,7 @@ import sys
 import django
 from django.conf import settings
 from django.core.management.base import CommandError
+from django.db import models
 
 # flake8: noqa
 
@@ -194,3 +195,9 @@ def add_to_builtins_compat(name):
     else:
         from django.template import engines
         engines['django'].engine.builtins.append(name)
+
+
+if django.VERSION >= (1, 10):
+    SubfieldBase = type
+else:
+    SubfieldBase = models.SubfieldBase

--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 
+from django_extensions.compat import SubfieldBase
+
 try:
     from keyczar import keyczar
 except ImportError:
@@ -108,8 +110,7 @@ class BaseEncryptedField(models.Field):
         return name, path, args, kwargs
 
 
-class EncryptedTextField(six.with_metaclass(models.SubfieldBase,
-                                            BaseEncryptedField)):
+class EncryptedTextField(six.with_metaclass(SubfieldBase, BaseEncryptedField)):
     def get_internal_type(self):
         return 'TextField'
 
@@ -128,8 +129,7 @@ class EncryptedTextField(six.with_metaclass(models.SubfieldBase,
         return (field_class, args, kwargs)
 
 
-class EncryptedCharField(six.with_metaclass(models.SubfieldBase,
-                                            BaseEncryptedField)):
+class EncryptedCharField(six.with_metaclass(SubfieldBase, BaseEncryptedField)):
     def __init__(self, *args, **kwargs):
         super(EncryptedCharField, self).__init__(*args, **kwargs)
 

--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -18,6 +18,8 @@ from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
+from django_extensions.compat import SubfieldBase
+
 try:
     # Django >= 1.7
     import json
@@ -64,7 +66,7 @@ class JSONList(list):
         return dumps(self)
 
 
-class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
+class JSONField(six.with_metaclass(SubfieldBase, models.TextField)):
     """JSONField is a generic textfield that neatly serializes/unserializes
     JSON objects seamlessly.  Main thingy must be a dict object."""
 


### PR DESCRIPTION
`SubfieldBase` is deprecated since Django 1.10