### PR TITLE
Fixes shell_plus command SyntaxError on exec(), python compatibility

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -226,7 +226,7 @@ class Command(BaseCommand):
                 # PYTHONSTARTUP prints an exception and continues.
                 try:
                     with open(pythonrc) as handle:
-                        exec(compile(handle.read(), pythonrc, 'exec'), imported_objects)
+                        exec(compile(handle.read(), pythonrc, 'exec'), imported_objects) in globals(), locals()
                 except Exception:
                     traceback.print_exc()
 


### PR DESCRIPTION
Fixes the SyntaxError in the shell_plus command.
It seems users with python 2.x has this problem.

I tried implemented @joej simple solution from https://github.com/django-extensions/django-extensions/issues/1091#issue-253504617

