### PR TITLE
Issue 1089: Fix --json option in graph_models

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -148,7 +148,7 @@ class Command(BaseCommand):
         cli_options = ' '.join(sys.argv[2:])
         graph_models = ModelGraph(args, cli_options=cli_options, **options)
         graph_models.generate_graph_data()
-        graph_data = graph_models.get_graph_data()
+        graph_data = graph_models.get_graph_data(as_json=use_json)
         if use_json:
             self.render_output_json(graph_data, **options)
             return

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -96,15 +96,20 @@ class ModelGraph(object):
                         if relation['target'] in nodes:
                             relation['needs_node'] = False
 
-    def get_graph_data(self):
+    def get_graph_data(self, as_json=False):
         now = datetime.datetime.now()
         graph_data = {
             'created_at': now.strftime("%Y-%m-%d %H:%M"),
             'cli_options': self.cli_options,
             'disable_fields': self.disable_fields,
             'use_subgraph': self.use_subgraph,
-            'graphs': self.graphs,
         }
+
+        if as_json:
+            graph_data['graphs'] = [context.flatten() for context in self.graphs]
+        else:
+            graph_data['graphs'] = self.graphs
+
         return graph_data
 
     def add_attributes(self, field, abstract_fields):


### PR DESCRIPTION
Fix `--json` option in graph_models to flatten contexts prior to serialization

See issue #1089 