### PR TITLE
FIX bug in windows when PYTHONPATH is defined

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -170,11 +170,11 @@ class Command(BaseCommand):
 
             if manage_py == 'manage.py' and os.path.isdir(manage_py_dir) and manage_py_dir != os.getcwd():
                 pythonpath = ks.env.get('PYTHONPATH', os.environ.get('PYTHONPATH', ''))
-                pythonpath = pythonpath.split(':')
+                pythonpath = pythonpath.split(os.pathsep)
                 if manage_py_dir not in pythonpath:
                     pythonpath.append(manage_py_dir)
 
-                ks.env['PYTHONPATH'] = ':'.join(filter(None, pythonpath))
+                ks.env['PYTHONPATH'] = os.pathsep.join(filter(None, pythonpath))
 
             kernel_dir = os.path.join(ksm.user_kernel_dir, 'django_extensions')
             if not os.path.exists(kernel_dir):


### PR DESCRIPTION
FIX bug in windows when PYTHONPATH is defined and not empty. When working with a django project that use a lib located  in a location outside of the django folder, i need to configure the enviroment variable PYTHONPATH to the path where the library is located. But, in windows, django extensions shell plus is using ":" as path separator and the windows separator is ";". That cause the library can't be located and django is not initializated.