### PR TITLE
Fix settings.GRAPH_MODELS breaking graph_models.

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import sys
-from optparse import NO_DEFAULT
 import json
 
 import six
@@ -31,68 +30,109 @@ class Command(BaseCommand):
 
     can_import_settings = True
 
+    def __init__(self, *args, **kwargs):
+        """Allow defaults for arguments to be set in settings.GRAPH_MODELS.
+
+        Each argument in self.arguments is a dict where the key is the
+        space-separated args and the value is our kwarg dict.
+
+        The default from settings is keyed as the long arg name with '--'
+        removed and any '-' replaced by '_'.
+        """
+        self.arguments = {
+            '--pygraphviz': {
+                'action': 'store_true', 'dest': 'pygraphviz',
+                'help': 'Use PyGraphViz to generate the image.'},
+
+            '--pydot': {'action': 'store_true', 'dest': 'pydot',
+                        'help': 'Use PyDot to generate the image.'},
+
+            '--disable-fields -d': {
+                'action': 'store_true', 'dest': 'disable_fields',
+                'help': 'Do not show the class member fields'},
+
+            '--group-models -g': {
+                'action': 'store_true', 'dest': 'group_models',
+                'help': 'Group models together respective to their '
+                'application'},
+
+            '--all-applications -a': {
+                'action': 'store_true', 'dest': 'all_applications',
+                'help': 'Automatically include all applications from '
+                'INSTALLED_APPS'},
+
+            '--output -o': {
+                'action': 'store', 'dest': 'outputfile',
+                'help': 'Render output file. Type of output dependend on file '
+                'extensions. Use png or jpg to render graph to image.'},
+
+            '--layout -l': {
+                'action': 'store', 'dest': 'layout', 'default': 'dot',
+                'help': 'Layout to be used by GraphViz for visualization. '
+                'Layouts: circo dot fdp neato nop nop1 nop2 twopi'},
+
+            '--verbose-names -n': {
+                'action': 'store_true', 'dest': 'verbose_names',
+                'help': 'Use verbose_name of models and fields'},
+
+            '--language -L': {
+                'action': 'store', 'dest': 'language',
+                'help': 'Specify language used for verbose_name localization'},
+
+            '--exclude-columns -x': {
+                'action': 'store', 'dest': 'exclude_columns',
+                'help': 'Exclude specific column(s) from the graph. '
+                'Can also load exclude list from file.'},
+
+            '--exclude-models -X': {
+                'action': 'store', 'dest': 'exclude_models',
+                'help': 'Exclude specific model(s) from the graph. Can also '
+                'load exclude list from file.'},
+
+            '--include-models -I': {
+                'action': 'store', 'dest': 'include_models',
+                'help': 'Restrict the graph to specified models.'},
+
+            '--inheritance -e': {
+                'action': 'store_true', 'dest': 'inheritance', 'default': True,
+                'help': 'Include inheritance arrows (default)'},
+
+            '--no-inheritance -E': {
+                'action': 'store_false', 'dest': 'inheritance',
+                'help': 'Do not include inheritance arrows'},
+
+            '--hide-relations-from-fields -R': {
+                'action': 'store_false', 'dest': 'relations_as_fields',
+                'default': True,
+                'help': 'Do not show relations as fields in the graph.'},
+
+            '--disable-sort-fields -S': {
+                'action': 'store_false', 'dest': 'sort_fields',
+                'default': True, 'help': 'Do not sort fields'},
+
+            '--json': {'action': 'store_true', 'dest': 'json',
+                       'help': 'Output graph data as JSON'}
+        }
+
+        defaults = getattr(settings, 'GRAPH_MODELS', None)
+
+        if defaults:
+            for argument in self.arguments:
+                arg_split = argument.split(' ')
+                setting_opt = arg_split[0].lstrip('-').replace('-', '_')
+                if setting_opt in defaults:
+                    self.arguments[argument]['default'] = defaults[setting_opt]
+
+        super(Command, self).__init__(*args, **kwargs)
+
     def add_arguments(self, parser):
-        parser.add_argument(
-            '--pygraphviz', action='store_true', dest='pygraphviz',
-            help='Use PyGraphViz to generate the image.')
-        parser.add_argument(
-            '--pydot', action='store_true', dest='pydot',
-            help='Use PyDot to generate the image.')
-        parser.add_argument('--json', action='store_true', dest='json',
-            help='Output graph data as JSON')
-        parser.add_argument(
-            '--disable-fields', '-d', action='store_true',
-            dest='disable_fields', help='Do not show the class member fields')
-        parser.add_argument(
-            '--group-models', '-g', action='store_true', dest='group_models',
-            help='Group models together respective to their application')
-        parser.add_argument(
-            '--all-applications', '-a', action='store_true',
-            dest='all_applications',
-            help='Automatically include all applications from INSTALLED_APPS')
-        parser.add_argument(
-            '--output', '-o', action='store', dest='outputfile',
-            help='Render output file. Type of output dependend on file '
-            'extensions. Use png or jpg to render graph to image.')
-        parser.add_argument(
-            '--layout', '-l', action='store', dest='layout', default='dot',
-            help='Layout to be used by GraphViz for visualization. '
-            'Layouts: circo dot fdp neato nop nop1 nop2 twopi')
-        parser.add_argument(
-            '--verbose-names', '-n', action='store_true', dest='verbose_names',
-            help='Use verbose_name of models and fields')
-        parser.add_argument(
-            '--language', '-L', action='store', dest='language',
-            help='Specify language used for verbose_name localization')
-        parser.add_argument(
-            '--exclude-columns', '-x', action='store', dest='exclude_columns',
-            help='Exclude specific column(s) from the graph. '
-            'Can also load exclude list from file.')
-        parser.add_argument(
-            '--exclude-models', '-X', action='store', dest='exclude_models',
-            help='Exclude specific model(s) from the graph. '
-            'Can also load exclude list from file.')
-        parser.add_argument(
-            '--include-models', '-I', action='store', dest='include_models',
-            help='Restrict the graph to specified models.')
-        parser.add_argument(
-            '--inheritance', '-e', action='store_true', dest='inheritance',
-            default=True, help='Include inheritance arrows (default)')
-        parser.add_argument(
-            '--no-inheritance', '-E', action='store_false', dest='inheritance',
-            help='Do not include inheritance arrows')
-        parser.add_argument(
-            '--hide-relations-from-fields', '-R', action='store_false',
-            dest="relations_as_fields",
-            default=True, help="Do not show relations as fields in the graph.")
-        parser.add_argument(
-            '--disable-sort-fields', '-S', action="store_false",
-            dest="sort_fields", default=True, help="Do not sort fields")
+        """Unpack self.arguments for parser.add_arguments."""
+        for argument in self.arguments:
+            parser.add_argument(*argument.split(' '),
+                                **self.arguments[argument])
 
     @signalcommand
     def handle(self, *args, **options):
-        self.options_from_settings(options)
-
         if len(args) < 1 and not options['all_applications']:
             raise CommandError("need one or more arguments for appname")
 
@@ -125,20 +165,6 @@ class Command(BaseCommand):
                 raise CommandError("Neither pygraphviz nor pydot could be found to generate the image")
         else:
             self.print_output(dotdata)
-
-    def options_from_settings(self, options):
-        defaults = getattr(settings, 'GRAPH_MODELS', None)
-        if defaults:
-            for option in self.graph_models_options:
-                long_opt = option._long_opts[0]
-                if long_opt:
-                    long_opt = long_opt.lstrip("-").replace("-", "_")
-                    if long_opt in defaults:
-                        default_value = None
-                        if not option.default == NO_DEFAULT:
-                            default_value = option.default
-                        if options[option.dest] == default_value:
-                            options[option.dest] = defaults[long_opt]
 
     def print_output(self, dotdata):
         if six.PY3 and isinstance(dotdata, six.binary_type):


### PR DESCRIPTION
I considered a couple different ways to do this and this seemed the most appropriate considering that CompatibilityBaseCommand should be considered temporary until support for Django 1.8 is removed (so not putting extra non-compat-specific code in there), removing potentially fragile library-specific code rather than adding more is better for future maintenance, and abstracting out settings defaults from this script is premature and may be appropriate as a feature addition, but not to resolve this issue.