### PR TITLE
JSON output for graph_models command

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
             with open(output_file, 'wt') as json_output_f:
                 json.dump(graph_data, json_output_f)
         else:
-            print json.dumps(graph_data)
+            print(json.dumps(graph_data))
 
     def render_output_pygraphviz(self, dotdata, **kwargs):
         """Renders the image using pygraphviz"""

--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -1,13 +1,14 @@
 # coding=utf-8
 import sys
 from optparse import NO_DEFAULT
+import json
 
 import six
 from django.conf import settings
 from django.core.management.base import CommandError
 
 from django_extensions.compat import CompatibilityBaseCommand as BaseCommand
-from django_extensions.management.modelviz import generate_dot
+from django_extensions.management.modelviz import generate_graph_data, generate_dot
 from django_extensions.management.utils import signalcommand
 
 try:
@@ -37,6 +38,8 @@ class Command(BaseCommand):
         parser.add_argument(
             '--pydot', action='store_true', dest='pydot',
             help='Use PyDot to generate the image.')
+        parser.add_argument('--json', action='store_true', dest='json',
+            help='Output graph data as JSON')
         parser.add_argument(
             '--disable-fields', '-d', action='store_true',
             dest='disable_fields', help='Do not show the class member fields')
@@ -95,8 +98,17 @@ class Command(BaseCommand):
 
         use_pygraphviz = options.get('pygraphviz', False)
         use_pydot = options.get('pydot', False)
+        use_json = options.get('json', False)
+        if use_json and (use_pydot or use_pygraphviz):
+            raise CommandError("Cannot specify --json with --pydot or --pygraphviz")
+
         cli_options = ' '.join(sys.argv[2:])
-        dotdata = generate_dot(args, cli_options=cli_options, **options)
+        graph_data = generate_graph_data(args, cli_options=cli_options, **options)
+        if use_json:
+            self.render_output_json(graph_data, **options)
+            return
+
+        dotdata = generate_dot(graph_data)
         if not six.PY3:
             dotdata = dotdata.encode('utf-8')
         if options['outputfile']:
@@ -133,6 +145,14 @@ class Command(BaseCommand):
             dotdata = dotdata.decode()
 
         print(dotdata)
+
+    def render_output_json(self, graph_data, **kwargs):
+        output_file = kwargs.get('outputfile')
+        if output_file:
+            with open(output_file, 'wt') as json_output_f:
+                json.dump(graph_data, json_output_f)
+        else:
+            print json.dumps(graph_data)
 
     def render_output_pygraphviz(self, dotdata, **kwargs):
         """Renders the image using pygraphviz"""

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -60,7 +60,7 @@ def parse_file_or_list(arg):
     return [e.strip() for e in arg.split(',')]
 
 
-def generate_dot(app_labels, **kwargs):
+def generate_graph_data(app_labels, **kwargs):
     cli_options = kwargs.get('cli_options', None)
     disable_fields = kwargs.get('disable_fields', False)
     include_models = parse_file_or_list(kwargs.get('include_models', ""))
@@ -292,6 +292,17 @@ def generate_dot(app_labels, **kwargs):
                     relation['needs_node'] = False
 
     now = datetime.datetime.now()
+    graph_data = {
+        'created_at': now.strftime("%Y-%m-%d %H:%M"),
+        'cli_options': cli_options,
+        'disable_fields': disable_fields,
+        'use_subgraph': use_subgraph,
+        'graphs': graphs,
+    }
+    return graph_data
+
+
+def generate_dot(graph_data):
     t = loader.get_template('django_extensions/graph_models/digraph.dot')
 
     if not isinstance(t, Template) and not (hasattr(t, 'template') and isinstance(t.template, Template)):
@@ -299,13 +310,7 @@ def generate_dot(app_labels, **kwargs):
                         "This can lead to the incorrect template rendering. "
                         "Please, check the settings.")
 
-    c = Context({
-        'created_at': now.strftime("%Y-%m-%d %H:%M"),
-        'cli_options': cli_options,
-        'disable_fields': disable_fields,
-        'use_subgraph': use_subgraph,
-        'graphs': graphs,
-    })
+    c = Context(graph_data)
     if django.VERSION >= (1, 8):
         c = c.flatten()
     dot = t.render(c)


### PR DESCRIPTION
Adds a ```--json``` option to the ```graph_models``` command to output visualization data as parseable JSON.

This allows for  rendering with alternative visualization and graphing tools (e.g. [d3.js](https://d3js.org/), [sigma.js](http://sigmajs.org/), [arbor.js](http://arborjs.org/), custom, etc...)