### PR TITLE
fix the orphen reference to get_apps() function

### DIFF
--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -64,9 +64,16 @@ class Command(BaseCommand):
     @transaction.atomic
     def handle(self, *fixture_labels, **options):
         """ Main method of a Django command """
-        from django.db.models import get_apps
         from django.core import serializers
         from django.conf import settings
+        from django.apps import apps
+        
+        def get_app_modules():
+            result = list()
+            for app in apps.get_app_configs():
+                result.append(app.module)
+                pass
+            return result
 
         self.style = no_style()
 
@@ -86,7 +93,7 @@ class Command(BaseCommand):
         # it isn't already initialized).
         cursor = connection.cursor()
 
-        app_fixtures = [os.path.join(os.path.dirname(app.__file__), 'fixtures') for app in get_apps()]
+        app_fixtures = [os.path.join(os.path.dirname(app.__file__), 'fixtures') for app in get_app_modules()]
         for fixture_label in fixture_labels:
             parts = fixture_label.split('.')
             if len(parts) == 1:


### PR DESCRIPTION
When dropping support for django 1.6 and 1.7, the call to get_apps() function was left behind.

Under Python2.7 and Django 1.9.7, this bug causes ImportError, which renders `syncdata` command unusable.

seealso:
https://github.com/django-extensions/django-extensions/commit/f4f82d0089695a5608cb3b0389b4163d1c2eb90a
https://github.com/django-extensions/django-extensions/commit/975a308756984da72f0b9a25a067e27dd09791db
https://github.com/django-extensions/django-extensions/commit/358178d5e676287b3113551da6c05d692f2336e6
https://github.com/django-extensions/django-extensions/commit/3a0ca9e40a11729d30cc3f2d916c446321805f97