### PR TITLE
Fix that aliases from SHELL_PLUS_MODEL_ALIASES were not applied.

### DIFF
--- a/django_extensions/management/shells.py
+++ b/django_extensions/management/shells.py
@@ -138,7 +138,6 @@ def import_objects(options, style):
         if app_name in dont_load:
             continue
 
-        app_aliases = model_aliases.get(app_name, {})
         for mod in app_models:
             if "%s.%s" % (app_name, mod.__name__) in dont_load:
                 continue
@@ -170,10 +169,11 @@ def import_objects(options, style):
 
                 alias = app_aliases.get(model_name)
 
-                if not alias and prefix:
-                    alias = "%s_%s" % (prefix, model_name)
-                else:
-                    alias = model_name
+                if not alias:
+                    if prefix:
+                        alias = "%s_%s" % (prefix, model_name)
+                    else:
+                        alias = model_name
 
                 imported_objects[alias] = imported_object
                 if model_name == alias:


### PR DESCRIPTION
L141 removal is just a cleanup, `app_aliases` was not used in this scope.

Aliases were never applied because `alias` was always reset to `model_name` when they were no prefix on L176.