### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Documentation
 
 You can view documentation online at:
 
-- http://django-extensions.readthedocs.org
+- https://django-extensions.readthedocs.io
 
 Or you can look at the docs/ directory in the repository.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Django Extensions is a collection of custom extensions for the Django Framework.
 These include management commands, additional database fields, admin extensions and
 much more.
 
-`这篇文档当然还有中文版 <http://django-extensions-zh.readthedocs.org/zh_CN/latest/>`_
+`这篇文档当然还有中文版 <https://django-extensions-zh.readthedocs.io/zh_CN/latest/>`_
 
 Getting Started
 ===============

--- a/tests/test_encrypted_fields.py
+++ b/tests/test_encrypted_fields.py
@@ -102,7 +102,7 @@ def secret_model():
     establishing the correct KeyCzar settings. This context manager handles
     that process.
 
-    See http://dynamic-models.readthedocs.org/en/latest/ and
+    See https://dynamic-models.readthedocs.io/en/latest/ and
     https://docs.djangoproject.com/en/dev/topics/db/models/
         #differences-between-proxy-inheritance-and-unmanaged-models
     """


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.