### PR TITLE
Handle function-based middleware in null_technical_500_response

### DIFF
--- a/django_extensions/management/technical_response.py
+++ b/django_extensions/management/technical_response.py
@@ -12,7 +12,7 @@ def null_technical_500_response(request, exc_type, exc_value, tb, status_code=50
     """Function to override django.views.debug.technical_500_response.
 
     Django's convert_exception_to_response() wrapper is called on each 'Middleware' object to avoid
-    leaking exceptions. If and uncaught exception is raised, the wrapper calls technical_500_response()
+    leaking exceptions. If an uncaught exception is raised, the wrapper calls technical_500_response()
     to create a response for django's debug view.
 
     Runserver_plus overrides the django debug view's technical_500_response() function to allow for
@@ -27,7 +27,7 @@ def null_technical_500_response(request, exc_type, exc_value, tb, status_code=50
 
     try:
         # Store the most recent tb for WSGI requests. The class can be found in the second frame of the tb
-        if isinstance(tb.tb_next.tb_frame.f_locals['self'], WSGIHandler):
+        if isinstance(tb.tb_next.tb_frame.f_locals.get('self'), WSGIHandler):
             tld.wsgi_tb = tb
         elif tld.wsgi_tb:
             tb = tld.wsgi_tb


### PR DESCRIPTION
See #1273 "runserver_plus shows wrong traceback if using any function-based middlewares"

The `null_technical_500_response` function expects to find `'self'` in the `f_locals` dictionary of a certain traceback frame. It will be present for class-based middlewares, but not function-based middlewares. If it's not present a `KeyError` is thrown and the traceback in the browser is corrupted.

I'm not sure how this should be tested, or whether it needs to be.
