### PR TITLE
Updated the runscript docs to match the Django tutorial for Django 1.8+

### DIFF
--- a/docs/runscript.rst
+++ b/docs/runscript.rst
@@ -17,6 +17,10 @@ set of commands in shell accessed by::
 Getting Started
 ---------------
 
+This example assumes you have followed the tutorial for Django 1.8+, and 
+created a polls app containing a ``Question`` model. We will create a script
+that deletes all of the questions from the database.
+
 To get started create a scripts directory in your project root, next to
 manage.py::
 
@@ -29,7 +33,7 @@ python package.
 Next, create a python file with the name of the script you want to run within
 the scripts directory::
 
-  $ touch scripts/delete_all_polls.py
+  $ touch scripts/delete_all_questions.py
 
 This file must implement a *run()* function. This is what gets called when you
 run the script. You can import any models or other parts of your django project
@@ -37,15 +41,15 @@ to use in these scripts.
 
 For example::
 
-  # scripts/delete_all_polls.py
+  # scripts/delete_all_questions.py
 
-  from Polls.models import Poll
+  from polls.models import Question
 
   def run():
-      # Get all polls
-      all_polls = Poll.objects.all()
-      # Delete polls
-      all_polls.delete()
+      # Fetch all questions
+      questions = Question.objects.all()
+      # Delete questions
+      questions.delete()
 
 Note: You can put a script inside a *scripts* folder in any of your apps too.
 
@@ -57,7 +61,7 @@ that you want to run.
 
 For example::
 
-  $ python manage.py runscript delete_all_polls
+  $ python manage.py runscript delete_all_questions
 
 Note: The command first checks for scripts in your apps i.e. *app_name/scripts*
 folder and runs them before checking for and running scripts in the
@@ -70,19 +74,23 @@ Passing arguments
 You can pass arguments from the command line to your script by passing a space separated
 list of values with ``--script-args``. For example::
 
-  $ python manage.py runscript delete_all_polls --script-args=staleonly
+  $ python manage.py runscript delete_all_questions --script-args=staleonly
 
 The list of argument values gets passed as arguments to your *run()* function. For
 example::
 
-  # scripts/delete_all_polls.py
+  # scripts/delete_all_questions.py
+  from datetime import timedelta
+
+  from django.utils import timezone
   
-  from Polls.models import Poll
+  from polls.models import Question
   
   def run(*args):
-      # Get all polls
-      all_polls = Poll.object.all()
+      # Get all questions
+      questions = Question.objects.all()
       if 'staleonly' in args:
-          all_polls = all_polls.filter(active=False)
-      # Delete polls
-      all_polls.delete()
+          # Only get questions more than 100 days old
+          questions = all_questions.filter(pub_date__lt=timezone.now() - timedelta(days=100))
+      # Delete questions
+      questions.delete()


### PR DESCRIPTION
The current example was causing a bit of confusion on [this stack overflow question](http://stackoverflow.com/questions/35226883/python-django-typeerror-relative-imports-require-the-package-argument/35227881?noredirect=1#comment58173246_35227881), so I've updated the example to more closely match the Django tutorial for Django 1.8+.