### PR TITLE
support for non standard user model

### DIFF
--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -58,10 +58,10 @@ class Command(BaseCommand):
             print("No user associated with that id.")
             return
 
-        username_field = 'username'
+	    # use django standrd api for reporting
+        print("full name: %s" % user.get_full_name())
+        print("short name: %s" % user.get_short_name())
+        print("username: %s" % user.get_username())
+        if hasattr(user, 'email'):
+            print("email: %s" % user.email)
 
-        if hasattr(User, 'USERNAME_FIELD') and User.USERNAME_FIELD is not None:
-            username_field = User.USERNAME_FIELD
-
-        for key in [username_field, 'email', 'first_name', 'last_name']:
-            print("%s: %s" % (key, getattr(user, key)))


### PR DESCRIPTION
Hi.
When using the command print_user_for_session, with User model that does not have first_name and last_name (for example, when using this [auth tools](https://github.com/fusionbox/django-authtools), then an error is given.
This could be fixed by adding hasattr(user, key) check, but instead changed it to use the user model functions [get_username](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.User.get_username),   [get_full_name](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.User.get_full_name) and [get_short_name](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.User.get_short_name) 