### PR TITLE
"ip:port" specification for runprofileserver

### DIFF
--- a/django_extensions/management/commands/runprofileserver.py
+++ b/django_extensions/management/commands/runprofileserver.py
@@ -260,7 +260,7 @@ class Command(BaseCommand):
                     if use_static_handler and (settings.DEBUG or insecure_serving):
                         handler = StaticFilesHandler(handler)
                 handler = make_profiler_handler(handler)
-                run(addr, int(port), handler)
+                run(addr, int(port), handler, threading=options.get('use_threading', True))
             except socket.error as e:
                 # Use helpful error messages instead of ugly tracebacks.
                 ERRORS = {

--- a/django_extensions/management/commands/runprofileserver.py
+++ b/django_extensions/management/commands/runprofileserver.py
@@ -103,6 +103,10 @@ class Command(BaseCommand):
             default=True,
             help='Tells Django to NOT use the auto-reloader.')
         parser.add_argument(
+            '--nothreading', action='store_false', dest='use_threading', default=True,
+            help='Tells Django to NOT use threading.',
+        )
+        parser.add_argument(
             '--prof-path', dest='prof_path', default='/tmp',
             help='Specifies the directory which to save profile information '
             'in.')

--- a/django_extensions/management/commands/runprofileserver.py
+++ b/django_extensions/management/commands/runprofileserver.py
@@ -95,6 +95,10 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
         parser.add_argument(
+            'addrport', nargs='?',
+            help='Optional port number, or ipaddr:port'
+        )
+        parser.add_argument(
             '--noreload', action='store_false', dest='use_reloader',
             default=True,
             help='Tells Django to NOT use the auto-reloader.')


### PR DESCRIPTION
I noticed that countrary to what the descriptions say, `runprofileserver` doesn't accept the usual `host:ip` pair of the `runserver` command. I added the relevant bit straight from the latter command's code. Seems to work in my setup.

Please let me know if I'm doing something wrong, looked like a bug for me.

UPD: re-added `--nothreading` too.