### PR TITLE
Remove and fix usage of `get_models_compat`

### DIFF
--- a/django_extensions/compat.py
+++ b/django_extensions/compat.py
@@ -153,20 +153,8 @@ def get_model_compat(app_label, model_name):
         return apps.get_model(app_label, model_name)
 
 
-def get_models_compat(app_label):
-    """Get models on multiple Django versions."""
-    try:
-        # django >= 1.7
-        from django.apps import apps
-    except ImportError:
-        from django.db.models import get_models
-        return get_models(app_label)
-    else:
-        return apps.get_app_config(app_label).get_models()
-
-
 def get_models_for_app(app_label):
-    """Returns the models in the given app label."""
+    """Returns the models in the given app for an app label."""
     try:
         # django >= 1.7
         from django.apps import apps

--- a/django_extensions/management/commands/admin_generator.py
+++ b/django_extensions/management/commands/admin_generator.py
@@ -21,7 +21,7 @@ import sys
 from django.conf import settings
 from django.db import models
 
-from django_extensions.compat import get_apps, get_models_compat
+from django_extensions.compat import get_apps, get_models_for_app
 from django_extensions.management.color import color_style
 from django_extensions.management.utils import signalcommand
 from django_extensions.compat import CompatibilityLabelCommand as LabelCommand
@@ -89,7 +89,7 @@ class AdminApp(UnicodeMixin):
         self.options = options
 
     def __iter__(self):
-        for model in get_models_compat(self.app):
+        for model in get_models_for_app(self.app):
             admin_model = AdminModel(model, **self.options)
 
             for model_re in self.model_res:

--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -43,7 +43,7 @@ from django.db.models import (
 
 from django_extensions.management.utils import signalcommand
 from django_extensions.compat import (
-    list_app_labels, get_model_compat, get_models_compat, get_models_for_app
+    list_app_labels, get_model_compat, get_models_for_app
 )
 from django_extensions.compat import CompatibilityBaseCommand as BaseCommand
 
@@ -132,8 +132,8 @@ def get_models(app_labels):
 
     # If no app labels are given, return all
     if not app_labels:
-        for app in list_app_labels():
-            models += [m for m in get_models_compat(app)
+        for app_label in list_app_labels():
+            models += [m for m in get_models_for_app(app_label)
                        if m not in EXCLUDED_MODELS]
         return models
 


### PR DESCRIPTION
It does not expect an app label, but an app instance.

Ref: https://github.com/django-extensions/django-extensions/issues/862.

Trivially conflicts with https://github.com/django-extensions/django-extensions/pull/883.