### PR TITLE
Use 'display_size', not 'precision' to identify MySQL bool field

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -638,7 +638,7 @@ class MySQLDiff(SQLDiff):
                 db_type = db_type.lstrip("var")
             # They like to call 'bool's 'tinyint(1)' and introspection makes that a integer
             # just convert it back to it's proper type, a bool is a bool and nothing else.
-            if db_type == 'integer' and description[1] == FIELD_TYPE.TINY and description[4] == 1:
+            if db_type == 'integer' and description[1] == FIELD_TYPE.TINY and description[2] == 1:
                 db_type = 'bool'
             if (table_name, field.column) in self.auto_increment:
                 db_type += ' AUTO_INCREMENT'


### PR DESCRIPTION
Was getting columns not recognized as `bool` on MySQL 5.6.34, looks like the `precision` field is 3 when the code was trying to match up to `tinyint(1)`. Seems like `display_size` might be a more reliable way to detect `tinyint(1)`.