### PR TITLE
Fix serialisation of float values in JSONFields.

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -12,8 +12,6 @@ more information.
 """
 from __future__ import absolute_import
 
-from decimal import Decimal
-
 import six
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
@@ -34,7 +32,6 @@ def dumps(value):
 def loads(txt):
     value = json.loads(
         txt,
-        parse_float=Decimal,
         encoding=settings.DEFAULT_CHARSET
     )
     return value

--- a/tests/test_json_field.py
+++ b/tests/test_json_field.py
@@ -18,3 +18,16 @@ class JsonFieldTest(TestCase):
         j = JSONFieldTestModel.objects.create(a=6, j_field=[])
         self.assertTrue(isinstance(j.j_field, list))
         self.assertEqual(j.j_field, [])
+
+    def test_float_values(self):
+        """ Tests that float values in JSONFields are correctly serialized over repeated saves.
+            Regression test for c382398b, which fixes floats being returned as strings after a second save.
+        """
+        test_instance = JSONFieldTestModel(a=6, j_field={'test': 0.1})
+        test_instance.save()
+
+        test_instance = JSONFieldTestModel.objects.get()
+        test_instance.save()
+
+        test_instance = JSONFieldTestModel.objects.get()
+        self.assertEqual(test_instance.j_field['test'], 0.1)


### PR DESCRIPTION
JSONField parses floats stored in the database as decimals. DjangoJSONEncoder turns decimals into strings before passing them to json.JSONEncoder (because Decimal isn't json-serializable), which is why ultimately, after an extra save, JSONFields will return float values as strings.

I looked through the commits and found that the `parse_float=Decimal` line came in in the original commit for `JSONField`, so I don't know if there was a good reason for using decimals. If there was, that'd be great to know so I can fix it differently.

This is basically a carbon copy of the same fix in https://github.com/potatolondon/djangae/issues/560