### PR TITLE
Fix #1220

### DIFF
--- a/django_extensions/admin/widgets.py
+++ b/django_extensions/admin/widgets.py
@@ -35,7 +35,7 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
 
     def label_for_value(self, value):
         key = self.rel.get_related_field().name
-        obj = self.rel.related_model._default_manager.get(**{key: value})
+        obj = self.rel.model._default_manager.get(**{key: value})
 
         return Truncator(obj).words(14, truncate='...')
 
@@ -46,7 +46,7 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
     def render(self, name, value, attrs=None):
         if attrs is None:
             attrs = {}
-        opts = self.rel.related_model._meta
+        opts = self.rel.model._meta
         app_label = opts.app_label
         model_name = opts.object_name.lower()
         related_url = reverse('admin:%s_%s_changelist' % (app_label, model_name))

--- a/tests/test_admin_widgets.py
+++ b/tests/test_admin_widgets.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
 from django.test import TestCase
-from django.test.utils import override_settings
 from django.utils.text import Truncator
 
 from django_extensions.admin import widgets

--- a/tests/test_admin_widgets.py
+++ b/tests/test_admin_widgets.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import mock
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils.text import Truncator
+
+from django_extensions.admin import widgets
+
+from .testapp import models
+
+
+class ForeignKeySearchInputTestCase(TestCase):
+
+    def test_widget_works(self):
+        name = models.Name.objects.create(name="Name")
+        person = models.Person.objects.create(
+            name=name,
+            age=30,
+        )
+        club = models.Club.objects.create(
+            name='Club',
+        )
+        membership = models.Membership.objects.create(club=club, person=person)
+
+        widget = widgets.ForeignKeySearchInput(
+            models.Membership._meta.get_field('person').remote_field,
+            ['person__name'])
+
+        label = widget.label_for_value(membership.pk)
+
+        self.assertEqual(
+            Truncator(person).words(14, truncate='...'),
+            label)
+
+        # Just making sure rendering the widget doesn't cause any issue
+        widget.render('person', person.pk)
+        widget.render('person', None)

--- a/tests/testapp/admin.py
+++ b/tests/testapp/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from . import models
+
+admin.site.register(models.Person)


### PR DESCRIPTION
See https://github.com/django-extensions/django-extensions/issues/1220#issuecomment-418286073 for details.

I wasn't sure how to test the specific change I made so I created an `admin.py` file in the `testapp` to register the `Person` model and tested the widget behavior against it. Without the fix, the test output would be as follow:

<img width="1679" alt="1__arthur_arthurs-macbook-pro____code_django-extensions__zsh_" src="https://user-images.githubusercontent.com/950449/45054592-46fb3b00-b042-11e8-8463-591cfa083e38.png">
