### PR TITLE
Append shell_plus DB queries to the query log

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -445,6 +445,11 @@ class Command(BaseCommand):
                         execution_time = time.time() - starttime
                         raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
 
+                        self.db.queries_log.append({
+                            'sql': raw_sql,
+                            'time': "%.3f" % execution_time,
+                        })
+
                         if sqlparse:
                             raw_sql = raw_sql[:truncate]
                             raw_sql = sqlparse.format(raw_sql, **sqlparse_format_kwargs)


### PR DESCRIPTION
The shell_plus  management command replaces the default Django `CursorDebugWrapper` with its own wrapper. The default wrapper has a useful feature which is to record all DB queries onto a log for debug/review purposes.

This log is accessable at [`django.db.connection.queries`](https://github.com/django/django/blob/de7f6b51b21747e19e90d9e3e04e0cdbf84e8a75/django/db/backends/base/base.py#L153), and can be very useful when debugging code in the shell, especially code with many queries. It's explicitly documented in the Django FAQ [here](https://docs.djangoproject.com/en/2.1/faq/models/#how-can-i-see-the-raw-sql-queries-django-is-running).

The default Django cursor behavior is [here](https://github.com/django/django/blob/de7f6b51b21747e19e90d9e3e04e0cdbf84e8a75/django/db/backends/utils.py#L104). This behavior has existed since before Django 1.11, and exists in all versions of Django supported by django-extensions.

The current shell_plus behavior doesn't append to this log, and so prevents `connection.queries` from working. This change copies the existing Django logic to ensure that all shell queries get added to the log.

---

As this is my first contribution to this project, three related questions (also happy to move these to a new issue if that'd be preferable):

1. There's a good bit of duplicated code between the way the debug SQL cursors are implemented in [shell_plus](https://github.com/django-extensions/django-extensions/blob/cf9ef1725d2eae232388cd57e649917efe19f68b/django_extensions/management/commands/shell_plus.py#L439) and [runserver_plus](https://github.com/django-extensions/django-extensions/blob/cf9ef1725d2eae232388cd57e649917efe19f68b/django_extensions/management/commands/runserver_plus.py#L158). Would there be interest/support in a PR that unified these (keeping the current minor differences), which would reduce duplication and potentially allow for unit testing?
2. Is the decision to skip the parent `CursorDebugWrapper.execute` call and instead [invoke `CursorWrapper.execute` directly](https://github.com/django-extensions/django-extensions/blob/master/django_extensions/management/commands/runserver_plus.py#L162) a deliberate one, as presumed [here](https://github.com/django-extensions/django-extensions/pull/1186#issuecomment-374886515)? It's true that calling `super` directly would invoke the `logger.debug` message [here](https://github.com/django/django/blob/de7f6b51b21747e19e90d9e3e04e0cdbf84e8a75/django/db/backends/utils.py#L108), but that doesn't seem like such a bad thing to me, especially if it means that we wouldn't have to duplicate the query log logic like I'm doing in this PR.
3. Is the fact that `CursorDebugWrapper.execute` is logged but `CursorDebugWrapper.execute_many` is not covered intentional? Would it be desirable to add `execute_many` functionality as well?