### PR TITLE
Treat dev versions as unstable in pipchecker

### DIFF
--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -117,7 +117,7 @@ class Command(BaseCommand):
         return json.loads(urlopen(req).read())
 
     def _is_stable(self, version):
-        return not re.search(r'([ab]|rc)\d+$', str(version))
+        return not re.search(r'([ab]|rc|dev)\d+$', str(version))
 
     def _available_version(self, dist_version, available):
         if self._is_stable(dist_version):


### PR DESCRIPTION
This prevents pipchecker from suggesting upgrading to a dev version when the currently installed version is stable.

See eg. https://pypi.org/project/django-filter/2.0.0.dev1/