### PR TITLE
Replace removed `rel` object with `remote_field`

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -146,11 +146,11 @@ class ForeignKeyAutocompleteAdminMixin(object):
         specified in the related_search_fields class attribute.
         """
         if isinstance(db_field, models.ForeignKey) and db_field.name in self.related_search_fields:
-            model_name = db_field.rel.to._meta.object_name
+            model_name = db_field.remote_field.to._meta.object_name
             help_text = self.get_help_text(db_field.name, model_name)
             if kwargs.get('help_text'):
                 help_text = six.u('%s %s' % (kwargs['help_text'], help_text))
-            kwargs['widget'] = ForeignKeySearchInput(db_field.rel, self.related_search_fields[db_field.name])
+            kwargs['widget'] = ForeignKeySearchInput(db_field.remote_field, self.related_search_fields[db_field.name])
             kwargs['help_text'] = help_text
         return super(ForeignKeyAutocompleteAdminMixin, self).formfield_for_dbfield(db_field, **kwargs)
 


### PR DESCRIPTION
Field.rel was removed in Django 1.9:
https://docs.djangoproject.com/en/1.9/releases/1.9/#field-rel-changes