### PR TITLE
Add collision resolvers based on app label for shell_plus

### DIFF
--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -236,6 +236,32 @@ In case of collisions he sets aliases like FullPathCR, but sets default model us
     from programming import Language, Language (as programming_Language)
     from workers import Language (as workers_Language)
 
+**AppLabelPrefixCR**
+
+Collision resolver which transform pair (app_label, model_name) to alias ``{app_label}_{model_name}``
+
+This is very similar to ``AppNamePrefixCR`` but this may generate shorter names in case of apps nested
+into several namespace (like Django's auth app)::
+
+    # with AppNamePrefixCR
+    from django.contrib.auth.models import Group (as django_contrib_auth_Group)
+
+    # with AppLabelPrefixCR
+    from django.contrib.auth.models import Group (as auth_Group)
+
+**AppLabelSuffixCR**
+
+Collision resolver which transform pair (app_label, model_name) to alias ``{model_name}_{app_label}``
+
+Similar idea as the above, but based on ``AppNameSuffixCR``::
+
+    # with AppNamePrefixCR
+    from django.contrib.auth.models import Group (as Group_django_contrib_auth)
+
+    # with AppLabelSuffixCR
+    from django.contrib.auth.models import Group (as Group_auth)
+
+
 Writing your custom collision resolver
 --------------------------------------
 

--- a/tests/management/commands/test_collision_resolver.py
+++ b/tests/management/commands/test_collision_resolver.py
@@ -142,6 +142,28 @@ class CRTestCase(TestCase):
         )
 
     @override_settings(
+        SHELL_PLUS_MODEL_IMPORTS_RESOLVER='django_extensions.collision_resolvers.AppLabelPrefixCR',
+    )
+    def test_app_label_prefix_collision_resolver(self):
+        self._assert_models_present_under_names(
+            {'auth_Group'}, {'collisions_Group', 'Group'}, {'django_extensions_Name', 'Name'},
+            {'collisions_Name'}, {'django_extensions_Note', 'Note'}, {'collisions_Note'}, {'SystemUser'},
+            {'UniqueModel'}, {'auth_Permission'}, {'testapp_Permission', 'Permission'},
+            {'UniqueTestAppModel'},
+        )
+
+    @override_settings(
+        SHELL_PLUS_MODEL_IMPORTS_RESOLVER='django_extensions.collision_resolvers.AppLabelSuffixCR',
+    )
+    def test_app_label_suffix_collision_resolver(self):
+        self._assert_models_present_under_names(
+            {'Group_auth'}, {'Group_collisions', 'Group'}, {'Name_django_extensions', 'Name'},
+            {'Name_collisions'}, {'Note_django_extensions', 'Note'}, {'Note_collisions'},
+            {'SystemUser'}, {'UniqueModel'}, {'Permission_auth'},
+            {'Permission_testapp', 'Permission'}, {'UniqueTestAppModel'},
+        )
+
+    @override_settings(
         SHELL_PLUS_MODEL_IMPORTS_RESOLVER='django_extensions.collision_resolvers.FullPathCR',
     )
     def test_full_path_collision_resolver(self):


### PR DESCRIPTION
To avoid having very long model names, add 2 new collision resolvers `AppLabelPrefixCR` and `AppLabelSuffixCR` leveraging the app label rather than the app name.