### PR TITLE
Remove unnecessary img tag for the foreignkey search input.

### DIFF
--- a/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
+++ b/django_extensions/templates/django_extensions/widgets/foreignkey_searchinput.html
@@ -1,8 +1,6 @@
 {% load i18n staticfiles %}
 <input type="text" id="lookup_{{ name }}" value="{{ label }}" style="display:none;" />
-<a href="{{ related_url }}{{ url }}" class="related-lookup" id="lookup_id_{{ name }}" onclick="return showRelatedObjectLookupPopup(this);">
-    <img src="{% static "admin/img/selector-search.gif" %}" width="16" height="16" alt="{% trans "Lookup" %}" />
-</a>
+<a href="{{ related_url }}{{ url }}" class="related-lookup" id="lookup_id_{{ name }}" onclick="return showRelatedObjectLookupPopup(this);"></a>
 <script type="text/javascript">
 (function($) {
     var current_value = $('#id_{{ name }}').val();


### PR DESCRIPTION
This PR fixes https://github.com/django-extensions/django-extensions/issues/1221 (and similar https://github.com/django-extensions/django-extensions/issues/229, https://github.com/django-extensions/django-extensions/issues/786).

As mentioned in the issue, Django's css already add a background image for the `.related-lookup` class, so instead of adding the missing asset `admin/img/selector-search.gif` we can just remove the `img` tag.

Before this PR:

![add_registration___ms_kgi_admin](https://user-images.githubusercontent.com/950449/43805733-c861f0ba-9a55-11e8-863c-41da8651df73.png)

After this PR:

<img width="300" alt="add_registration___ms_kgi_admin" src="https://user-images.githubusercontent.com/950449/43805696-9ccd8db0-9a55-11e8-9d18-d1f4a8f91302.png">
