### PR TITLE
Do not deprecate JSONField

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -55,9 +55,6 @@ class JSONField(models.TextField):
     JSON objects seamlessly.  Main thingy must be a dict object."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Django 1.9 features a native JsonField, this JSONField will "
-            "be removed somewhere after Django 1.8 becomes unsupported.",
-            DeprecationWarning)
         kwargs['default'] = kwargs.get('default', dict)
         models.TextField.__init__(self, *args, **kwargs)
 

--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 
 import json
 import six
-import warnings
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder


### PR DESCRIPTION
Django's JSONField only works for PostgreSQK 9.4 and up and as such this field here still has value and can be used for any other DBs and should not be deprecated.
