### PR TITLE
Add option to preserve modified timestamps on save

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -409,6 +409,11 @@ class ModificationDateTimeField(CreationDateTimeField):
             kwargs['auto_now'] = True
         return name, path, args, kwargs
 
+    def pre_save(self, model_instance, add):
+        if not model_instance.update_modified:
+            return model_instance.modified
+        return super(ModificationDateTimeField, self).pre_save(model_instance, add)
+
 
 class UUIDVersionError(Exception):
     pass

--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -26,7 +26,7 @@ class TimeStampedModel(models.Model):
     modified = ModificationDateTimeField(_('modified'))
 
     def save(self, **kwargs):
-        self.update_modified = kwargs.pop('update_modified', True)
+        self.update_modified = kwargs.pop('update_modified', getattr(self, 'update_modified', True))
         super(TimeStampedModel, self).save(**kwargs)
 
     class Meta:

--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -25,6 +25,10 @@ class TimeStampedModel(models.Model):
     created = CreationDateTimeField(_('created'))
     modified = ModificationDateTimeField(_('modified'))
 
+    def save(self, **kwargs):
+        self.update_modified = kwargs.pop('update_modified', True)
+        super(TimeStampedModel, self).save(**kwargs)
+
     class Meta:
         get_latest_by = 'modified'
         ordering = ('-modified', '-created',)

--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -35,7 +35,37 @@ Current Database Model Field Extensions
 
 * *ModificationDateTimeField* - DateTimeField that will automatically set its
   date when an object is saved to the database. Works in the same way as the
-  auto_now keyword.
+  auto_now keyword. It is possible to preserve the current timestamp by setting update_modified to False::
+
+    >>> example = MyTimeStampedModel.objects.get(pk=1)
+
+    >>> print example.modified
+    datetime.datetime(2016, 3, 18, 10, 3, 39, 740349, tzinfo=<UTC>)
+
+    >>> example.save(update_modified=False)
+
+    >>> print example.modified
+    datetime.datetime(2016, 3, 18, 10, 3, 39, 740349, tzinfo=<UTC>)
+
+    >>> example.save()
+
+    >>> print example.modified
+    datetime.datetime(2016, 4, 8, 14, 25, 43, 123456, tzinfo=<UTC>)
+
+  It is also possible to set the attribute directly on the model,
+  for example when you don't use the TimeStampedModel provided in this package, or when you are in a migration::
+
+    >>> example = MyCustomModel.objects.get(pk=1)
+
+    >>> print example.modified
+    datetime.datetime(2016, 3, 18, 10, 3, 39, 740349, tzinfo=<UTC>)
+
+    >>> example.update_modified=False
+
+    >>> example.save()
+
+    >>> print example.modified
+    datetime.datetime(2016, 3, 18, 10, 3, 39, 740349, tzinfo=<UTC>)
 
 * *UUIDField* - UUIDField for Django, supports all uuid versions that are
   natively supported by the uuid python module.

--- a/tests/test_timestamped_model.py
+++ b/tests/test_timestamped_model.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+import time
+from django.test import TestCase
+
+from .testapp.models import TimestampedTestModel
+
+
+class ModifiedFieldTest(TestCase):
+    def test_update(self):
+        t = TimestampedTestModel.objects.create()
+        modified = t.modified
+
+        time.sleep(1)
+
+        t.save()
+        self.assertNotEqual(modified, t.modified)
+
+    def test_update_no_modified(self):
+        t = TimestampedTestModel.objects.create()
+        modified = t.modified
+
+        time.sleep(1)
+
+        t.save(update_modified=False)
+        self.assertEqual(modified, t.modified)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -8,7 +8,7 @@ from django_extensions.db.fields import (
     UUIDField,
 )
 from django_extensions.db.fields.json import JSONField
-from django_extensions.db.models import ActivatorModel
+from django_extensions.db.models import ActivatorModel, TimeStampedModel
 
 
 class Secret(models.Model):
@@ -202,5 +202,10 @@ class RandomCharTestModelPunctuation(models.Model):
         include_alpha=False,
     )
 
+    class Meta:
+        app_label = 'django_extensions'
+
+
+class TimestampedTestModel(TimeStampedModel):
     class Meta:
         app_label = 'django_extensions'


### PR DESCRIPTION
I've added the option to override the default behaviour of always updating the modified date of the `TimeStampedModel` / `ModificationDateTimeField`. I used the code from @jacobg in issue #579 as inspiration.

Also added a simple testcase and some docs.