### PR TITLE
Treat rc versions as unstable in pipchecker

### DIFF
--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -110,7 +110,7 @@ class Command(BaseCommand):
         return json.loads(urlopen(req).read())
 
     def _is_stable(self, version):
-        return not re.search(r'[ab]\d+$', str(version))
+        return not re.search(r'([ab]|rc)\d+$', str(version))
 
     def _available_version(self, dist_version, available):
         if self._is_stable(dist_version):


### PR DESCRIPTION
This prevents pipchecker from suggesting upgrading to a release candidate when the currently installed version is stable.