### PR TITLE
Quote table name when using PRAGMA table_info

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -654,7 +654,7 @@ class SqliteSQLDiff(SQLDiff):
             tablespace = "public"
             # index, column_name, column_type, nullable, default_value
             # see: http://www.sqlite.org/pragma.html#pragma_table_info
-            for table_info in self.sql_to_dict("PRAGMA table_info(%s);" % table_name, []):
+            for table_info in self.sql_to_dict("PRAGMA table_info('%s');" % table_name, []):
                 key = (tablespace, table_name, table_info['name'])
                 self.null[key] = not table_info['notnull']
 


### PR DESCRIPTION
Table names with hyphens will cause the `sqldiff` management command to fail when using sqlite3. Creates the following error:

````django.db.utils.OperationalError: near "-": syntax error````

Fix is simply to quote the table name. Issue may exist for other database types as well (such as MySQL).