### PR TITLE
Fix for hanging when printing large SQL quires

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -148,7 +148,8 @@ class Command(BaseCommand):
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
 
                         if sqlparse:
-                            raw_sql = sqlparse.format(raw_sql, reindent=True)
+                            raw_sql = raw_sql[:1000]
+                            raw_sql = sqlparse.format(raw_sql, reindent_aligned=True, truncate_strings=500)
 
                         if pygments:
                             raw_sql = pygments.highlight(

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -138,6 +138,8 @@ class Command(BaseCommand):
             except ImportError:
                 pygments = None
 
+            truncate = getattr(settings, 'RUNSERVER_PLUS_PRINT_SQL_TRUNCATE', 1000)
+
             class PrintQueryWrapper(utils.CursorDebugWrapper):
                 def execute(self, sql, params=()):
                     starttime = time.time()
@@ -148,7 +150,7 @@ class Command(BaseCommand):
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
 
                         if sqlparse:
-                            raw_sql = raw_sql[:1000]
+                            raw_sql = raw_sql[:truncate]
                             raw_sql = sqlparse.format(raw_sql, reindent_aligned=True, truncate_strings=500)
 
                         if pygments:

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -98,6 +98,7 @@ class Command(BaseCommand):
         no_browser = options.get('no_browser', False)
         verbosity = int(options.get('verbosity', 1))
         print_sql = getattr(settings, 'SHELL_PLUS_PRINT_SQL', False)
+        truncate = getattr(settings, 'SHELL_PLUS_PRINT_SQL_TRUNCATE', 1000)
 
         if options.get("print_sql", False) or print_sql:
 
@@ -123,7 +124,7 @@ class Command(BaseCommand):
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
 
                         if sqlparse:
-                            raw_sql = raw_sql[:1000]
+                            raw_sql = raw_sql[:truncate]
                             raw_sql = sqlparse.format(raw_sql, reindent_aligned=True, truncate_strings=500)
 
                         if pygments:

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -123,7 +123,8 @@ class Command(BaseCommand):
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
 
                         if sqlparse:
-                            raw_sql = sqlparse.format(raw_sql, reindent=True)
+                            raw_sql = raw_sql[:1000]
+                            raw_sql = sqlparse.format(raw_sql, reindent_aligned=True, truncate_strings=500)
 
                         if pygments:
                             raw_sql = pygments.highlight(


### PR DESCRIPTION
When printing large quires it would hang, this just cuts it off to ensure it doesn't go out of hand. A common large query is bulk insert.