### PR TITLE
Fix validate_templates with symlinks

### DIFF
--- a/django_extensions/management/commands/validate_templates.py
+++ b/django_extensions/management/commands/validate_templates.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
                     if self.ignore_filename(filename):
                         continue
 
-                    filepath = os.path.realpath(os.path.join(root, filename))
+                    filepath = os.path.join(root, filename)
                     if verbosity > 1:
                         print(filepath)
                     try:


### PR DESCRIPTION
Fixes #1147

I ran into the same issue with django extensions not being able to find and validate templates.  I traced it to Django's [filesystem.py template loader](https://github.com/django/django/blob/master/django/template/loaders/filesystem.py#L36) where it was blocking loading the template because the template was not within one of the `template_dirs` due to `os.path.realpath` removing a symbolic link.  By removing the `realpath` below, the template path follows the symbolic link that matches the `template_dirs`.