### PR TITLE
PosixPath has no attribute endswith

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -357,7 +357,7 @@ class Command(BaseCommand):
             webbrowser.open(bind_url)
 
         if use_reloader and settings.USE_I18N:
-            extra_files.extend(filter(lambda filename: filename.endswith('.mo'), gen_filenames()))
+            extra_files.extend(filter(lambda filename: str(filename).endswith('.mo'), gen_filenames()))
 
         # Werkzeug needs to be clued in its the main instance if running
         # without reloader or else it won't show key.


### PR DESCRIPTION
With the following python setup:

`
platform linux -- Python 3.7.2, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
Django settings: tests.testapp.settings (from command line option)
rootdir: /home/kuter/workspace/github/django-extensions, inifile: setup.cfg
plugins: django-3.4.8, cov-2.6.1
`

I get an error when runserver_plus test executed:

extra_files.extend(filter(lambda filename: filename.endswith('.mo'), gen_filenames()))
AttributeError: 'PosixPath' object has no attribute 'endswith

Seems like gen_filenames() returns list of PosixPath instead of strings so I've added converting it to a string.