### PR TITLE
Some commands were missing (there are others too)

### DIFF
--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -81,6 +81,8 @@ Current Command Extensions
 * `runserver_plus`_ - The standard runserver stuff but with
   the Werkzeug debugger baked in. Requires Werkzeug_. This one kicks ass.
 
+* *set_fake_emails* - Give all users a new email based on their account data ("%(username)s@example.com" by default). Possible parameters are: username, first_name, last_name. *DEBUG only*
+
 * *set_fake_passwords* -  Sets all user passwords to a common value (*password* by default). *DEBUG only*.
 
 * *show_urls* - Displays the url routes that are defined in your project. Very
@@ -102,6 +104,8 @@ Current Command Extensions
   caching.
 
 * *update_permissions* - Reloads permissions for specified apps, or all apps if no args are specified.
+
+* *set_default_site* - Set parameters of the default `django.contrib.sites` Site using `name` and `domain` or `system-fqdn`.
 
 
 .. _`create_app`: create_app.html


### PR DESCRIPTION
I didn't add all the missing ones, but I found some useful ones were missing documentation entries:
```
 python manage.py set_default_site -h
usage: manage.py set_default_site [-h] [--version] [-v {0,1,2,3}]
                                  [--settings SETTINGS]
                                  [--pythonpath PYTHONPATH] [--traceback]
                                  [--no-color] [--name SITE_NAME]
                                  [--domain SITE_DOMAIN] [--system-fqdn]

Set parameters of the default django.contrib.sites Site

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --name SITE_NAME      Use this as site name.
  --domain SITE_DOMAIN  Use this as site domain.
  --system-fqdn         Use the systems FQDN (Fully Qualified Domain Name) as
                        name and domain. Can be used in combination with
                        --name
```

```
 python manage.py set_fake_emails -h
usage: manage.py set_fake_emails [-h] [--version] [-v {0,1,2,3}]
                                 [--settings SETTINGS]
                                 [--pythonpath PYTHONPATH] [--traceback]
                                 [--no-color] [--email DEFAULT_EMAIL] [-a]
                                 [-s] [--include INCLUDE_REGEXP]
                                 [--exclude EXCLUDE_REGEXP]
                                 [--include-groups INCLUDE_GROUPS]
                                 [--exclude-groups EXCLUDE_GROUPS]

DEBUG only: give all users a new email based on their account data
("%(username)s@example.com" by default). Possible parameters are: username,
first_name, last_name

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --email DEFAULT_EMAIL
                        Use this as the new email format.
  -a, --no-admin        Do not change administrator accounts
  -s, --no-staff        Do not change staff accounts
  --include INCLUDE_REGEXP
                        Include usernames matching this regexp.
  --exclude EXCLUDE_REGEXP
                        Exclude usernames matching this regexp.
  --include-groups INCLUDE_GROUPS
                        Include users matching this group. (use comma
                        seperation for multiple groups)
  --exclude-groups EXCLUDE_GROUPS
                        Exclude users matching this group. (use comma
                        seperation for multiple groups)
```

There are other small commands missing.