### PR TITLE
MANIFEST.in: Add tests to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,10 @@
 recursive-include django_extensions/conf *.tmpl
-recursive-include django_extensions/templates *
+recursive-include django_extensions/templates *.dot *.html
 recursive-include django_extensions/static *
-recursive-include django_extensions/locale *
+recursive-include django_extensions/locale *.po *.mo
 recursive-include docs *
 include LICENSE
 include README.rst
-include tox.ini
+include CHANGELOG.md
+include tox.ini manage.py Makefile
+recursive-include tests *.py


### PR DESCRIPTION
Also adds other sdist build related files, and
tighten up the other recursive includes to avoid
accidentally including undesirable files.

Closes https://github.com/django-extensions/django-extensions/issues/1307