### PR TITLE
Fix deprecation warning on JSONField and EncryptedTextField

### DIFF
--- a/django_extensions/db/fields/encrypted.py
+++ b/django_extensions/db/fields/encrypted.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import warnings
 
+import django
 import six
 from django import forms
 from django.conf import settings
@@ -82,8 +83,12 @@ class BaseEncryptedField(models.Field):
             retval = value
         return retval
 
-    def from_db_value(self, value, expression, connection, context):
-        return self.to_python(value)
+    if django.VERSION < (2, ):
+        def from_db_value(self, value, expression, connection, context):
+            return self.to_python(value)
+    else:
+        def from_db_value(self, value, expression, connection):
+            return self.to_python(value)
 
     def get_db_prep_value(self, value, connection, prepared=False):
         if value and not value.startswith(self.prefix):

--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -13,8 +13,9 @@ more information.
 from __future__ import absolute_import
 
 import json
-import six
 
+import django
+import six
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -89,8 +90,12 @@ class JSONField(models.TextField):
             return dumps(value)
         return super(models.TextField, self).get_prep_value(value)
 
-    def from_db_value(self, value, expression, connection, context):
-        return self.to_python(value)
+    if django.VERSION < (2, ):
+        def from_db_value(self, value, expression, connection, context):
+            return self.to_python(value)
+    else:
+        def from_db_value(self, value, expression, connection):
+            return self.to_python(value)
 
     def get_db_prep_save(self, value, connection, **kwargs):
         """Convert our JSON object to a string before we save"""


### PR DESCRIPTION
fix this warning: "RemovedInDjango30Warning: Remove the context parameter from JSONField.from_db_value(). Support for it will be removed in Django 3.0."

Resolves #1263 