### PR TITLE
Fix runserver_plus in Django 1.11 using MIDDLEWARE_CLASSES

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -193,13 +193,7 @@ class Command(BaseCommand):
             # Add pdb middleware if --pdb is specified or if in DEBUG mode
             if (pdb_option or ipdb_option or settings.DEBUG):
                 middleware = 'django_pdb.middleware.PdbMiddleware'
-                try:
-                    settings_middleware = settings.MIDDLEWARE
-                except AttributeError:
-                    if django.VERSION >= (2, 0):
-                        raise
-
-                    settings_middleware = settings.MIDDLEWARE_CLASSES
+                settings_middleware = getattr(settings, 'MIDDLEWARE', None) or settings.MIDDLEWARE_CLASSES
 
                 if middleware not in settings_middleware:
                     if isinstance(settings_middleware, tuple):


### PR DESCRIPTION
We're upgrading to Django 1.11, but not (yet) using `settings.MIDDLEWARE`. However, at runtime it defaults to `None`, which results in `TypeError: argument of type 'NoneType' is not iterable` when
running `runserver_plus`. This approach allow for both styles of middleware in Django < 2.0.

I've only tested this manually in our 1.11 environment.