### PR TITLE
Note that `--print-sql` requires `DEBUG` to be `True`

### DIFF
--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -309,7 +309,7 @@ If using PostgreSQL the ``application_name`` is set by default to
 SQL queries
 -------------------------
 
-If the configuration option DEBUG is set tu True, it is possible to print SQL queries as they're executed in shell_plus like::
+If the configuration option DEBUG is set to True, it is possible to print SQL queries as they're executed in shell_plus like::
 
   $ ./manage.py shell_plus --print-sql
 

--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -309,10 +309,9 @@ If using PostgreSQL the ``application_name`` is set by default to
 SQL queries
 -------------------------
 
-It is possible to print SQL queries as they're executed in shell_plus like::
+If the configuration option DEBUG is set tu True, it is possible to print SQL queries as they're executed in shell_plus like::
 
   $ ./manage.py shell_plus --print-sql
-
 
 You can also set the configuration option SHELL_PLUS_PRINT_SQL to omit the above command line option.
 


### PR DESCRIPTION
In order to print the SQL, `shell_plus` monkey patches `django.db.backends.util.CursorDebugWrapper`, which is only used when `DEBUG` is set to `True`.