### PR TITLE
supported_backends changed.

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -362,7 +362,8 @@ class Command(BaseCommand):
 
             http://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS  # noqa
             """
-            supported_backends = ['django.db.backends.postgresql_psycopg2']
+            supported_backends = ['django.db.backends.postgresql',
+                                  'django.db.backends.postgresql_psycopg2']
             opt_name = 'fallback_application_name'
             default_app_name = 'django_shell'
             app_name = default_app_name


### PR DESCRIPTION
in django 1.9, 'django.db.backends.postgresql_psycopg2' renamed to 'django.db.backends.postgresql'.