### PR TITLE
Replace `super().find_unique()` with `self.find_unique()`

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -198,7 +198,7 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
             setattr(model_instance, self.attname, slug)
             return slug
 
-        return super(AutoSlugField, self).find_unique(
+        return self.find_unique(
             model_instance, slug_field, self.slug_generator(original_slug, start))
 
     def get_slug_fields(self, model_instance, lookup_value):


### PR DESCRIPTION
Solves #1311

This way one is able to override `find_unique` as expected.