### PR TITLE
Fix #1011 AutoSlugField for foreignkey relationships

### DIFF
--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -9,7 +9,16 @@ Current Database Model Field Extensions
 
 * *AutoSlugField* - AutoSlugfield will automatically create a unique slug
   incrementing an appended number on the slug until it is unique. Inspired by
-  SmileyChris' Unique Slugify snippet.
+  SmileyChris' Unique Slugify snippet. 
+
+  AutoSlugField takes a `popuate_from` argument that specifies which field, list of
+  fields, or model method the slug will be populated from, for instance::
+
+    slug = AutoSlugField(populate_from=['title', 'description', 'get_author_name'])
+ 
+  `populate_from` can traverse a ForeignKey relationship by using Django ORM syntax::
+
+    slug = AutoSlugField(populate_from=['related_model__title', 'related_model__get_readable_name'])
 
 * *RandomCharField* - AutoRandomCharField will automatically create a
   unique random character field with the specified length. By default

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -63,6 +63,33 @@ class ChildSluggedTestModel(SluggedTestModel):
         app_label = 'django_extensions'
 
 
+class ModelMethodSluggedTestModel(models.Model):
+    title = models.CharField(max_length=42)
+    slug = AutoSlugField(populate_from='get_readable_title')
+
+    class Meta:
+        app_label = 'django_extensions'
+
+    def get_readable_title(self):
+        return "The title is {}".format(self.title)
+
+
+class FKSluggedTestModel(models.Model):
+    related_field = models.ForeignKey(SluggedTestModel)
+    slug = AutoSlugField(populate_from="related_field__title")
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
+class FKSluggedTestModelCallable(models.Model):
+    related_field = models.ForeignKey(ModelMethodSluggedTestModel)
+    slug = AutoSlugField(populate_from="related_field__get_readable_title")
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
 class JSONFieldTestModel(models.Model):
     a = models.IntegerField()
     j_field = JSONField()


### PR DESCRIPTION
Fixes #1011 

This PR allows the user to span ForeignKey relationships with AutoSlugField's `populate_from` argument. It also allows the user use model methods in the `populate_from` argument. 

@trbs please let me know any feedback or suggestions? Thanks again for your work on this library, and for considering this PR!