### PR TITLE
Fixes #928 AutoSlugField.deconstruct does not match construction values

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -149,14 +149,15 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
 
     def create_slug(self, model_instance, add):
         # get fields to populate from and slug field to set
-        if not isinstance(self._populate_from, (list, tuple)):
-            self._populate_from = (self._populate_from, )
+        populate_from = self._populate_from
+        if not isinstance(populate_from, (list, tuple)):
+            populate_from = (populate_from, )
         slug_field = model_instance._meta.get_field(self.attname)
 
         if add or self.overwrite:
             # slugify the original field content and set next step to 2
             slug_for_field = lambda lookup_value: self.slugify_func(self.get_slug_fields(model_instance, lookup_value))
-            slug = self.separator.join(map(slug_for_field, self._populate_from))
+            slug = self.separator.join(map(slug_for_field, populate_from))
             start = 2
         else:
             # get slug from the current model instance

--- a/tests/test_autoslug_fields.py
+++ b/tests/test_autoslug_fields.py
@@ -172,3 +172,10 @@ class MigrationTest(TestCase):
         # Just make sure it runs for now, and that things look alright.
         result = self.safe_exec(output)
         self.assertIn("Migration", result)
+
+    def test_stable_deconstruct(self):
+        slug_field = SluggedTestModel._meta.get_field('slug')
+        construction_values = slug_field.deconstruct()
+        m = SluggedTestModel(title='foo')
+        m.save()
+        self.assertEqual(slug_field.deconstruct(), construction_values)


### PR DESCRIPTION
We also hit the problem described in https://github.com/django-oscar/django-oscar/commit/27cb08936252ae320423ecccc22b5658135c5b04 where a unittest to detect missing migrations keeps failing because if the test run creates a slug, the `_populate_from` attr gets changed, and this alters the result of `deconstruct`, so Django wants another migration to include this change.

This change:
- ensures the values that come out of `deconstruct()` are unchanging
- the value of `populate_from` matches that values passed into `__init__`