### PR TITLE
Add ptpython to the shell_plus docs

### DIFF
--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -14,9 +14,14 @@ IPython::
   $ ./manage.py shell_plus --ipython
 
 
-BPython::
+bpython::
 
   $ ./manage.py shell_plus --bpython
+
+
+ptpython::
+
+  $ ./manage.py shell_plus --ptpython
 
 
 Python::
@@ -24,7 +29,7 @@ Python::
   $ ./manage.py shell_plus --plain
 
 
-The default resolution order is: bpython, ipython, python.
+The default resolution order is: ptpython, bpython, ipython, python.
 
 You can also set the configuration option SHELL_PLUS to explicitly specify which version you want.
 


### PR DESCRIPTION
This is already implemented in https://github.com/django-extensions/django-extensions/blob/master/django_extensions/management/commands/shell_plus.py but not documented. This PR corrects that.
I tested the resolution order to confirm this update is correct.
I also changed the capitalisation on bpython since that's how the project refers to itself: https://bpython-interpreter.org/about.html