### PR TITLE
Fix reading templates setting after django 1.8

### DIFF
--- a/django_extensions/compat.py
+++ b/django_extensions/compat.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import importlib
 import django
 
+from django.conf import settings
+
 
 #
 # Django compatibility
@@ -38,3 +40,15 @@ def add_to_builtins_compat(name):
     else:
         from django.template import engines
         engines['django'].engine.builtins.append(name)
+
+
+def get_template_setting(template_key, default=None):
+    """ Read template settings pre and post django 1.8 """
+    templates_var = getattr(settings, 'TEMPLATES', None)
+    if templates_var is not None and template_key in templates_var[0]:
+        return templates_var[0][template_key]
+    if template_key == 'DIRS':
+        pre18_template_key = 'TEMPLATES_%s' % template_key
+        value = getattr(settings, pre18_template_key, default)
+        return value
+    return default

--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -7,6 +7,7 @@ import re
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from django_extensions.compat import get_template_setting
 from django_extensions.management.utils import signalcommand
 
 ANNOTATION_RE = re.compile("\{?#[\s]*?(TODO|FIXME|BUG|HACK|WARNING|NOTE|XXX)[\s:]?(.+)")
@@ -22,7 +23,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # don't add django internal code
         apps = [app for app in filter(lambda app: not app.startswith('django.contrib'), settings.INSTALLED_APPS)]
-        template_dirs = getattr(settings, 'TEMPLATE_DIRS', [])
+        template_dirs = get_template_setting('DIRS', [])
         if template_dirs:
             apps += template_dirs
         for app_dir in apps:

--- a/docs/validate_templates.rst
+++ b/docs/validate_templates.rst
@@ -8,7 +8,7 @@ Options
 
 verbosity
 ~~~~~~~~~
-A higher verbosity level will print out all the files that are processed 
+A higher verbosity level will print out all the files that are processed
 instead of only the ones that contain errors.
 
 break
@@ -17,7 +17,7 @@ Do not continue scanning other templates after the first failure.
 
 includes
 ~~~~~~~~
-Use -i (can be used multiple times) to add directories to the TEMPLATE_DIRS.
+Use -i (can be used multiple times) to add directories to the TEMPLATE DIRS.
 
 Settings
 --------
@@ -25,10 +25,10 @@ Settings
 VALIDATE_TEMPLATES_EXTRA_TEMPLATE_DIRS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can use `VALIDATE_TEMPLATES_EXTRA_TEMPLATE_DIRS` to include a number of template 
-dirs by default directly from the settings file. This can be useful for situations 
-where TEMPLATE_DIRS is dynamically generated or switched in middleware, or when you 
-have other template dirs for external applications like celery, and you want to 
+You can use `VALIDATE_TEMPLATES_EXTRA_TEMPLATE_DIRS` to include a number of template
+dirs by default directly from the settings file. This can be useful for situations
+where TEMPLATE DIRS is dynamically generated or switched in middleware, or when you
+have other template dirs for external applications like celery, and you want to
 check those as well.
 
 Usage Example

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase, override_settings
+
+from django_extensions.compat import get_template_setting
+
+
+class GetTemplateSettingTests(TestCase):
+    @override_settings(TEMPLATES=[{'DIRS': ['asdf']}])
+    def test_new_dir_template(self):
+        setting = get_template_setting('DIRS')
+        self.assertEqual(setting, ['asdf'])
+
+    @override_settings(TEMPLATES=None, TEMPLATES_DIRS=['asdf'])
+    def test_old_dir_template(self):
+        setting = get_template_setting('DIRS')
+        self.assertEqual(setting, ['asdf'])
+
+    @override_settings(TEMPLATES=None)
+    def test_old_dir_missing(self):
+        setting = get_template_setting('DIRS', 'default')
+        self.assertEqual(setting, 'default')
+
+    def test_default_setting(self):
+        setting = get_template_setting('ASDF', 'default')
+        self.assertEqual(setting, 'default')


### PR DESCRIPTION
This replaces code that directly reads `TEMPLATE_DIRS` with a function that can read either that setting or the newer `TEMPLATES` setting.

Fixes #942 