### PR TITLE
Fix argument error when running dumpscript

### DIFF
--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -92,7 +92,10 @@ class Command(BaseCommand):
 
     @signalcommand
     def handle(self, *args, **options):
-        app_labels = options['appname']
+        if 'appname' in options:
+            app_labels = options['appname']
+        else:
+            app_labels = args
 
         # Get the models we want to export
         models = get_models(app_labels)


### PR DESCRIPTION
Without this fix, the dumpscript command fail:

```
manage.py dumpscript auth.User
[...]
  File "/usr/lib/python2.7/site-packages/django_extensions-1.7.4-py2.7.egg/django_extensions/management/commands/dumpscript.py", line 95, in handle
    app_labels = options['appname']
KeyError: 'appname'
```
