### PR TITLE
Add SHELL_PLUS_PRINT_SQL option

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -88,8 +88,10 @@ class Command(BaseCommand):
         use_pythonrc = options.get('use_pythonrc', True)
         no_browser = options.get('no_browser', False)
         verbosity = int(options.get('verbosity', 1))
+        print_sql = getattr(settings, 'SHELL_PLUS_PRINT_SQL', False)
 
-        if options.get("print_sql", False):
+        if options.get("print_sql", False) or print_sql:
+
             # Code from http://gist.github.com/118990
             sqlparse = None
             try:

--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -157,3 +157,19 @@ Database application signature
 
 If using PostgreSQL the ``application_name`` is set by default to
 ``django_shell`` to help  identify queries made under shell_plus.
+
+
+SQL queries
+-------------------------
+
+It is possible to print SQL queries as they're executed in shell_plus like::
+
+  $ ./manage.py shell_plus --print-sql
+
+
+You can also set the configuration option SHELL_PLUS_PRINT_SQL to omit the above command line option.
+
+::
+
+  # print SQL queries in shell_plus
+  SHELL_PLUS_PRINT_SQL = True


### PR DESCRIPTION
Add the configuration option  SHELL_PLUS_PRINT_SQL equivalent to command line option `--print-sql`.