### PR TITLE
reset_db command: Fix problem that 'utf8_support' option is ignored

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -122,7 +122,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
 
             connection = Database.connect(**kwargs)
             drop_query = 'DROP DATABASE IF EXISTS `%s`' % database_name
-            utf8_support = options.get('no_utf8_support', False) and '' or 'CHARACTER SET utf8'
+            utf8_support = 'CHARACTER SET utf8' if options.get('no_utf8_support', False) else ''
             create_query = 'CREATE DATABASE `%s` %s' % (database_name, utf8_support)
             logging.info('Executing... "' + drop_query + '"')
             connection.query(drop_query)


### PR DESCRIPTION
Always when I run `reset_db` command, `CHARACTER SET utf8` is append to `CREATE TABLE` statement whether passing `--no-utf8` option or not.
This option is handled at [this code](https://github.com/django-extensions/django-extensions/blob/master/django_extensions/management/commands/reset_db.py#L125), then fixed this line.