### PR TITLE
Improve profile doc

### DIFF
--- a/django_extensions/management/commands/runprofileserver.py
+++ b/django_extensions/management/commands/runprofileserver.py
@@ -194,9 +194,9 @@ class Command(BaseCommand):
             import time
             try:
                 import hotshot
-                HAS_HOTSPOT = True
+                HAS_HOTSHOT = True
             except ImportError:
-                HAS_HOTSPOT = False  # python 3.x
+                HAS_HOTSHOT = False  # python 3.x
             USE_CPROFILE = options.get('use_cprofile', False)
             USE_LSPROF = options.get('use_lsprof', False)
             if USE_LSPROF:
@@ -211,8 +211,8 @@ class Command(BaseCommand):
             if USE_LSPROF and not USE_CPROFILE:
                 raise CommandError("Kcachegrind compatible output format required cProfile from Python 2.5")
 
-            if not HAS_HOTSPOT and not USE_CPROFILE:
-                raise CommandError("Hotspot profile library not found. (and not using cProfile)")
+            if not HAS_HOTSHOT and not USE_CPROFILE:
+                raise CommandError("Hotshot profile library not found. (and not using cProfile)")
 
             prof_path = options.get('prof_path', '/tmp')
 

--- a/docs/runprofileserver.rst
+++ b/docs/runprofileserver.rst
@@ -46,6 +46,26 @@ one aggregated profile file. This tool is called *gather_profile_stats.py* and
 is located inside the *bin* directory of your Django distribution.
 
 
+Profiler choice
+---------------
+*runprofileserver* supports two profilers: *hotshot* and *cProfile*. Both come 
+with the standard Python library but *cProfile* is more recent and may not be
+available on all systems. For this reason, *hotshot* is the default profiler.
+
+However, *hotshot* `is not maintained anymore <https://docs.python.org/2/library/profile.html#introduction-to-the-profilers>`_
+and using *cProfile* is usually the recommended way. 
+If it is available on your system, you can use it with the option ``--use-cprofile``.
+
+Example::
+  
+  $ mkdir /tmp/my-profile-data
+  $ ./manage.py runprofileserver --use-cprofile --prof-path=/tmp/my-profile-data
+
+If you used the default profiler but are not able to open the profiling results
+with the ``pstats`` module or with your profiling GUI of choice because of an
+error "*ValueError: bad marshal data (unknown type code)*", try using *cProfile*
+instead.
+
 KCacheGrind
 -----------
 


### PR DESCRIPTION
While trying the *runprofileserver* command, I got an error while opening the profiling results.
After some investigation I found out that this is because I was using the default profiler (hotshot) as opposed to cProfile.

I am submitting this PR to improve the documentation in the hope that this will help someone with the same issue. I also slightly modified the code of the command to replace "hotsPot" instances with "hotsHot", this the real name is "hotshot" and it may make it easier for someone searching the word.