### PR TITLE
Adds ability to enforce_max_length

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -101,6 +101,11 @@ class BaseEncryptedField(models.Field):
             return value
 
         if value and not value.startswith(self.prefix):
+            # We need to encode a unicode string into a byte string, first. 
+            # keyczar expects a bytestring, not a unicode string.   
+            if six.PY2: 
+                if type(value) == six.types.UnicodeType:    
+                    value = value.encode('utf-8')
             # Truncated encrypted content is unreadable,
             # so truncate before encryption
             max_length = self.unencrypted_length

--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -6,7 +6,6 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
-import logging
 
 try:
     from keyczar import keyczar


### PR DESCRIPTION
Adds a property to BaseEncryptedField 'enforce_max_length' that defaults to False.
Upon encrypting, the library currently warns and truncates the field value if it is beyond max length.
These changes allow for an error to be raised instead if enforce_max_length is set to true.

A test has also been created to verify the error is raised.