### PR TITLE
Remove JSONField from deprecation path

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 
 import json
 import six
-import warnings
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
@@ -55,9 +54,6 @@ class JSONField(models.TextField):
     JSON objects seamlessly.  Main thingy must be a dict object."""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Django 1.9 features a native JsonField, this JSONField will "
-            "be removed somewhere after Django 1.8 becomes unsupported.",
-            DeprecationWarning)
         kwargs['default'] = kwargs.get('default', dict)
         models.TextField.__init__(self, *args, **kwargs)
 

--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -9,13 +9,13 @@ Current Database Model Field Extensions
 
 * *AutoSlugField* - AutoSlugfield will automatically create a unique slug
   incrementing an appended number on the slug until it is unique. Inspired by
-  SmileyChris' Unique Slugify snippet. 
+  SmileyChris' Unique Slugify snippet.
 
   AutoSlugField takes a `populate_from` argument that specifies which field, list of
   fields, or model method the slug will be populated from, for instance::
 
     slug = AutoSlugField(populate_from=['title', 'description', 'get_author_name'])
- 
+
   `populate_from` can traverse a ForeignKey relationship by using Django ORM syntax::
 
     slug = AutoSlugField(populate_from=['related_model__title', 'related_model__get_readable_name'])
@@ -93,7 +93,4 @@ Current Database Model Field Extensions
 
 * *ShortUUIDField* - CharField which transparently generates a UUID and pass it to base57. It result in shorter 22 characters values useful e.g. for concise, unambiguous URLS. It's possible to get shorter values with length parameter: they are not Universal Unique any more but probability of collision is still low
 
-* *JSONField* - a generic TextField that neatly serializes/unserializes JSON objects seamlessly
-
-  .. deprecated:: 1.7.3
-     Django 1.9 features a native JSONField. Django-Extensions will support *JSONField* at the very least until Django 1.8 becomes unsupported.
+* *JSONField* - a generic TextField that neatly serializes/unserializes JSON objects seamlessly. Django 1.9 introduces a native JSONField for PostgreSQL, which is preferred for PostgreSQL users on Django 1.9 and above.


### PR DESCRIPTION
Also add note to docs about native JSONField being preferred for users of Django 1.9 and PostgreSQL.

Resolves https://github.com/django-extensions/django-extensions/issues/1061