### PR TITLE
Improved displaying of related field names in diagram

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -19,7 +19,7 @@ from django.db.models.fields.related import (
 )
 from django.contrib.contenttypes.fields import GenericRelation
 from django.template import Context, Template, loader
-from django.utils.encoding import force_bytes
+from django.utils.encoding import force_bytes, force_str
 from django.utils.safestring import mark_safe
 from django.utils.translation import activate as activate_language
 
@@ -143,7 +143,7 @@ class ModelGraph(object):
             related_query_name = field.related_query_name()
             if self.verbose_names and related_query_name.islower():
                 related_query_name = related_query_name.replace('_', ' ').capitalize()
-            label = '{} ({})'.format(label, force_bytes(related_query_name))
+            label = '{} ({})'.format(label, force_str(related_query_name))
 
         # handle self-relationships and lazy-relationships
         if isinstance(field.rel.to, six.string_types):

--- a/tests/management/test_modelviz.py
+++ b/tests/management/test_modelviz.py
@@ -6,7 +6,6 @@ from django_extensions.management.modelviz import generate_graph_data
 
 
 class ModelVizTests(SimpleTestCase):
-    @skipIf(six.PY3, 'FIXME Python 3 renders labels funny, see below')
     def test_generate_graph_data_can_render_label(self):
         app_labels = ['auth']
         data = generate_graph_data(app_labels)
@@ -15,13 +14,3 @@ class ModelVizTests(SimpleTestCase):
         user_data = [x for x in models if x['name'] == 'User'][0]
         relation_labels = [x['label'] for x in user_data['relations']]
         self.assertIn("groups (user)", relation_labels)
-
-    @skipUnless(six.PY3, 'DELETEME Python 3 should render the same as Python 2')
-    def test_generate_graph_data_formats_labels_as_bytes(self):
-        app_labels = ['auth']
-        data = generate_graph_data(app_labels)
-
-        models = data['graphs'][0]['models']
-        user_data = [x for x in models if x['name'] == 'User'][0]
-        relation_labels = [x['label'] for x in user_data['relations']]
-        self.assertIn("groups (b'user')", relation_labels)

--- a/tests/management/test_modelviz.py
+++ b/tests/management/test_modelviz.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from unittest import skipIf, skipUnless
-import six
 from django.test import SimpleTestCase
 from django_extensions.management.modelviz import generate_graph_data
 


### PR DESCRIPTION
Hello!
This little MR drops 'b' prefix and the quotes from the related query names in diagram (otherwise it looks liek this: ![looks](https://cloud.githubusercontent.com/assets/160056/22288798/ef974b00-e311-11e6-92ba-c775f7af0253.png)).