### PR TITLE
sqldiff: drop (really)retro-compatible code

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -26,7 +26,7 @@ import sys
 import six
 from typing import Dict, Union, Callable, Optional  # NOQA
 from django.apps import apps
-from django.core.management import BaseCommand, CommandError, sql as _sql
+from django.core.management import BaseCommand, CommandError
 from django.core.management.base import OutputWrapper
 from django.core.management.color import no_style
 from django.db import connection, transaction, models
@@ -136,14 +136,10 @@ class SQLDiff(object):
         self.options = options
         self.dense = options.get('dense_output', False)
 
-        try:
-            self.introspection = connection.introspection
-        except AttributeError:
-            from django.db import get_introspection_module
-            self.introspection = get_introspection_module()
+        self.introspection = connection.introspection
 
         self.cursor = connection.cursor()
-        self.django_tables = self.get_django_tables(options.get('only_existing', True))
+        self.django_tables = self.introspection.django_table_names(only_existing=options.get('only_existing', True))
         # TODO: We are losing information about tables which are views here
         self.db_tables = [table_info.name for table_info in self.introspection.get_table_list(self.cursor)]
         self.differences = []
@@ -193,18 +189,6 @@ class SQLDiff(object):
         # type: () -> Dict[int, Union[str, Callable]]
         return self.DATA_TYPES_REVERSE_OVERRIDE
 
-    def get_django_tables(self, only_existing):
-        try:
-            django_tables = self.introspection.django_table_names(only_existing=only_existing)
-        except AttributeError:
-            # backwards compatibility for before introspection refactoring (r8296)
-            try:
-                django_tables = _sql.django_table_names(only_existing=only_existing)
-            except AttributeError:
-                # backwards compatibility for before svn r7568
-                django_tables = _sql.django_table_list(only_existing=only_existing)
-        return django_tables
-
     def sql_to_dict(self, query, param):
         """ sql_to_dict(query, param) -> list of dicts
 
@@ -236,11 +220,7 @@ class SQLDiff(object):
             reverse_type = DATA_TYPES_REVERSE_OVERRIDE[type_code]
         else:
             try:
-                try:
-                    reverse_type = self.introspection.data_types_reverse[type_code]
-                except AttributeError:
-                    # backwards compatibility for before introspection refactoring (r8296)
-                    reverse_type = self.introspection.DATA_TYPES_REVERSE.get(type_code)
+                reverse_type = self.introspection.data_types_reverse[type_code]
             except KeyError:
                 reverse_type = self.get_field_db_type_lookup(type_code)
                 if not reverse_type:


### PR DESCRIPTION
connection.introspection and connection.introspection.django_table_names
were already there in Django 1.0.

cf https://github.com/django/django/commit/9dc4ba875f