### PR TITLE
Fix default utf8 support in reset_db.

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -127,7 +127,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
 
             connection = Database.connect(**kwargs)
             drop_query = 'DROP DATABASE IF EXISTS `%s`' % database_name
-            utf8_support = 'CHARACTER SET utf8' if options['no_utf8_support'] else ''
+            utf8_support = '' if options['no_utf8_support'] else 'CHARACTER SET utf8'
             create_query = 'CREATE DATABASE `%s` %s' % (database_name, utf8_support)
             logging.info('Executing... "' + drop_query + '"')
             connection.query(drop_query)


### PR DESCRIPTION
The behavior was previously reversed which got introduced in 0791541788798247971a652c55a955304bd68d6d
where it seems that the option got read as "force utf-8 support" but it
always has been the other way around.