### PR TITLE
Add autocomplete for inline model admins. Fixes #109

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -15,12 +15,12 @@ from django.db.models.query import QuerySet
 from django.utils.encoding import smart_str
 from django.utils.translation import ugettext as _
 from django.utils.text import get_text_list
-from django.contrib.admin import ModelAdmin
+from django.contrib import admin
 
 from django_extensions.admin.widgets import ForeignKeySearchInput
 
 
-class ForeignKeyAutocompleteAdmin(ModelAdmin):
+class ForeignKeyAutocompleteAdminMixin(object):
     """Admin class for models using the autocomplete feature.
 
     There are two additional fields:
@@ -60,7 +60,7 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
         return [
             url(r'foreignkey_autocomplete/$', wrap(self.foreignkey_autocomplete),
                 name='%s_%s_autocomplete' % (self.model._meta.app_label, self.model._meta.model_name))
-        ] + super(ForeignKeyAutocompleteAdmin, self).get_urls()
+        ] + super(ForeignKeyAutocompleteAdminMixin, self).get_urls()
 
     def foreignkey_autocomplete(self, request):
         """
@@ -151,4 +151,16 @@ class ForeignKeyAutocompleteAdmin(ModelAdmin):
                 help_text = six.u('%s %s' % (kwargs['help_text'], help_text))
             kwargs['widget'] = ForeignKeySearchInput(db_field.rel, self.related_search_fields[db_field.name])
             kwargs['help_text'] = help_text
-        return super(ForeignKeyAutocompleteAdmin, self).formfield_for_dbfield(db_field, **kwargs)
+        return super(ForeignKeyAutocompleteAdminMixin, self).formfield_for_dbfield(db_field, **kwargs)
+
+
+class ForeignKeyAutocompleteAdmin(ForeignKeyAutocompleteAdminMixin, admin.ModelAdmin):
+    pass
+
+
+class ForeignKeyAutocompleteTabularInline(ForeignKeyAutocompleteAdminMixin, admin.TabularInline):
+    pass
+
+
+class ForeignKeyAutocompleteStackedInline(ForeignKeyAutocompleteAdminMixin, admin.StackedInline):
+    pass

--- a/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
+++ b/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
@@ -5,6 +5,9 @@
 </a>
 <script type="text/javascript">
 (function($) {
+    var current_value = $('#id_{{ name }}').val();
+    var new_value = null;
+
     // Show lookup input
     $('#lookup_{{ name }}').show();
     function reset() {
@@ -18,7 +21,7 @@
             'object_pk': query
         }, function(data) {
             $('#lookup_{{ name }}').val(data);
-            {{ name }}_value = query;
+            current_value = query;
         });
     };
     $('#id_{{ name }}').bind('keyup', function(event) {
@@ -47,12 +50,11 @@
             $('#id_{{ name }}').val(item.data[0]);
         }
     });
-    var {{ name }}_value = $('#id_{{ name }}').val();
     function check() {
-        {{ name }}_check = $('#id_{{ name }}').val();
-        if ({{ name }}_check) {
-            if ({{ name }}_check != {{ name }}_value) {
-                lookup({{ name }}_check);
+        new_value = $('#id_{{ name }}').val();
+        if (new_value) {
+            if (new_value != current_value) {
+                lookup(new_value);
             }
         }
     };


### PR DESCRIPTION
It turns out that the existing admin autocomplete code works perfectly with inline admins; the base class just needs to be refactored into a mixin and a couple little JavaScript things fixed.