### PR TITLE
Add django.contrib.auth.get_user_model to shell+

### DIFF
--- a/django_extensions/management/shells.py
+++ b/django_extensions/management/shells.py
@@ -199,6 +199,7 @@ def import_objects(options, style):
         SHELL_PLUS_DJANGO_IMPORTS = {
             'django.core.cache': ['cache'],
             'django.conf': ['settings'],
+            'django.contrib.auth': ['get_user_model'],
             'django.db': ['transaction'],
             'django.db.models': [
                 'Avg', 'Case', 'Count', 'F', 'Max', 'Min', 'Prefetch', 'Q',


### PR DESCRIPTION
Sometimes `get_user_model` is much more convenient than fetching the model class by name.

There are some use cases, where people could find it useful. I for example use it to fetch swapped `User` model and to find out which one is currently active and writing `from django.contrib.auth import get_user_model` is quite cumbersome.

Also, it makes it easier to approach a new project, especially if it overrides `User` model in unconventional way.