### PR TITLE
Fix autoslug generation when existing model is copied

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -149,7 +149,7 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
 
     def create_slug(self, model_instance, add):
         slug = getattr(model_instance, self.attname)
-        if slug and not self.overwrite:
+        if slug and not self.overwrite and not add:
             # Existing slug and not configured to overwrite - Short-circuit
             # here to prevent slug generation when not required.
             return slug

--- a/tests/test_autoslug_fields.py
+++ b/tests/test_autoslug_fields.py
@@ -143,6 +143,15 @@ class AutoSlugFieldTest(TestCase):
         m.save()
         self.assertEqual(m.slug, 'the-title-is-foo')
 
+    def test_copy_model_generates_new_slug(self):
+        m = SluggedTestModel(title='foo')
+        m.save()
+        self.assertEqual(m.slug, 'foo')
+
+        m.pk = None
+        m.save()
+        self.assertEqual(m.slug, 'foo-2')
+
 
 class MigrationTest(TestCase):
     def safe_exec(self, string, value=None):


### PR DESCRIPTION
Fixes the issue described by @tisdall in #1171 that occurs when an existing autoslug model is copied.