### PR TITLE
Improve module existence test in runscript

### DIFF
--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -179,7 +179,7 @@ class Command(EmailNotificationCommand):
                 try:
                     if importlib.util.find_spec(full_module_path) is None:
                         return False
-                except:
+                except Exception:
                     module_file = os.path.join(settings.BASE_DIR, *full_module_path.split('.')) + '.py'
                     if not os.path.isfile(module_file):
                         return False

--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -176,9 +176,13 @@ class Command(EmailNotificationCommand):
                 t = importlib.import_module(full_module_path)
             except ImportError as e:
                 # The parent package exists, but the module doesn't
-                module_file = os.path.join(settings.BASE_DIR, *full_module_path.split('.')) + '.py'
-                if not os.path.isfile(module_file):
-                    return False
+                try:
+                    if importlib.util.find_spec(full_module_path) is None:
+                        return False
+                except:
+                    module_file = os.path.join(settings.BASE_DIR, *full_module_path.split('.')) + '.py'
+                    if not os.path.isfile(module_file):
+                        return False
 
                 if silent:
                     return False

--- a/tests/test_runscript.py
+++ b/tests/test_runscript.py
@@ -2,6 +2,7 @@
 import os
 import six
 import sys
+import importlib
 
 from django.core.management import call_command
 from django.test import TestCase, override_settings
@@ -55,6 +56,13 @@ class InvalidImportScriptsTests(RunScriptTests):
         call_command('runscript', 'invalid_import_script')
         self.assertIn("Cannot import module 'tests.testapp.scripts.invalid_import_script'", sys.stdout.getvalue())
         self.assertRegexpMatches(sys.stdout.getvalue(), 'No module named (\')?(invalidpackage)\1?')
+
+    def test_prints_import_error_on_script_with_invalid_imports_reliably(self):
+        if hasattr(importlib, 'util') and hasattr(importlib.util, 'find_spec'):
+            with self.settings(BASE_DIR=os.path.dirname(os.path.abspath(__file__))):
+                call_command('runscript', 'invalid_import_script')
+                self.assertIn("Cannot import module 'tests.testapp.scripts.invalid_import_script'", sys.stdout.getvalue())
+                self.assertRegexpMatches(sys.stdout.getvalue(), 'No module named (\')?(invalidpackage)\1?')
 
 
 class InvalidScriptsTests(RunScriptTests):


### PR DESCRIPTION
Check if the import system actually didn't find the module, instead of just guessing the file name and testing if that file exists.
Because find_spec was added in Python 3.4, we still keep the old method.

I had the issue that import errors inside my scripts were swallowed because the scripts and manage.py are not where BASE_DIR is. That is fixed with this PR.

If you think this needs a test, tell me.