### PR TITLE
fix issue #927

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -16,7 +16,10 @@ except ImportError:
     HAS_PYGRAPHVIZ = False
 
 try:
-    import pydot
+    try:
+        import pydotplus as pydot
+    except ImportError:
+        import pydot
     HAS_PYDOT = True
 except ImportError:
     HAS_PYDOT = False


### PR DESCRIPTION
according to http://stackoverflow.com/questions/38176472/graph-write-pdfiris-pdf-attributeerror-list-object-has-no-attribute-writ
try import pydotplus as default pydot