### PR TITLE
Fix missing special markers `::` in runserver_plus.rst

### DIFF
--- a/docs/runserver_plus.rst
+++ b/docs/runserver_plus.rst
@@ -213,11 +213,11 @@ You can read more about this in `Werkzeug documentation <http://werkzeug.pocoo.o
 You can also increase the poll interval when using `stat polling` from the default of 1 second. This
 will decrease the CPU load at the expense of file edits taking longer to pick up.
 
-This can be set two ways, in the django settings file:
+This can be set two ways, in the django settings file::
 
     RUNSERVERPLUS_POLLER_RELOADER_INTERVAL = 5
 
-or as a commad line argument:
+or as a commad line argument::
 
   $ python manage.py runserver_plus --reloader-interval 5
 


### PR DESCRIPTION
* Consistent with the rest of the document
* Without this, `--reloader-interval 5` is rendered with an em dash instead on Read the Docs @ http://django-extensions.readthedocs.io/en/latest/runserver_plus.html#io-calls-and-cpu-usage
    * > –reloader-interval 5