### PR TITLE
Create a management command for de-duplicating model instances.

### DIFF
--- a/django_extensions/management/commands/merge_model_instances.py
+++ b/django_extensions/management/commands/merge_model_instances.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+from django.apps import apps
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from django_extensions.management.utils import signalcommand
+
+
+def get_model_to_deduplicate():
+    models = apps.get_models()
+    iterator = 1
+    for model in models:
+        print("%s. %s" % (iterator, model.__name__))
+        iterator += 1
+    model_choice = int(input("""
+        Enter the number of the model you would like to de-duplicate:
+        """))
+    model_to_deduplicate = models[model_choice - 1]
+    return model_to_deduplicate
+
+
+def get_field_names(model):
+    fields = [field.name for field in model._meta.get_fields()]
+    iterator = 1
+    for field in fields:
+        print("%s. %s" % (iterator, field))
+        iterator += 1
+    validated = False
+    while not validated:
+        first_field = int(input("""
+            Enter the number of the (first) field you would like to de-duplicate.
+            """))
+        if first_field in range(1, iterator):
+            validated = True
+        else:
+            print("Invalid input. Please try again.")
+    fields_to_deduplicate = [fields[first_field - 1]]
+
+    done = False
+    while not done:
+        available_fields = [
+            f for f in fields if f not in fields_to_deduplicate
+        ]
+        iterator = 1
+        for field in available_fields:
+            print("%s. %s" % (iterator, field))
+            iterator += 1
+        print("C. Done adding fields.")
+
+        validated = False
+        while not validated:
+            print("You are currently deduplicating on the following fields:")
+            print('\n'.join(fields_to_deduplicate) + '\n')
+
+            additional_field = input("""
+                Enter the number of the field you would like to de-duplicate.
+                If you have entered all fields, enter C to continue.
+                """)
+            if additional_field == "C":
+                done = True
+                validated = True
+            elif int(additional_field) in list(range(1, len(available_fields) + 1)):
+                fields_to_deduplicate += [available_fields[int(additional_field) - 1]]
+                validated = True
+            else:
+                print("Invalid input. Please try again.")
+
+    return fields_to_deduplicate
+
+
+def keep_first_or_last_instance():
+    while True:
+        first_or_last = input("""
+            Do you want to keep the first or last duplicate instance?
+            Enter "first" or "last" to continue.
+            """)
+        if first_or_last in ["first", "last"]:
+            return first_or_last
+
+
+def get_generic_fields():
+    """Return a list of all GenericForeignKeys in all models."""
+    generic_fields = []
+    for model in apps.get_models():
+        for field_name, field in model.__dict__.items():
+            if isinstance(field, GenericForeignKey):
+                generic_fields.append(field)
+    return generic_fields
+
+
+class Command(BaseCommand):
+    help = """
+        Removes duplicate model instances based on a specified
+        model and field name(s).
+
+        Makes sure that any OneToOne, ForeignKey, or ManyToMany relationships
+        attached to a deleted model(s) get reattached to the remaining model.
+
+        Based on the following:
+        https://djangosnippets.org/snippets/2283/
+        https://stackoverflow.com/a/41291137/2532070
+        https://gist.github.com/edelvalle/01886b6f79ba0c4dce66
+        """
+
+    @signalcommand
+    def handle(self, *args, **options):
+        model = get_model_to_deduplicate()
+        field_names = get_field_names(model)
+        first_or_last = keep_first_or_last_instance()
+        total_deleted_objects_count = 0
+        for instance in model.objects.all():
+            kwargs = {}
+            for field_name in field_names:
+                instance_field_value = instance.__getattribute__(field_name)
+                kwargs.update({
+                    field_name: instance_field_value
+                })
+            try:
+                model.objects.get(**kwargs)
+            except model.MultipleObjectsReturned:
+                instances = model.objects.filter(**kwargs)
+
+                if first_or_last == "first":
+                    primary_object = instances[0]
+                    alias_objects = instances[1:]
+                elif first_or_last == "last":
+                    primary_object = instances[len(instances) - 1]
+                    alias_objects = instances[:len(instances) - 1]
+                primary_object, deleted_objects, deleted_objects_count = self.merge_model_instances(primary_object, alias_objects)
+                total_deleted_objects_count += deleted_objects_count
+
+        print("Successfully deleted {} model instances.".format(total_deleted_objects_count))
+
+    @transaction.atomic()
+    def merge_model_instances(self, primary_object, alias_objects):
+        """Merge several model instances into one, the `primary_object`.
+        Use this function to merge model objects and migrate all of the related
+        fields from the alias objects the primary object.
+        """
+        generic_fields = get_generic_fields()
+
+        # get related fields
+        related_fields = list(filter(
+            lambda x: x.is_relation is True,
+            primary_object._meta.get_fields()))
+
+        many_to_many_fields = list(filter(
+            lambda x: x.many_to_many is True, related_fields))
+
+        related_fields = list(filter(
+            lambda x: x.many_to_many is False, related_fields))
+
+        # Loop through all alias objects and migrate their references to the
+        # primary object
+        deleted_objects = []
+        deleted_objects_count = 0
+        for alias_object in alias_objects:
+            # Migrate all foreign key references from alias object to primary
+            # object.
+            for many_to_many_field in many_to_many_fields:
+                alias_varname = many_to_many_field.name
+                related_objects = getattr(alias_object, alias_varname)
+                for obj in related_objects.all():
+                    try:
+                        # Handle regular M2M relationships.
+                        getattr(alias_object, alias_varname).remove(obj)
+                        getattr(primary_object, alias_varname).add(obj)
+                    except AttributeError:
+                        # Handle M2M relationships with a 'through' model.
+                        # This does not delete the 'through model.
+                        # TODO: Allow the user to delete a duplicate 'through' model.
+                        through_model = getattr(alias_object, alias_varname).through
+                        kwargs = {
+                            many_to_many_field.m2m_reverse_field_name(): obj,
+                            many_to_many_field.m2m_field_name(): alias_object,
+                        }
+                        through_model_instances = through_model.objects.filter(**kwargs)
+                        for instance in through_model_instances:
+                            # Re-attach the through model to the primary_object
+                            setattr(
+                                instance,
+                                many_to_many_field.m2m_field_name(),
+                                primary_object)
+                            instance.save()
+                            # TODO: Here, try to delete duplicate instances that are
+                            # disallowed by a unique_together constraint
+
+            for related_field in related_fields:
+                if related_field.one_to_many:
+                    alias_varname = related_field.get_accessor_name()
+                    related_objects = getattr(alias_object, alias_varname)
+                    for obj in related_objects.all():
+                        field_name = related_field.field.name
+                        setattr(obj, field_name, primary_object)
+                        obj.save()
+                elif related_field.one_to_one or related_field.many_to_one:
+                    alias_varname = related_field.name
+                    related_object = getattr(alias_object, alias_varname)
+                    primary_related_object = getattr(primary_object, alias_varname)
+                    if primary_related_object is None:
+                        setattr(primary_object, alias_varname, related_object)
+                        primary_object.save()
+                    elif related_field.one_to_one:
+                        self.stdout.write("Deleted {} with id {}\n".format(
+                            related_object, related_object.id))
+                        related_object.delete()
+
+            for field in generic_fields:
+                filter_kwargs = {}
+                filter_kwargs[field.fk_field] = alias_object._get_pk_val()
+                filter_kwargs[field.ct_field] = field.get_content_type(alias_object)
+                related_objects = field.model.objects.filter(**filter_kwargs)
+                for generic_related_object in related_objects:
+                    setattr(generic_related_object, field.name, primary_object)
+                    generic_related_object.save()
+
+            if alias_object.id:
+                deleted_objects += [alias_object]
+                self.stdout.write("Deleted {} with id {}\n".format(
+                    alias_object, alias_object.id))
+                alias_object.delete()
+                deleted_objects_count += 1
+
+        return primary_object, deleted_objects, deleted_objects_count

--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -57,6 +57,9 @@ Current Command Extensions
 * *mail_debug* - Starts a mail server which echos out the contents of the email
   instead of sending it.
 
+* :doc:`merge_model_instances` - Merges duplicate model instances by
+  reassigning related model references to a chosen primary model instance.
+
 * *notes* - Show all annotations like TODO, FIXME, BUG, HACK, WARNING, NOTE or XXX in your py and HTML files.
 
 * *passwd* - Makes it easy to reset a user's password.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ Contents
    field_extensions
    graph_models
    jobs_scheduling
+   merge_model_instances
    model_extensions
    namespace_proposal
    print_settings

--- a/docs/merge_model_instances.rst
+++ b/docs/merge_model_instances.rst
@@ -1,0 +1,18 @@
+merge_model_instances
+==========================
+
+:synopsis: Merges duplicate model instances by
+  reassigning related model references to a chosen primary model instance.
+
+*Note: This management command is in beta. Use with care, and make sure to test thoroughly before implementing.*
+
+Allows the user to choose a model to de-duplicate and a field on which to de-duplicate model instances. Provides an interactive session with the user to select the model to de-duplicate and the field on which to de-duplicate model instances. After merging model instances to one instance, deletes the merged model instances. Use with care!
+
+Example Usage
+-------------
+
+With *django-extensions* installed you merge model instances using the
+*merge_model_instances* command::
+
+  # Delete leftover migrations from the first squashed migration found in myapp
+  $ ./manage.py merge_model_instances

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 import os
 import sys
 import shutil
@@ -11,7 +12,13 @@ from django.test import TestCase
 from django.utils.six import StringIO, PY3
 
 from django_extensions.management.modelviz import use_model, generate_graph_data
+from django_extensions.management.commands.merge_model_instances import \
+    get_model_to_deduplicate, \
+    get_field_names, \
+    keep_first_or_last_instance
 from . import force_color_support
+from .testapp.models import Person, Name, Note, Personality, Club, Membership, \
+    Permission
 
 
 class MockLoggingHandler(logging.Handler):
@@ -295,3 +302,140 @@ class ShowUrlsTests(TestCase):
             call_command('show_urls', '--no-color', stdout=out)
             self.output = out.getvalue()
             self.assertNotIn('\x1b', self.output)
+
+
+class MergeModelInstancesTests(TestCase):
+    """
+    Tests for the `merge_model_instances` management command.
+    """
+
+    @mock.patch('django_extensions.management.commands.merge_model_instances.apps.get_models')
+    @mock.patch('django_extensions.management.commands.merge_model_instances.input')
+    def test_get_model_to_merge(self, test_input, get_models):
+        class Model(object):
+            __name__ = ""
+
+        return_value = []
+        for v in ["one", "two", "three"]:
+            instance = Model()
+            instance.__name__ = v
+            return_value.append(instance)
+        get_models.return_value = return_value
+        test_input.return_value = 2
+        model_to_deduplicate = get_model_to_deduplicate()
+        self.assertEqual(model_to_deduplicate.__name__, "two")
+
+    @mock.patch('django_extensions.management.commands.merge_model_instances.input')
+    def test_get_field_names(self, test_input):
+
+        class Field(object):
+            name = ""
+
+            def __init__(self, name):
+                self.name = name
+
+        class Model(object):
+            __name__ = ""
+            one = Field(name="one")
+            two = Field(name="two")
+            three = Field(name="three")
+
+        return_value = [Model().__getattribute__(field) for field in dir(Model()) if not field.startswith("__")]
+        Model._meta = mock.MagicMock()
+        Model._meta.get_fields = mock.MagicMock(return_value=return_value)
+
+        # Choose the second return_value
+        test_input.side_effect = [2, "C"]
+        field_names = get_field_names(Model())
+        # Test that the second return_value returned
+        self.assertEqual(field_names, [return_value[1].name])
+
+    @mock.patch('django_extensions.management.commands.merge_model_instances.input')
+    def test_keep_first_or_last_instance(self, test_input):
+        test_input.side_effect = ["xxxx", "first", "last"]
+        first_or_last = keep_first_or_last_instance()
+        self.assertEqual(first_or_last, "first")
+        first_or_last = keep_first_or_last_instance()
+        self.assertEqual(first_or_last, "last")
+
+    @mock.patch('django_extensions.management.commands.merge_model_instances.get_model_to_deduplicate')
+    @mock.patch('django_extensions.management.commands.merge_model_instances.get_field_names')
+    @mock.patch('django_extensions.management.commands.merge_model_instances.keep_first_or_last_instance')
+    def test_merge_model_instances(self, keep_first_or_last_instance, get_field_names, get_model_to_deduplicate):
+        get_model_to_deduplicate.return_value = Person
+        get_field_names.return_value = ["name"]
+        keep_first_or_last_instance.return_value = "first"
+
+        name = Name.objects.create(name="Name")
+        note = Note.objects.create(note="This is a note.")
+        personality_1 = Personality.objects.create(
+            description="Child 1's personality.")
+        personality_2 = Personality.objects.create(
+            description="Child 2's personality.")
+        child_1 = Person.objects.create(
+            name=Name.objects.create(name="Child1"),
+            age=10,
+            personality=personality_1
+        )
+        child_1.notes.add(note)
+        child_2 = Person.objects.create(
+            name=Name.objects.create(name="Child2"),
+            age=10,
+            personality=personality_2
+        )
+        child_2.notes.add(note)
+
+        club1 = Club.objects.create(name="Club one")
+        club2 = Club.objects.create(name="Club two")
+        person_1 = Person.objects.create(
+            name=name,
+            age=50,
+            personality=Personality.objects.create(
+                description="First personality")
+        )
+        person_1.children.add(child_1)
+        person_1.notes.add(note)
+        Permission.objects.create(text="Permission", person=person_1)
+
+        person_2 = Person.objects.create(
+            name=name,
+            age=50,
+            personality=Personality.objects.create(
+                description="Second personality")
+        )
+        person_2.children.add(child_2)
+        new_note = Note.objects.create(note="This is a new note")
+        person_2.notes.add(new_note)
+        Membership.objects.create(club=club1, person=person_2)
+        Membership.objects.create(club=club1, person=person_2)
+        Permission.objects.create(text="Permission", person=person_2)
+
+        person_3 = Person.objects.create(
+            name=name,
+            age=50,
+            personality=Personality.objects.create(
+                description="Third personality")
+        )
+        person_3.children.add(child_2)
+        person_3.notes.add(new_note)
+        Membership.objects.create(club=club2, person=person_3)
+        Membership.objects.create(club=club2, person=person_3)
+        Permission.objects.create(text="Permission", person=person_3)
+
+        self.assertEqual(Person.objects.count(), 5)
+        self.assertEqual(Membership.objects.count(), 4)
+        out = StringIO()
+        call_command('merge_model_instances', stdout=out)
+        self.ouptput = out.getvalue()
+        self.assertEqual(Person.objects.count(), 3)
+        person = Person.objects.get(name__name="Name")
+        self.assertRaises(
+            Person.DoesNotExist,
+            lambda: Person.objects.get(
+                personality__description="Second personality"))
+        self.assertEqual(person.notes.count(), 2)
+        self.assertEqual(person.clubs.distinct().count(), 2)
+        self.assertEqual(person.permission_set.count(), 3)
+        self.assertRaises(
+            Personality.DoesNotExist,
+            lambda: Personality.objects.get(description="Second personality"))

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -32,14 +32,33 @@ class Note(models.Model):
         app_label = 'django_extensions'
 
 
+class Personality(models.Model):
+    description = models.CharField(max_length=50)
+
+
+class Club(models.Model):
+    name = models.CharField(max_length=50)
+
+
 class Person(models.Model):
     name = models.ForeignKey(Name, on_delete=models.CASCADE)
     age = models.PositiveIntegerField()
     children = models.ManyToManyField('self')
     notes = models.ManyToManyField(Note)
+    personality = models.OneToOneField(
+        Personality,
+        null=True,
+        on_delete=models.CASCADE)
+    clubs = models.ManyToManyField(Club, through='testapp.Membership')
 
     class Meta:
         app_label = 'django_extensions'
+
+
+class Membership(models.Model):
+    person = models.ForeignKey(Person, on_delete=models.CASCADE)
+    club = models.ForeignKey(Club, on_delete=models.CASCADE)
+    created = models.DateTimeField(auto_now=True)
 
 
 class Post(ActivatorModel):


### PR DESCRIPTION
First, thanks for building this great library. I use it in every project I build.

This PR creates a management command for merging duplicate model instances on a specified field(s). I frequently find myself having to merge (or de-duplicate) model instances on existing Django sites.

There are various gists out there, including the three I used for inspiration (see the comments on the command), but all of these were buggy and kept getting outdated.

The command asks the user to input the model to deduplicate, the field on which to de-duplicate the model, and whether the user wants to keep the first (or last) duplicate instance of the model. The command then merges all duplicate instances of the model into the first (or last) instance. Related fields (M2M, FK) of all duplicate model instances are also merged onto the remaining instance.

Thanks for taking a look - I hope this will be considered a helpful addition to django-extensions! Please let me know if I can add any improvements or revisions.