### PR TITLE
validate_templates improvement

### DIFF
--- a/django_extensions/management/commands/validate_templates.py
+++ b/django_extensions/management/commands/validate_templates.py
@@ -3,7 +3,8 @@ import os
 
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management.color import color_style
-from django.template.loader import get_template
+import django.template
+import django.template.loader
 
 from django_extensions.compat import get_template_setting
 from django_extensions.management.utils import signalcommand
@@ -12,6 +13,16 @@ from django_extensions.management.utils import signalcommand
 #
 # TODO: Render the template with fake request object ?
 #
+
+
+def get_template(filepath):
+    try:
+        django.template.loader.get_template(filepath)
+    except django.template.TemplateDoesNotExist:
+        if 'templates/' in filepath:
+            get_template(filepath[filepath.find('templates/') + len('templates/'):])
+        else:
+            raise
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Allow --include paths like "app/templates".

Otherwise there's no way to include app templates (only template folders in your project root).