### PR TITLE
Handle runscript import error messages consistently on Python 2 and 3

### DIFF
--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -89,13 +89,22 @@ class Command(EmailNotificationCommand):
                     if not isinstance(e, CommandError):
                         raise
 
-        def my_import(mod):
+        def my_import(parent_package, module):
+            mod = "%s.%s" % (parent_package, module)
             if verbosity > 1:
                 print(NOTICE("Check for %s" % mod))
-            # check if module exists before importing
+            # Try importing the parent package first
+            try:
+                importlib.import_module(parent_package)
+            except ImportError as e:
+                if str(e).startswith('No module named'):
+                    # No need to proceed if the parent package doesn't exist
+                    return False
+
             try:
                 t = importlib.import_module(mod)
             except ImportError as e:
+                # The parent package exists, but the module doesn't
                 if str(e).startswith('No module named'):
                     try:
                         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -107,8 +116,11 @@ class Command(EmailNotificationCommand):
                     finally:
                         exc_traceback = None
 
-                if not silent:
+                if silent:
+                    return False
+                if show_traceback:
                     traceback.print_exc()
+                if verbosity > 0:
                     print(ERROR("Cannot import module '%s': %s." % (mod, e)))
 
                 return False
@@ -127,23 +139,22 @@ class Command(EmailNotificationCommand):
             # first look in apps
             for app in apps.get_app_configs():
                 for subdir in subdirs:
-                    mod = my_import("%s.%s.%s" % (app.name, subdir, script))
+                    mod = my_import("%s.%s" % (app.name, subdir), script)
                     if mod:
                         modules.append(mod)
 
-            # try app.DIR.script import
-            sa = script.split(".")
-            for subdir in subdirs:
-                nn = ".".join(sa[:-1] + [subdir, sa[-1]])
-                mod = my_import(nn)
-                if mod:
-                    modules.append(mod)
-
             # try direct import
             if script.find(".") != -1:
-                mod = my_import(script)
+                parent, mod_name = script.rsplit(".", 1)
+                mod = my_import(parent, mod_name)
                 if mod:
                     modules.append(mod)
+            else:
+                # try app.DIR.script import
+                for subdir in subdirs:
+                    mod = my_import(subdir, script)
+                    if mod:
+                        modules.append(mod)
 
             return modules
 

--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -53,13 +53,12 @@ class Command(EmailNotificationCommand):
         if options.get('infixtures'):
             subdirs.append('fixtures')
         verbosity = int(options.get('verbosity', 1))
-        show_traceback = options.get('traceback', True)
-        if show_traceback is None:
-            # XXX: traceback is set to None from Django ?
-            show_traceback = True
+        show_traceback = options.get('traceback', False)
         no_traceback = options.get('no_traceback', False)
         if no_traceback:
             show_traceback = False
+        else:
+            show_traceback = True
         silent = options.get('silent', False)
         if silent:
             verbosity = 0
@@ -86,8 +85,9 @@ class Command(EmailNotificationCommand):
                 if email_notifications:
                     self.send_email_notification(
                         notification_id=mod.__name__, include_traceback=True)
-                if show_traceback or not isinstance(e, CommandError):
-                    raise
+                if show_traceback:
+                    if not isinstance(e, CommandError):
+                        raise
 
         def my_import(mod):
             if verbosity > 1:

--- a/tests/test_runscript.py
+++ b/tests/test_runscript.py
@@ -26,16 +26,60 @@ class RunScriptTests(TestCase):
             self.assertIn("Found script 'tests.testapp.scripts.sample_script'", sys.stdout.getvalue())
             self.assertIn("Running script 'tests.testapp.scripts.sample_script'", sys.stdout.getvalue())
 
+
+class NonExistentScriptsTests(RunScriptTests):
     def test_prints_error_on_nonexistent_script(self):
         call_command('runscript', 'non_existent_script', verbosity=2)
         self.assertIn("No (valid) module for script 'non_existent_script' found", sys.stdout.getvalue())
 
-    def test_prints_additional_info_on_nonexistent_script_and_low_verbosity(self):
-        call_command('runscript', 'non_existent_script', verbosity=1)
+    def test_prints_nothing_for_nonexistent_script_when_silent(self):
+        call_command('runscript', 'non_existent_script', silent=True)
+        self.assertEqual("", sys.stdout.getvalue())
+
+    def test_doesnt_print_exception_for_nonexistent_script_when_no_traceback(self):
+        call_command('runscript', 'non_existent_script', no_traceback=True)
+        self.assertEqual("", sys.stderr.getvalue())
+
+
+class InvalidImportScriptsTests(RunScriptTests):
+    def test_prints_additional_info_on_nonexistent_script_by_default(self):
+        call_command('runscript', 'non_existent_script')
         self.assertIn("No (valid) module for script 'non_existent_script' found", sys.stdout.getvalue())
         self.assertIn("Try running with a higher verbosity level like: -v2 or -v3", sys.stdout.getvalue())
 
-    def test_prints_import_error_on_script_with_invalid_imports(self):
-        call_command('runscript', 'invalid_import_script', verbosity=2)
+    def test_prints_import_error_on_script_with_invalid_imports_by_default(self):
+        call_command('runscript', 'invalid_import_script')
         self.assertIn("Cannot import module 'tests.testapp.scripts.invalid_import_script'", sys.stdout.getvalue())
         self.assertRegexpMatches(sys.stdout.getvalue(), 'No module named (\')?(invalidpackage)\1?')
+
+
+class InvalidScriptsTests(RunScriptTests):
+    def test_raises_error_message_on_invalid_script_by_default(self):
+        with self.assertRaises(Exception):
+            call_command('runscript', 'error_script')
+        self.assertIn("Exception while running run() in", sys.stdout.getvalue())
+
+    def test_prints_nothing_for_invalid_script_when_silent(self):
+        call_command('runscript', 'error_script', silent=True)
+        self.assertEqual("", sys.stdout.getvalue())
+
+    def test_doesnt_print_exception_for_nonexistent_script_when_no_traceback(self):
+        call_command('runscript', 'error_script', no_traceback=True)
+        self.assertEqual("", sys.stderr.getvalue())
+        self.assertIn("Exception while running run() in", sys.stdout.getvalue())
+
+
+class RunFunctionTests(RunScriptTests):
+    def test_prints_error_message_for_script_without_run(self):
+        call_command('runscript', 'script_no_run_function')
+        self.assertIn("No (valid) module for script 'script_no_run_function' found", sys.stdout.getvalue())
+        self.assertIn("Try running with a higher verbosity level like: -v2 or -v3", sys.stdout.getvalue())
+
+    def test_prints_additional_info_for_script__run_extra_verbosity(self):
+        call_command('runscript', 'script_no_run_function', verbosity=2)
+        self.assertIn("No (valid) module for script 'script_no_run_function' found", sys.stdout.getvalue())
+        self.assertIn("Found script", sys.stdout.getvalue())
+
+    def test_prints_nothing_for_script_without_run(self):
+        call_command('runscript', 'script_no_run_function', silent=True)
+        self.assertEqual("", sys.stdout.getvalue())

--- a/tests/testapp/scripts/error_script.py
+++ b/tests/testapp/scripts/error_script.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+def run():
+    raise Exception


### PR DESCRIPTION
[`importlib.import_module`](https://docs.python.org/3/library/importlib.html#importlib.import_module) in Python 3.3+ works by trying to import all parent packages first before importing a module.
This ended up showing many more errors on Python 3 than on Python 2. 
This makes the error messages shown to the user on an invalid package import consistent on all supported Python versions