### PR TITLE
Graph model filter wildcards

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -87,11 +87,12 @@ class Command(BaseCommand):
             '--exclude-models -X': {
                 'action': 'store', 'dest': 'exclude_models',
                 'help': 'Exclude specific model(s) from the graph. Can also '
-                'load exclude list from file.'},
+                'load exclude list from file. Wildcards (*) are allowed.'},
 
             '--include-models -I': {
                 'action': 'store', 'dest': 'include_models',
-                'help': 'Restrict the graph to specified models.'},
+                'help': 'Restrict the graph to specified models. Wildcards '
+                '(*) are allowed.'},
 
             '--inheritance -e': {
                 'action': 'store_true', 'dest': 'inheritance', 'default': True,

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -10,6 +10,7 @@ Based on:
 
 import datetime
 import os
+import re
 
 import six
 import django
@@ -47,7 +48,8 @@ __contributors__ = [
     "Joern Hees <gitdev@joernhees.de>",
     "Kevin Cherepski <cherepski@gmail.com>",
     "Jose Tomas Tocino <theom3ga@gmail.com>",
-    "Adam Dobrawy <naczelnik@jawnosc.tk>"
+    "Adam Dobrawy <naczelnik@jawnosc.tk>",
+    "Mikkel Munch Mortensen <https://www.detfalskested.dk/>",
 ]
 
 
@@ -60,6 +62,27 @@ def parse_file_or_list(arg):
         return [e.strip() for e in open(arg).readlines()]
     return [e.strip() for e in arg.split(',')]
 
+def use_model(model_name, include_models, exclude_models):
+    """
+    Decide whether to use a model, based on the model name and the lists of
+    models to exclude and include.
+    """
+    # Check against exclude list.
+    if exclude_models:
+        for model_pattern in exclude_models:
+            model_pattern = \
+                '^%s$' % model_pattern.replace('*', '.*')
+            if re.search(model_pattern, model_name):
+                return False
+    # Check against exclude list.
+    elif include_models:
+        for model_pattern in include_models:
+            model_pattern = \
+                '^%s$' % model_pattern.replace('*', '.*')
+            if re.search(model_pattern, model_name):
+                return True
+    # Return `True` if `include_models` is falsey, otherwise return `False`.
+    return not include_models
 
 def generate_graph_data(app_labels, **kwargs):
     cli_options = kwargs.get('cli_options', None)
@@ -129,15 +152,11 @@ def generate_graph_data(app_labels, **kwargs):
                 'relations': []
             }
 
-            # consider given model name ?
-            def consider(model_name):
-                if exclude_models and model_name in exclude_models:
-                    return False
-                elif include_models and model_name not in include_models:
-                    return False
-                return not include_models or model_name in include_models
-
-            if not consider(appmodel._meta.object_name):
+            if not use_model(
+                appmodel._meta.object_name,
+                include_models,
+                exclude_models
+            ):
                 continue
 
             if verbose_names and appmodel._meta.verbose_name:
@@ -230,7 +249,11 @@ def generate_graph_data(app_labels, **kwargs):
                     'arrows': extras,
                     'needs_node': True
                 }
-                if _rel not in model['relations'] and consider(_rel['target']):
+                if _rel not in model['relations'] and use_model(
+                    _rel['target'],
+                    include_models,
+                    exclude_models
+                ):
                     model['relations'].append(_rel)
 
             for field in appmodel._meta.local_fields:
@@ -275,7 +298,11 @@ def generate_graph_data(app_labels, **kwargs):
                             'needs_node': True,
                         }
                         # TODO: seems as if abstract models aren't part of models.getModels, which is why they are printed by this without any attributes.
-                        if _rel not in model['relations'] and consider(_rel['target']):
+                        if _rel not in model['relations'] and use_model(
+                            _rel['target'],
+                            include_models,
+                            exclude_columns
+                        ):
                             model['relations'].append(_rel)
 
             graph['models'].append(model)

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -62,6 +62,7 @@ def parse_file_or_list(arg):
         return [e.strip() for e in open(arg).readlines()]
     return [e.strip() for e in arg.split(',')]
 
+
 def use_model(model_name, include_models, exclude_models):
     """
     Decide whether to use a model, based on the model name and the lists of
@@ -83,6 +84,7 @@ def use_model(model_name, include_models, exclude_models):
                 return True
     # Return `True` if `include_models` is falsey, otherwise return `False`.
     return not include_models
+
 
 def generate_graph_data(app_labels, **kwargs):
     cli_options = kwargs.get('cli_options', None)

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -121,18 +121,84 @@ class GraphModelsTests(TestCase):
     def test_use_model(self):
         include_models = [
             'NoWildcardInclude',
+            'Wildcard*InsideInclude',
             '*WildcardPrefixInclude',
             'WildcardSuffixInclude*',
             '*WildcardBothInclude*'
         ]
         exclude_models = [
             'NoWildcardExclude',
+            'Wildcard*InsideExclude',
             '*WildcardPrefixExclude',
             'WildcardSuffixExclude*',
             '*WildcardBothExclude*'
         ]
+        # Any model name should be used if neither include or exclude
+        # are defined.
         self.assertTrue(use_model(
             'SomeModel',
+            None,
+            None
+        ))
+        # Some tests with the `include_models` defined above.
+        self.assertFalse(use_model(
+            'SomeModel',
+            include_models,
+            None
+        ))
+        self.assertTrue(use_model(
+            'NoWildcardInclude',
+            include_models,
+            None
+        ))
+        self.assertTrue(use_model(
+            'WildcardSomewhereInsideInclude',
+            include_models,
+            None
+        ))
+        self.assertTrue(use_model(
+            'MyWildcardPrefixInclude',
+            include_models,
+            None
+        ))
+        self.assertTrue(use_model(
+            'WildcardSuffixIncludeModel',
+            include_models,
+            None
+        ))
+        self.assertTrue(use_model(
+            'MyWildcardBothIncludeModel',
+            include_models,
+            None
+        ))
+        # Some tests with the `exclude_models` defined above.
+        self.assertTrue(use_model(
+            'SomeModel',
+            None,
+            exclude_models
+        ))
+        self.assertFalse(use_model(
+            'NoWildcardExclude',
+            None,
+            exclude_models
+        ))
+        self.assertFalse(use_model(
+            'WildcardSomewhereInsideExclude',
+            None,
+            exclude_models
+        ))
+        self.assertFalse(use_model(
+            'MyWildcardPrefixExclude',
+            None,
+            exclude_models
+        ))
+        self.assertFalse(use_model(
+            'WildcardSuffixExcludeModel',
+            None,
+            exclude_models
+        ))
+        self.assertFalse(use_model(
+            'MyWildcardBothExcludeModel',
             None,
             exclude_models
         ))

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -114,6 +114,7 @@ class CommandClassTests(TestCase):
         except Exception as e:
             self.fail("Can't load command class of {0}\n{1}".format(command, e))
 
+
 class GraphModelsTests(TestCase):
     """
     Tests for the `graph_models` management command.

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -140,6 +140,18 @@ class GraphModelsTests(TestCase):
             None,
             None
         ))
+        # Any model name should be allowed if `*` is in `include_models`.
+        self.assertTrue(use_model(
+            'SomeModel',
+            ['OtherModel', '*', 'Wildcard*Model'],
+            None
+        ))
+        # No model name should be allowed if `*` is in `exclude_models`.
+        self.assertFalse(use_model(
+            'SomeModel',
+            None,
+            ['OtherModel', '*', 'Wildcard*Model']
+        ))
         # Some tests with the `include_models` defined above.
         self.assertFalse(use_model(
             'SomeModel',

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -9,6 +9,7 @@ from django.core.management import (
 from django.test import TestCase
 
 from django_extensions.compat import StringIO, importlib
+from django_extensions.management.modelviz import use_model
 
 
 class MockLoggingHandler(logging.Handler):
@@ -112,3 +113,26 @@ class CommandClassTests(TestCase):
                 load_command_class('django_extensions', command)
         except Exception as e:
             self.fail("Can't load command class of {0}\n{1}".format(command, e))
+
+class GraphModelsTests(TestCase):
+    """
+    Tests for the `graph_models` management command.
+    """
+    def test_use_model(self):
+        include_models = [
+            'NoWildcardInclude',
+            '*WildcardPrefixInclude',
+            'WildcardSuffixInclude*',
+            '*WildcardBothInclude*'
+        ]
+        exclude_models = [
+            'NoWildcardExclude',
+            '*WildcardPrefixExclude',
+            'WildcardSuffixExclude*',
+            '*WildcardBothExclude*'
+        ]
+        self.assertTrue(use_model(
+            'SomeModel',
+            None,
+            exclude_models
+        ))


### PR DESCRIPTION
This is a fix to issue #866, which I opened a couple of weeks ago. The basic idea is to allow wildcards in the `include-models` and `exclude-models` arguments to the `graph_models` management command.

Example: `./manage.py graph_models --exclude-models="*IrrelevantModel"` -- this will exclude both `SomeIrrelevantModel` and `OtherIrrelevantModel`.

I've done a bit of restructuring of the code, to allow testing of the function that checks whether a model name should be included or not. I also added tests for the new wildcard code.