### PR TITLE
Fix print-sql: call execute on CursorWrapper instead of directly

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -157,7 +157,7 @@ class Command(BaseCommand):
                 def execute(self, sql, params=()):
                     starttime = time.time()
                     try:
-                        return self.cursor.execute(sql, params)
+                        return utils.CursorWrapper.execute(self, sql, params)
                     finally:
                         execution_time = time.time() - starttime
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -398,7 +398,7 @@ class Command(BaseCommand):
                 def execute(self, sql, params=()):
                     starttime = time.time()
                     try:
-                        return self.cursor.execute(sql, params)
+                        return utils.CursorWrapper.execute(self, sql, params)
                     finally:
                         execution_time = time.time() - starttime
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)


### PR DESCRIPTION
`runserver_plus --print-sql` and `shell_plus --print-sql` have the same implementation for printing sql. They call `execute` on the cursor directly instead of calling `execute` on `django.db.backends.utils.CursorWrapper` (as `django.db.backends.utils.CursorDebugWrapper` does). 

This is a problem because then we do not get the query [executed with wrappers](https://github.com/django/django/blob/51a00749e9d1814acfb6bf8732ecd21f18944083/django/db/backends/utils.py#L68) . => [`DatabaseErrorWrapper` ](https://github.com/django/django/blob/51a00749e9d1814acfb6bf8732ecd21f18944083/django/db/utils.py#L51)is not properly run on db exceptions. A notable effect of the is that Integrity errors are eg. (for Postgres db backend) not converted from `psycopg2.IntegrityError` to `django.db.utils.IntegrityError` which might have a severe impact on code relying on catching `django.db.utils.IntegrityError`.