### PR TITLE
Fix positional argument of print_settings

### DIFF
--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -16,6 +16,7 @@ from django_extensions.compat import CompatibilityBaseCommand as BaseCommand
 class Command(BaseCommand):
     """print_settings command"""
 
+    args = '<SETTING>'
     help = "Print the active Django settings."
 
     def add_arguments(self, parser):


### PR DESCRIPTION
Fixes:

    usage: ./manage.py print_settings [-h] [--version] [-v {0,1,2,3}]
                                      [--settings SETTINGS] [--pythonpath PYTHONPATH]
                                      [--traceback] [--no-color] [--format FORMAT]
                                      [--indent INDENT]
    ./manage.py print_settings: error: unrecognized arguments: DATABASES