### PR TITLE
Update graph_model css to match 2018 style djangoproject.com

### DIFF
--- a/django_extensions/templates/django_extensions/graph_models/digraph.dot
+++ b/django_extensions/templates/django_extensions/graph_models/digraph.dot
@@ -3,18 +3,18 @@
   // Created: {{ created_at }}
   {% if cli_options %}// Cli Options: {{ cli_options }}{% endif %}
 
-  {% block digraph_options %}fontname = "Helvetica"
+  {% block digraph_options %}fontname = "Roboto"
   fontsize = 8
   splines  = true{% endblock %}
 
   node [{% block node_options %}
-    fontname = "Helvetica"
+    fontname = "Roboto"
     fontsize = 8
     shape = "plaintext"
   {% endblock %}]
 
   edge [{% block edge_options %}
-    fontname = "Helvetica"
+    fontname = "Roboto"
     fontsize = 8
   {% endblock %}]
 

--- a/django_extensions/templates/django_extensions/graph_models/label.dot
+++ b/django_extensions/templates/django_extensions/graph_models/label.dot
@@ -2,8 +2,8 @@
     label=<
           <TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0">
           <TR><TD COLSPAN="2" CELLPADDING="4" ALIGN="CENTER">
-          <FONT FACE="Helvetica Bold" COLOR="Black" POINT-SIZE="12">
-          {{ graph.app_name }}
+          <FONT FACE="Roboto" COLOR="Black" POINT-SIZE="10">
+          <B>{{ graph.app_name }}</B>
           </FONT>
           </TD></TR>
           </TABLE>
@@ -12,20 +12,17 @@
     style="rounded"{% endif %}
 {% indentby 2 if use_subgraph %}{% for model in graph.models %}
   {{ model.app_name }}_{{ model.name }} [label=<
-    <TABLE BGCOLOR="palegoldenrod" BORDER="0" CELLBORDER="0" CELLSPACING="0">
-    <TR><TD COLSPAN="2" CELLPADDING="4" ALIGN="CENTER" BGCOLOR="olivedrab4">
-    <FONT FACE="Helvetica Bold" COLOR="white">
-    {{ model.label }}{% if model.abstracts %}<BR/>&lt;<FONT FACE="Helvetica Italic">{{ model.abstracts|join:"," }}</FONT>&gt;{% endif %}
-    </FONT></TD></TR>
+    <TABLE BGCOLOR="white" BORDER="1" CELLBORDER="0" CELLSPACING="0">
+    <TR><TD COLSPAN="2" CELLPADDING="5" ALIGN="CENTER" BGCOLOR="#1b563f">
+    <FONT FACE="Roboto" COLOR="white" POINT-SIZE="10"><B>
+    {{ model.label }}{% if model.abstracts %}<BR/>&lt;<FONT FACE="Roboto"><I>{{ model.abstracts|join:"," }}</I></FONT>&gt;{% endif %}
+    </B></FONT></TD></TR>
   {% if not disable_fields %}{% for field in model.fields %}
-  {% if disable_abstract_fields and field.abstract %}
-  {% else %}
     <TR><TD ALIGN="LEFT" BORDER="0">
-    <FONT {% if not field.primary_key and field.blank %}COLOR="#7B7B7B" {% endif %}FACE="Helvetica {% if field.abstract %}Italic{% endif %}{% if field.relation or field.primary_key %}Bold{% endif %}">{{ field.label }}</FONT>
+    <FONT {% if not field.primary_key and field.blank %}COLOR="#7B7B7B" {% endif %}FACE="Roboto">{% if field.abstract %}<I>{% endif %}{% if field.relation or field.primary_key %}<B>{% endif %}{{ field.label }}{% if field.abstract %}</I>{% endif %}{% if field.relation or field.primary_key %}</B>{% endif %}</FONT>
     </TD><TD ALIGN="LEFT">
-    <FONT {% if not field.primary_key and field.blank %}COLOR="#7B7B7B" {% endif %}FACE="Helvetica {% if field.abstract %}Italic{% endif %}{% if field.relation or field.primary_key %}Bold{% endif %}">{{ field.type }}</FONT>
+    <FONT {% if not field.primary_key and field.blank %}COLOR="#7B7B7B" {% endif %}FACE="Roboto">{% if field.abstract %}<I>{% endif %}{% if field.relation or field.primary_key %}<B>{% endif %}{{ field.type }}{% if field.abstract %}</I>{% endif %}{% if field.relation or field.primary_key %}</B>{% endif %}</FONT>
     </TD></TR>
-  {% endif %}
   {% endfor %}{% endif %}
     </TABLE>
     >]

--- a/django_extensions/templates/django_extensions/graph_models/relation.dot
+++ b/django_extensions/templates/django_extensions/graph_models/relation.dot
@@ -1,10 +1,10 @@
 {% for model in graph.models %}{% for relation in model.relations %}{% if relation.needs_node %}  {{ relation.target_app }}_{{ relation.target }} [label=<
-  <TABLE BGCOLOR="palegoldenrod" BORDER="0" CELLBORDER="0" CELLSPACING="0">
-  <TR><TD COLSPAN="2" CELLPADDING="4" ALIGN="CENTER" BGCOLOR="olivedrab4">
-  <FONT FACE="Helvetica Bold" COLOR="white">{{ relation.target }}</FONT>
+  <TABLE BGCOLOR="white" BORDER="0" CELLBORDER="0" CELLSPACING="0">
+  <TR><TD COLSPAN="2" CELLPADDING="4" ALIGN="CENTER" BGCOLOR="#1b563f">
+  <FONT FACE="Roboto" POINT-SIZE="12" COLOR="white">{{ relation.target }}</FONT>
   </TD></TR>
   </TABLE>
   >]{% endif %}
   {{ model.app_name }}_{{ model.name }} -> {{ relation.target_app }}_{{ relation.target }}
-  [label="{{ relation.label }}"] {{ relation.arrows }};
+  [label=" {{ relation.label }}"] {{ relation.arrows }};
 {% endfor %}{% endfor %}


### PR DESCRIPTION
First cut of an attempt to update the default style from the ~2005 version of djangoproject to the current style.

Removes pale golden rod and olive green for djangoproject green and white. Also uses Roboto, which is a Google Font, but for some output formats would be required to be installed natively on the system (as would Helvetica Bold, which is not on maOS Mojave, causing some font issues when generating SVGs)

Sample before/after

<img width="1046" alt="screen shot 2018-11-10 at 9 32 54 am" src="https://user-images.githubusercontent.com/813732/48291927-4e204880-e4cc-11e8-8d45-31bef055e56b.png">


