### PR TITLE
Python3 fixes to graph_models: byte/str coercion and version comparison

### DIFF
--- a/django_extensions/compat.py
+++ b/django_extensions/compat.py
@@ -200,7 +200,7 @@ def add_to_builtins_compat(name):
 
 
 def get_model(path):
-    if django.VERSION < (1.7):
+    if django.VERSION < (1, 7):
         from django.db.models.loading import get_model
         return get_model(*path.split('.', 1))
     else:

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -210,7 +210,7 @@ def generate_graph_data(app_labels, **kwargs):
                     related_query_name = field.related_query_name()
                     if verbose_names and related_query_name.islower():
                         related_query_name = related_query_name.replace('_', ' ').capitalize()
-                    label += force_bytes(' (%s)' % related_query_name)
+                    label = '{} ({})'.format(label, force_bytes(related_query_name))
 
                 # handle self-relationships and lazy-relationships
                 if isinstance(field.rel.to, six.string_types):


### PR DESCRIPTION
Addresses two issues that prevent `graph_models` from running under python3:

 - `TypeError: unorderable types: tuple() < float()`: The version check for Django 1.7 uses a float instead of a tuple, this is an invalid comparison in python3.
 - `TypeError: Can't convert 'bytes' object to str implicitly` (issue #740).  Instead of relying on `+=` to do implicit str conversion, use a formatting string (`"{} ({})".format(...)`).  While the fix in this PR enables the command to run successfully, it's not ideal, as under python3 it will retain the `b''` prefix on the resulting string.  Nevertheless, it's better than a crash.