### PR TITLE
AutoSlugField: fix allow_duplicates

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -168,6 +168,7 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
         original_slug = slug
 
         if self.allow_duplicates:
+            setattr(model_instance, self.attname, slug)
             return slug
 
         return super(AutoSlugField, self).find_unique(


### PR DESCRIPTION
Resolves #801 

The issue is that if `allow_duplicates` is True, `create_slug` will return the slug directly without setting the attribute (field name) on the model instance. `find_unique` takes care of this in case `allow_duplicates` is False or not set.
