### PR TITLE
Add --reloader-type command line argument

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -40,6 +40,7 @@ naiveip_re = re.compile(r"""^(?:
 ):)?(?P<port>\d+)$""", re.X)
 DEFAULT_PORT = "8000"
 DEFAULT_POLLER_RELOADER_INTERVAL = getattr(settings, 'RUNSERVERPLUS_POLLER_RELOADER_INTERVAL', 1)
+DEFAULT_POLLER_RELOADER_TYPE = getattr(settings, 'RUNSERVERPLUS_POLLER_RELOADER_TYPE', 'auto')
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,8 @@ class Command(BaseCommand):
                             help='auto-reload whenever the given file changes too (can be specified multiple times)')
         parser.add_argument('--reloader-interval', dest='reloader_interval', action="store", type=int, default=DEFAULT_POLLER_RELOADER_INTERVAL,
                             help='After how many seconds auto-reload should scan for updates in poller-mode [default=%s]' % DEFAULT_POLLER_RELOADER_INTERVAL)
+        parser.add_argument('--reloader-type', dest='reloader_type', action="store", type=str, default=DEFAULT_POLLER_RELOADER_TYPE,
+                            help='Werkzeug reloader type [options are auto, watchdog, or stat, default=%s]' % DEFAULT_POLLER_RELOADER_TYPE)
         parser.add_argument('--pdb', action='store_true', dest='pdb', default=False,
                             help='Drop into pdb shell at the start of any view.')
         parser.add_argument('--ipdb', action='store_true', dest='ipdb', default=False,
@@ -251,6 +254,7 @@ class Command(BaseCommand):
             self.addr if not self._raw_ipv6 else '[%s]' % self.addr, self.port)
         extra_files = options.get('extra_files', None) or []
         reloader_interval = options.get('reloader_interval', 1)
+        reloader_type = options.get('reloader_type', 'auto')
 
         self.nopin = options.get('nopin', False)
 
@@ -341,6 +345,7 @@ class Command(BaseCommand):
             use_debugger=True,
             extra_files=extra_files,
             reloader_interval=reloader_interval,
+            reloader_type=reloader_type,
             threaded=threaded,
             request_handler=WSGIRequestHandler,
             ssl_context=ssl_context,


### PR DESCRIPTION
This pull request adds a `--reloader-type` command line argument which can be set to either "stat", "watchdog", or "auto", and gets passed through to Werkzeug's run_simple() function to let users manually choose a reloader type. If omitted, the option defaults to "auto". Since that's the current choice, behavior does not change for existing users.

Motivation:

runserver_plus does not currently work in environments where watchdog is installed but inotify is not available. Having watchdog installed causes Werkzeug's run_simple function to default to the "watchdog" reloader_type, which depends on inotify, so runserver_plus then fails to restart on file change.

I happen to be in such an environment -- I am running Django in a Vagrant box with an NFS mount, which does not support inotify, but I have to have watchdog installed because it happens to be included in the dependencies for an unrelated package I'm using. I think this might be a common enough configuration to be worth supporting.

This pull request lets people like me set `--reloader-type stat` and continue to use runserver_plus.

Alternatives:

I considered two alternatives which you might prefer:

* Set reloader_type to "stat" if reloader_interval is supplied. Setting `--reloader-interval` is pointless if Werkzeug is using watchdog. So runserver_plus could assume that if you're setting --reloader-interval, you also want to use the filesystem-based watcher. I rejected this because it might break things for existing users who are setting `--reloader-interval` but are actually benefitting from having it be ignored.

 * Use Django's inotify detection. Django has a [conservative test for inotify support](https://github.com/django/django/blob/master/django/utils/autoreload.py#L56) based on pyinotify. So you could set `reloader_type = "auto" if django.utils.autoreload.USE_INOTIFY else "stat"`, and runserver_plus would be guaranteed to only attempt inotify reloading if `runserver` would. This is appealing because it makes sure that runserver_plus will work as well as runserver. But since pyinotify isn't installed by default with Django, this reports False unless the user happens to have separately installed pyinotify as well as watchdog, which seems like maybe a dealbreaker. 