### PR TITLE
Fix admin_generator incompatible "default" identifier raising TypeError.

### DIFF
--- a/django_extensions/compat.py
+++ b/django_extensions/compat.py
@@ -206,7 +206,16 @@ class ProxyParser(object):
         self.command = command
 
     def add_argument(self, *args, **kwargs):
-        self.command.option_list +=  (make_option(*args, **kwargs), )
+        """Transform our argument into an option to append to self.option_list.
+
+        In argparse, "available specifiers [in help strings] include the
+        program name, %(prog)s and most keyword arguments to add_argument()".
+        However, optparse only mentions %default in the help string, and we
+        must alter the format to properly replace in optparse without error.
+        """
+        if 'help' in kwargs:
+            kwargs['help'] = kwargs['help'].replace('%(default)s', '%default')
+        self.command.option_list += (make_option(*args, **kwargs), )
 
 class CompatibilityBaseCommand(BaseCommand):
     """Provides a compatibility between optparse and argparse transition.

--- a/django_extensions/management/commands/admin_generator.py
+++ b/django_extensions/management/commands/admin_generator.py
@@ -297,28 +297,28 @@ class Command(BaseCommand):
             '-s', '--search-field', action='append',
             default=SEARCH_FIELD_NAMES,
             help='Fields named like this will be added to `search_fields`'
-            ' [default: %default]')
+            ' [default: %(default)s]')
         parser.add_argument(
             '-d', '--date-hierarchy', action='append',
             default=DATE_HIERARCHY_NAMES,
             help='A field named like this will be set as `date_hierarchy`'
-            ' [default: %default]')
+            ' [default: %(default)s]')
         parser.add_argument(
             '-p', '--prepopulated-fields', action='append',
             default=PREPOPULATED_FIELD_NAMES,
             help='These fields will be prepopulated by the other field.'
             'The field names can be specified like `spam=eggA,eggB,eggC`'
-            ' [default: %default]')
+            ' [default: %(default)s]')
         parser.add_argument(
             '-l', '--list-filter-threshold', type=int,
             default=LIST_FILTER_THRESHOLD, metavar='LIST_FILTER_THRESHOLD',
             help='If a foreign key has less than LIST_FILTER_THRESHOLD items '
-            'it will be added to `list_filter` [default: %default]')
+            'it will be added to `list_filter` [default: %(default)s]')
         parser.add_argument(
             '-r', '--raw-id-threshold', type=int,
             default=RAW_ID_THRESHOLD, metavar='RAW_ID_THRESHOLD',
             help='If a foreign key has more than RAW_ID_THRESHOLD items '
-            'it will be added to `list_filter` [default: %default]')
+            'it will be added to `list_filter` [default: %(default)s]')
 
     @signalcommand
     def handle(self, *args, **kwargs):


### PR DESCRIPTION
In admin_generator.py we change to the argparse "default" string replace
style and update ProxyParser to handle the necessary replacement for
optparse. The 3.5.1 docs for argparse state: "The help strings can
include various format specifiers to avoid repetition of things like the
program name or the argument default. The available specifiers include
the program name, %(prog)s and most keyword arguments to add_argument(),
e.g. %(default)s, %(type)s, etc." The use of "most" is ambiguous and in
preliminary testing, this functionality is at least missing for the
kwarg "action". It is not the intent of CompatibilityBaseCommand or
ProxyParser to add functionality to optparse, so we make no effort to
handle whatever other kwargs may be supported as formatted
identifiers in argparse as the optparse docs only mention %default
in the help string. %prog exists in optparse only in the usage and
version strings.