### PR TITLE
Tests for cache_cleanup job

### DIFF
--- a/django_extensions/jobs/daily/cache_cleanup.py
+++ b/django_extensions/jobs/daily/cache_cleanup.py
@@ -5,12 +5,11 @@ Daily cleanup job.
 Can be run as a cronjob to clean out old data from the database (only expired
 sessions at the moment).
 """
-
-from contextlib import contextmanager
-
 import six
 
-from django.utils import timezone
+from django.conf import settings
+from django.core.cache import caches
+
 from django_extensions.management.jobs import DailyJob
 
 
@@ -18,43 +17,9 @@ class Job(DailyJob):
     help = "Cache (db) cleanup Job"
 
     def execute(self):
-        from django.conf import settings
-        from django.db import transaction
-        import os
-
-        if hasattr(transaction, 'atomic'):
-            atomic = transaction.atomic
-        else:
-            @contextmanager
-            def atomic(using=None):
-                yield
-                transaction.commit_unless_managed(using=using)
-
         if hasattr(settings, 'CACHES'):
-            from django.core.cache import caches
-            from django.db import router, connections
-
             for cache_name, cache_options in six.iteritems(settings.CACHES):
                 if cache_options['BACKEND'].endswith("DatabaseCache"):
                     cache = caches[cache_name]
-                    db = router.db_for_write(cache.cache_model_class)
-                    with atomic(using=db):
-                        cursor = connections[db].cursor()
-                        now = timezone.now()
-                        cache._cull(db, cursor, now)
+                    cache.clear()
             return
-
-        if hasattr(settings, 'CACHE_BACKEND'):
-            if settings.CACHE_BACKEND.startswith('db://'):
-                from django.db import connection
-                os.environ['TZ'] = settings.TIME_ZONE
-                table_name = settings.CACHE_BACKEND[5:]
-
-                with atomic():
-                    cursor = connection.cursor()
-                    cursor.execute(
-                        "DELETE FROM %s WHERE %s < current_timestamp;" % (
-                            connection.ops.quote_name(table_name),
-                            connection.ops.quote_name('expires')
-                        )
-                    )

--- a/tests/jobs/daily/test_cache_cleanup.py
+++ b/tests/jobs/daily/test_cache_cleanup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.core.cache import caches
 from django.core.management import call_command
 from django.test import TestCase

--- a/tests/jobs/daily/test_cache_cleanup.py
+++ b/tests/jobs/daily/test_cache_cleanup.py
@@ -1,0 +1,26 @@
+from django.core.cache import caches
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+
+
+class CacheCleanupTests(TestCase):
+    """Tests for cache_cleanup job."""
+
+    def test_should_not_do_anything_if_settings_does_not_have_CACHES_settings(self):
+        call_command('runjob', 'cache_cleanup', verbosity=2)
+
+    @override_settings(CACHES={
+        'test_cache': {
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': 'my_cache_table',
+        }
+    })
+    def test_remove_all_keys_from_DatabaseCache(self):
+        call_command('createcachetable')
+        db_cache = caches['test_cache']
+        db_cache.set('my_key', 'hello world')
+
+        call_command('runjob', 'cache_cleanup', verbosity=2)
+
+        self.assertIsNone(db_cache.get('my_key'))


### PR DESCRIPTION
* according to the django documentation CACHE_BACKEND setting will be removed, cache backend should be specified in the CACHES setting - so I removed unused if statement
* I've changed way of deleting keys from cache - now its done by simple cache.clear() method
* I didn't change job behaviour - it still clear only DatabaseCache