### PR TITLE
Skipping all models importing feature added.

### DIFF
--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -71,8 +71,12 @@ Note: These settings are only used inside shell_plus and will not affect your en
   SHELL_PLUS_DONT_LOAD = ['sites', 'blog.pictures']
 
 
-You can also combine model_aliases and dont_load.
+::
 
+  # Dont load any models
+  SHELL_PLUS_DONT_LOAD = ['*']
+
+You can also combine model_aliases and dont_load.
 When referencing nested modules, e.g. `somepackage.someapp.models.somemodel`, omit the
 package name and the reference to `models`. For example:
 

--- a/tests/management/commands/test_shell_plus.py
+++ b/tests/management/commands/test_shell_plus.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+import inspect
+
+from django.db.models import Model
+from django.test import override_settings
+
 from django_extensions.management.commands import shell_plus
 from django_extensions.management.shells import SHELL_PLUS_DJANGO_IMPORTS
 
@@ -9,3 +14,23 @@ def test_shell_plus_get_imported_objects():
     for items in SHELL_PLUS_DJANGO_IMPORTS.values():
         for item in items:
             assert item in objs, "%s not loaded by get_imported_objects()" % item
+
+
+def assert_should_models_be_imported(should_be, cli_arguments=None):
+    command = shell_plus.Command()
+    objs = command.get_imported_objects(cli_arguments or {})
+    imported_models = filter(lambda imported: inspect.isclass(imported) and issubclass(imported, Model), objs.values())
+    assert bool(list(imported_models)) == should_be
+
+
+def test_shell_plus_loading_models():
+    assert_should_models_be_imported(True)
+
+
+def test_shell_plus_skipping_models_import_cli():
+    assert_should_models_be_imported(False, cli_arguments={'dont_load': ['*']})
+
+
+@override_settings(SHELL_PLUS_DONT_LOAD=['*'])
+def test_shell_plus_skipping_models_import_settings():
+    assert_should_models_be_imported(False)


### PR DESCRIPTION
Phase of importing models can be skipped through command line:
`python manage.py shell_plus --dont-load=*`
or in django settings:
`SHELL_PLUS_DONT_LOAD=['*']`

Logic of importing models is unchanged. It is now under if statement.