### PR TITLE
Add workaround for extension checking on django22 with i18n

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -357,7 +357,7 @@ class Command(BaseCommand):
             webbrowser.open(bind_url)
 
         if use_reloader and settings.USE_I18N:
-            extra_files.extend(filter(lambda filename: filename.endswith('.mo'), gen_filenames()))
+            extra_files.extend(filter(lambda filename: str(filename).endswith('.mo'), gen_filenames()))
 
         # Werkzeug needs to be clued in its the main instance if running
         # without reloader or else it won't show key.


### PR DESCRIPTION
Following up https://github.com/django-extensions/django-extensions/issues/1295

Added a workaround on using `.endswith` on a Path (from pathlib). 

Since there are two possible datatypes for `filename` (str and PosixPath), I just wrap it around str(). 
In the case of str, we get the same string, in case of PosixPath, we get the path as a string.

Let me know, if there's anything I should add/modify.

Also, maybe too much ask, but can we get a release after? The current one on pypi, breaks due to this issue with the latest django version (https://pypi.org/project/django-extensions/)