### PR TITLE
Update set_fake_passwords.py

### DIFF
--- a/django_extensions/management/commands/set_fake_passwords.py
+++ b/django_extensions/management/commands/set_fake_passwords.py
@@ -18,7 +18,7 @@ DEFAULT_FAKE_PASSWORD = 'password'
 
 class Command(BaseCommand):
     help = 'DEBUG only: sets all user passwords to a common value ("%s" by default)' % (DEFAULT_FAKE_PASSWORD, )
-    requires_model_validation = False
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)


### PR DESCRIPTION
requires_model_validation has been replaced with requires_system_checks sinc 1.9 see https://docs.djangoproject.com/en/1.11/internals/deprecation/