### PR TITLE
Generate HTML coverage report by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv*
 .DS_Store
 .eggs/
 .idea/
+htmlcov/
 .coverage
 .cache/
 django-sample-app*/

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ try:
 
         def initialize_options(self):
             TestCommand.initialize_options(self)
-            self.pytest_args = 'tests django_extensions --ds=tests.testapp.settings --cov=django_extensions'
+            self.pytest_args = 'tests django_extensions --ds=tests.testapp.settings --cov=django_extensions --cov-report html --cov-report term'
 
         def finalize_options(self):
             TestCommand.finalize_options(self)


### PR DESCRIPTION
HTML coverage helps a lot during development. It would be nice to have it included by default.