### PR TITLE
Document funny graph_models labels for reverse relation names in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,16 @@ additions for Django projects. See the project page for more information:
     cmdclass=cmdclasses,
     package_data=package_data,
     install_requires=['six>=1.2'],
-    tests_require=['Django', 'shortuuid', 'python-dateutil', 'pytest', 'tox', 'mock'],
+    tests_require=[
+        'Django',
+        'shortuuid',
+        'python-dateutil',
+        'pytest',
+        'pytest-django',
+        'pytest-cov',
+        'tox',
+        'mock',
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tests/management/test_modelviz.py
+++ b/tests/management/test_modelviz.py
@@ -1,0 +1,27 @@
+from unittest import skipIf, skipUnless
+
+import six
+from django.test import SimpleTestCase
+from django_extensions.management.modelviz import generate_graph_data
+
+
+class ModelVizTests(SimpleTestCase):
+    @skipIf(six.PY3, 'FIXME Python 3 renders labels funny, see below')
+    def test_generate_graph_data_can_render_label(self):
+        app_labels = ['auth']
+        data = generate_graph_data(app_labels)
+
+        models = data['graphs'][0]['models']
+        user_data = [x for x in models if x['name'] == 'User'][0]
+        relation_labels = [x['label'] for x in user_data['relations']]
+        self.assertIn("groups (user)", relation_labels)
+
+    @skipUnless(six.PY3, 'DELETEME Python 3 should render the same as Python 2')
+    def test_generate_graph_data_formats_labels_as_bytes(self):
+        app_labels = ['auth']
+        data = generate_graph_data(app_labels)
+
+        models = data['graphs'][0]['models']
+        user_data = [x for x in models if x['name'] == 'User'][0]
+        relation_labels = [x['label'] for x in user_data['relations']]
+        self.assertIn("groups (b'user')", relation_labels)


### PR DESCRIPTION
There have been a couple attempts to get the `graph_models` command to behave in Python 3: #851 #834 #877

#851 fixed a bug but created a visual bug where `"groups (user)` now shows as `groups (b'user')`
Using #877 instead of #834 looks like it fixes things, but without tests, it's hard to know what's going on.

So this just adds a basic test. I couldn't think of a way to say "expected failure, but only for Python 3", so I put some skips and threw `FIXME` and `DELETEME` red flags in.

This test was able to catch the problem #851 fixed, but I have no idea what #834 was trying to fix.