### PR TITLE
Remove support for end-of-life Python 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   - TOX_ENV=py27-dj19
   - TOX_ENV=py27-dj110
   - TOX_ENV=py27-djmaster
-  - TOX_ENV=py32-dj18
   - TOX_ENV=py33-dj18
   - TOX_ENV=py34-dj18
   - TOX_ENV=py34-dj19
@@ -36,7 +35,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: TOX_ENV=py32-dj18
     - env: TOX_ENV=py35-djmaster
     - env: TOX_ENV=py34-djmaster
     - env: TOX_ENV=py27-djmaster
@@ -47,8 +45,7 @@ matrix:
     - env: TOX_ENV=pypy3-djmaster
 
 install:
-  # virtualenv<14.0.0 is for Python 3.2 compatibility
-  - pip install "virtualenv<14.0.0" tox coveralls
+  - pip install virtualenv tox coveralls
 
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+ - Cleanup: removing support for end-of-life Python 3.2.
+
 1.7.4
 -----
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist =
 	precommit
 	{py27,py34,py35}-flake8
-	{py27,py32,py33,py34,pypy,pypy3}-dj18
+	{py27,py33,py34,pypy,pypy3}-dj18
 	{py27,py34,py35,pypy}-dj{19,dj110,master}
 
 [testenv]
@@ -19,7 +19,6 @@ deps =
 	dj19: Django>=1.9,<1.10
 	dj110: Django==1.10rc1
 	djmaster: https://github.com/django/django/archive/master.tar.gz
-	py32: coverage==3.7.1
 	shortuuid==0.4
 	python-dateutil
 	pytest-django


### PR DESCRIPTION
Django 1.8 will officially drop support for it at the end of the year, but most apps I've seen have already done so and anyone still using it can use an older version of django-extensions.