### PR TITLE
Reduce reraise pollution in runserver_plus traceback page

### DIFF
--- a/django_extensions/management/technical_response.py
+++ b/django_extensions/management/technical_response.py
@@ -1,6 +1,31 @@
 # -*- coding: utf-8 -*-
 import six
+from django.core.handlers.wsgi import WSGIHandler
+
+wsgi_tb = None
 
 
 def null_technical_500_response(request, exc_type, exc_value, tb, status_code=500):
-    six.reraise(exc_type, exc_value, tb)
+    """Function to override django.views.debug.technical_500_response.
+
+    Django's convert_exception_to_response wrapper is called on each 'Middleware' object to avoid
+    leaking exceptions. The wrapper eventually calls technical_500_response to create a response for
+    an error view.
+
+    Runserver_plus overrides the django debug view's technical_500_response function with this
+    to allow for an enhanced WSGI debugger view to be displayed. However, because Django calls
+    convert_exception_to_response on each object in the stack of Middleware objects, re-raising an error
+    quickly pollutes the traceback displayed.
+
+    Runserver_plus only needs needs traceback frames relevant to WSGIHandler Middleware objects, so
+    only raise the traceback if it is for a WSGIHandler. If an exception is not raised here, Django
+    eventually throws an error for not getting a valid response object for its debug view.
+    """
+    global wsgi_tb
+
+    # After an uncaught exception is raised the class can be found in the second frame of the tb
+    if isinstance(tb.tb_next.tb_frame.f_locals['self'], WSGIHandler):
+        wsgi_tb = tb
+        six.reraise(exc_type, exc_value, tb)
+    else:
+        six.reraise(exc_type, exc_value, wsgi_tb)

--- a/django_extensions/management/technical_response.py
+++ b/django_extensions/management/technical_response.py
@@ -1,31 +1,34 @@
 # -*- coding: utf-8 -*-
+import threading
+
 import six
 from django.core.handlers.wsgi import WSGIHandler
 
-wsgi_tb = None
+tld = threading.local()
 
 
 def null_technical_500_response(request, exc_type, exc_value, tb, status_code=500):
     """Function to override django.views.debug.technical_500_response.
 
-    Django's convert_exception_to_response wrapper is called on each 'Middleware' object to avoid
-    leaking exceptions. The wrapper eventually calls technical_500_response to create a response for
-    an error view.
+    Django's convert_exception_to_response() wrapper is called on each 'Middleware' object to avoid
+    leaking exceptions. If and uncaught exception is raised, the wrapper calls technical_500_response()
+    to create a response for django's debug view.
 
-    Runserver_plus overrides the django debug view's technical_500_response function with this
-    to allow for an enhanced WSGI debugger view to be displayed. However, because Django calls
-    convert_exception_to_response on each object in the stack of Middleware objects, re-raising an error
-    quickly pollutes the traceback displayed.
+    Runserver_plus overrides the django debug view's technical_500_response() function to allow for
+    an enhanced WSGI debugger view to be displayed. However, because Django calls
+    convert_exception_to_response() on each object in the stack of Middleware objects, re-raising an
+    error quickly pollutes the traceback displayed.
 
     Runserver_plus only needs needs traceback frames relevant to WSGIHandler Middleware objects, so
-    only raise the traceback if it is for a WSGIHandler. If an exception is not raised here, Django
+    only store the traceback if it is for a WSGIHandler. If an exception is not raised here, Django
     eventually throws an error for not getting a valid response object for its debug view.
     """
-    global wsgi_tb
 
-    # After an uncaught exception is raised the class can be found in the second frame of the tb
+    # Store the most recent tb for WSGI requests. The class can be found in the second frame of the tb
     if isinstance(tb.tb_next.tb_frame.f_locals['self'], WSGIHandler):
-        wsgi_tb = tb
-        six.reraise(exc_type, exc_value, tb)
-    else:
-        six.reraise(exc_type, exc_value, wsgi_tb)
+        tld.wsgi_tb = tb
+
+    elif tld.wsgi_tb:
+        tb = tld.wsgi_tb
+
+    six.reraise(exc_type, exc_value, tb)


### PR DESCRIPTION
For issue #1201. 

It felt a little hacky but I couldn't figure out a better way to do it, I'm open to suggestions. I tested on 2.7 and 3.7. The output looks much better now.

![image](https://user-images.githubusercontent.com/2342553/43433362-3a9c7a4c-9434-11e8-9ffb-75eaa21f72e7.png)
