### PR TITLE
Fix pipchecker "up to date"

### DIFF
--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -273,7 +273,7 @@ class Command(BaseCommand):
 
                 if "message" in frozen_commit_data and frozen_commit_data["message"] == "Not Found":
                     msg = self.style.ERROR("{0} not found in {1}. Repo may be private.".format(frozen_commit_sha[:10], name))
-                elif frozen_commit_sha in [branch["commit"]["sha"] for branch in branch_data]:
+                elif frozen_commit_data["sha"] in [branch["commit"]["sha"] for branch in branch_data]:
                     msg = self.style.BOLD("up to date")
                 else:
                     msg = self.style.INFO("{0} is not the head of any branch".format(frozen_commit_data["sha"][:10]))


### PR DESCRIPTION
When requirement is from GitHub correctly check commit sha to see if the requirement is up to date if in the requirement string there is branch name instead of commit sha.

The variable `frozen_commit_sha` actually holds the value in the requirement which can be commit hash, branch name or a tag. If it is a branch name or a tag then `frozen_commit_sha != frozen_commit_data["sha"]` where `frozen_commit_data["sha"]` is the actual commit hash of the last commit in the branch or the commit hash marked by a tag.

Currently even if this is the last commit in a branch `pipchecker` will still say that `givenhash is not the head of any branch`. This patch will fix it.