### PR TITLE
Add feature to Graph model : disable_abstract_fields

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -58,6 +58,12 @@ class Command(BaseCommand):
                 'dest': 'disable_fields',
                 'help': 'Do not show the class member fields',
             },
+            '--disable-abstract-fields': {
+                'action': 'store_true',
+                'default': False,
+                'dest': 'disable_abstract_fields',
+                'help': 'Do not show the class member fields that were inherited',
+            },
             '--group-models -g': {
                 'action': 'store_true',
                 'default': False,

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -60,6 +60,7 @@ class ModelGraph(object):
         self.graphs = []
         self.cli_options = kwargs.get('cli_options', None)
         self.disable_fields = kwargs.get('disable_fields', False)
+        self.disable_abstract_fields = kwargs.get('disable_abstract_fields', False)
         self.include_models = parse_file_or_list(
             kwargs.get('include_models', "")
         )
@@ -103,6 +104,7 @@ class ModelGraph(object):
             'created_at': now.strftime("%Y-%m-%d %H:%M"),
             'cli_options': self.cli_options,
             'disable_fields': self.disable_fields,
+            'disable_abstract_fields': self.disable_abstract_fields,
             'use_subgraph': self.use_subgraph,
         }
 

--- a/django_extensions/templates/django_extensions/graph_models/label.dot
+++ b/django_extensions/templates/django_extensions/graph_models/label.dot
@@ -18,11 +18,13 @@
     {{ model.label }}{% if model.abstracts %}<BR/>&lt;<FONT FACE="Helvetica Italic">{{ model.abstracts|join:"," }}</FONT>&gt;{% endif %}
     </FONT></TD></TR>
   {% if not disable_fields %}{% for field in model.fields %}
+  {% if not disable_abstract_fields or not field.abstract %}
     <TR><TD ALIGN="LEFT" BORDER="0">
     <FONT {% if not field.primary_key and field.blank %}COLOR="#7B7B7B" {% endif %}FACE="Helvetica {% if field.abstract %}Italic{% endif %}{% if field.relation or field.primary_key %}Bold{% endif %}">{{ field.label }}</FONT>
     </TD><TD ALIGN="LEFT">
     <FONT {% if not field.primary_key and field.blank %}COLOR="#7B7B7B" {% endif %}FACE="Helvetica {% if field.abstract %}Italic{% endif %}{% if field.relation or field.primary_key %}Bold{% endif %}">{{ field.type }}</FONT>
     </TD></TR>
+  {% endif %}
   {% endfor %}{% endif %}
     </TABLE>
     >]


### PR DESCRIPTION
[ This PR concerns the Graph Model extension ]

Hi there,

I am currently working on a project where I have a lot of inheritance going on and I was frustrated by the fact that there were no way not to display fields that were inherited.

There were only very few changes to make in order to tackle this issue, and a result, I have added a new command line option "--disable-abstract-fields".

Concerning what I am not sure for this PR : 
- Should I provide some unit tests ? (I am not sure how I would do it)
- Should I suggest a shorter command line attribute ? (with the `-d` taken for  `--disable-fields` I couldn't come up with a none confusing option)