### PR TITLE
Make ForeignKeySearchInput usable outside changeforms

### DIFF
--- a/django_extensions/admin/widgets.py
+++ b/django_extensions/admin/widgets.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 import six
 from django import forms
-from django.core.urlresolvers import reverse
 from django.contrib.admin.sites import site
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
+from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.text import Truncator
@@ -17,7 +17,7 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
     # Set in subclass to render the widget with a different template
     widget_template = None
     # Set this to the patch of the search view
-    search_path = '../foreignkey_autocomplete/'
+    search_path = None
 
     def _media(self):
         js_files = ['django_extensions/js/jquery.bgiframe.min.js',
@@ -46,6 +46,8 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
         app_label = opts.app_label
         model_name = opts.object_name.lower()
         related_url = reverse('admin:%s_%s_changelist' % (app_label, model_name))
+        if not self.search_path:
+            self.search_path = '%s/foreignkey_autocomplete/' % related_url
         params = self.url_parameters()
         if params:
             url = '?' + '&amp;'.join(['%s=%s' % (k, v) for k, v in params.items()])

--- a/django_extensions/admin/widgets.py
+++ b/django_extensions/admin/widgets.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 import six
 from django import forms
+from django.core.urlresolvers import reverse
 from django.contrib.admin.sites import site
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
-from django.core import urlresolvers
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.text import Truncator
@@ -45,7 +45,7 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
         opts = self.rel.to._meta
         app_label = opts.app_label
         model_name = opts.object_name.lower()
-        related_url = urlresolvers.reverse('admin:%s_%s_changelist' % (app_label, model_name))
+        related_url = reverse('admin:%s_%s_changelist' % (app_label, model_name))
         params = self.url_parameters()
         if params:
             url = '?' + '&amp;'.join(['%s=%s' % (k, v) for k, v in params.items()])


### PR DESCRIPTION
Previously the `related_url` variable was calculated assuming the page with a widget is nested 3 levels down (like a model's changeform, `/app/model/<pk>`). That was making it harder to use the widget in a custom admin views, which could reside at the arbitrary nesting level. Here we switch to using a more flexible `reverse()` call.