### PR TITLE
Missing colon for code block

### DIFF
--- a/docs/runserver_plus.rst
+++ b/docs/runserver_plus.rst
@@ -151,7 +151,7 @@ You can use settings to automatically default your development to an address/por
     RUNSERVERPLUS_SERVER_ADDRESS_PORT = '0.0.0.0:8000'
 
 To ensure Werkzeug can log to the console, you may need to add the following
-to your settings:
+to your settings::
 
   LOGGING = {
       ...


### PR DESCRIPTION
I missed a colon out in #821. A thousand apologies.