### PR TITLE
Add function support to AutoSlugField populate_from

### DIFF
--- a/tests/test_autoslug_fields.py
+++ b/tests/test_autoslug_fields.py
@@ -12,7 +12,7 @@ from django_extensions.db.fields import AutoSlugField
 
 from .testapp.models import ChildSluggedTestModel, SluggedTestModel, \
     FKSluggedTestModel, FKSluggedTestModelCallable, \
-    ModelMethodSluggedTestModel
+    FunctionSluggedTestModel, ModelMethodSluggedTestModel
 
 
 @pytest.mark.usefixtures("admin_user")
@@ -93,12 +93,24 @@ class AutoSlugFieldTest(TestCase):
         n.save()
         self.assertEqual(n.slug, '-3')
 
-    def test_callable_slug_source(self):
+    def test_callable_method_slug_source(self):
         m = ModelMethodSluggedTestModel(title='-foo')
         m.save()
         self.assertEqual(m.slug, 'the-title-is-foo')
 
         n = ModelMethodSluggedTestModel(title='-foo')
+        n.save()
+        self.assertEqual(n.slug, 'the-title-is-foo-2')
+
+        n.save()
+        self.assertEqual(n.slug, 'the-title-is-foo-2')
+
+    def test_callable_function_slug_source(self):
+        m = FunctionSluggedTestModel(title='-foo')
+        m.save()
+        self.assertEqual(m.slug, 'the-title-is-foo')
+
+        n = FunctionSluggedTestModel(title='-foo')
         n.save()
         self.assertEqual(n.slug, 'the-title-is-foo-2')
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -87,6 +87,10 @@ class ChildSluggedTestModel(SluggedTestModel):
         app_label = 'django_extensions'
 
 
+def get_readable_title(instance):
+    return "The title is {}".format(instance.title)
+
+
 class ModelMethodSluggedTestModel(models.Model):
     title = models.CharField(max_length=42)
     slug = AutoSlugField(populate_from='get_readable_title')
@@ -95,7 +99,15 @@ class ModelMethodSluggedTestModel(models.Model):
         app_label = 'django_extensions'
 
     def get_readable_title(self):
-        return "The title is {}".format(self.title)
+        return get_readable_title(self)
+
+
+class FunctionSluggedTestModel(models.Model):
+    title = models.CharField(max_length=42)
+    slug = AutoSlugField(populate_from=get_readable_title)
+
+    class Meta:
+        app_label = 'django_extensions'
 
 
 class FKSluggedTestModel(models.Model):


### PR DESCRIPTION
Hello!

As per the title, adds the ability to specify functions directly in the `populate_from` argument of `AutoSlugField`. For example:

```
def get_readable_title(instance):
    return "The title is {}".format(instance.title)

class FunctionSluggedTestModel(models.Model):
    title = models.CharField(max_length=42)
    slug = AutoSlugField(populate_from=get_readable_title)

    class Meta:
        app_label = 'django_extensions'
```

The motivation for this is that Django disallows methods to be called via migrations (easily), and this proves to be a major inconvenience when the slug generation isn't simply derived. :-)

This PR also pushes the evaluation of whether the slug should be overwritten or not further up, so that when the value is already specified, none of the logic for slug generation is called. This means that you can create objects with slugs pre-populated (e.g. data migration) and you can be certain that none of the logic will be executed. It's also slightly more efficient.

All tests executed successfully apart from unrelated issues with sqldiff tests (on my machine).