### PR TITLE
Include default value in missing field for sqldiff

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -372,6 +372,8 @@ class SQLDiff(object):
                 else:
                     op = 'field-missing-in-db'
                 field_output.append(field.db_type(connection=connection))
+                if field.has_default():
+                    field_output.append('DEFAULT %s' % field.get_prep_value(field.get_default()))
                 if not field.null:
                     field_output.append('NOT NULL')
                 self.add_difference(op, table_name, field_name, *field_output)


### PR DESCRIPTION
Note: This isn't a ready-to-go pull request, and I'm not sure it'll pass the tests, I just wanted to start a discussion.

Is there any reason the default isn't included in the `sqldiff` output for missing fields? This bites me all the time when adding fields with `sqlite3` during development since the generated output is often not valid (if the field is `NOT NULL` then `sqlite3` will require a default value if the table exists).

The PR is fairly simple, although it doesn't act like how I'd expect for a `BooleanField`. The default should get converted to 0 or 1 for `sqlite3` but it instead outputs `False` instead of 0. I would have thought `get_prep_value` would handle this conversion, but it does not appear to. Neither does `get_db_prep_value`. Perhaps someone with more experience here could spot why this isn't the case.