### PR TITLE
Install notebook kernel spec to virtual environment

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -160,7 +160,8 @@ class Command(BaseCommand):
 
                 ks.env['PYTHONPATH'] = ':'.join(filter(None, pythonpath))
 
-            kernel_dir = os.path.join(ksm.user_kernel_dir, 'django_extensions')
+            # Install the kernel to the virtual environment
+            kernel_dir = ksm._get_destination_dir('django_extensions', prefix=sys.prefix)
             if not os.path.exists(kernel_dir):
                 os.makedirs(kernel_dir)
             with open(os.path.join(kernel_dir, 'kernel.json'), 'w') as f:


### PR DESCRIPTION
Quick fix #1026.

I don't love using the private [`_get_destination_dir`](https://github.com/jupyter/jupyter_client/blob/2822872afb8fc52b44cf9e18febe68d1375124a2/jupyter_client/kernelspec.py#L247), but it gets the job done. I'd like to go further and use the [public API for `KernelSpecManager`](https://jupyter-client.readthedocs.io/en/stable/api/kernelspec.html#jupyter_client.kernelspec.KernelSpecManager), which installs kernel specs from a directory. I'd probably do something similar to the [implementation of `python -m ipykernel install`](https://github.com/ipython/ipykernel/blob/9e7d1920e376de4e290009a760464b948a09d85c/ipykernel/kernelspec.py#L86-L88), which writes the spec to a temporary directory, installs it, then removes the directory. But, before I do that, I thought maybe a PR discussion might be in order.

Also, for people who have already run `manage.py shell_plus --notebook`, the kernel spec installed in `user_kernel_dir` will take precedence over this. Ideally, it should be deleted, but I'm wary of doing that automatically. What if I added a warning along the lines of `The kernel installation location has changed; please delete {ksm.user_kernel_dir}/django_extensions`?

