### PR TITLE
Fix HStoreField for newer versions of django

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -878,7 +878,7 @@ class PostgresqlSQLDiff(SQLDiff):
     can_detect_unsigned_differ = True
 
     DATA_TYPES_REVERSE_NAME = {
-        'hstore': 'django_hstore.hstore.DictionaryField',
+        'hstore': 'django.contrib.postgres.fields.HStoreField',
     }
 
     # Hopefully in the future we can add constraint checking and other more


### PR DESCRIPTION
sqldiff command causes exception:

```
Traceback (most recent call last):
  File "./manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1265, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 316, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1252, in execute
    super(Command, self).execute(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 353, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/utils.py", line 59, in inner
    ret = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1245, in handle
    sqldiff_instance.find_differences()
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 665, in find_differences
    self.find_field_type_differ(meta, table_description, table_name)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 539, in find_field_type_differ
    db_type = self.get_field_db_type(description, field, table_name)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1068, in get_field_db_type
    db_type = super(PostgresqlSQLDiff, self).get_field_db_type(description, field, table_name)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 342, in get_field_db_type
    field_class = self.get_field_class(reverse_type)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 359, in get_field_class
    module = importlib.import_module(module_path)
  File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 941, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'django_hstore'
```

After `pip install django-hstore` here appears another error:

```
Traceback (most recent call last):
  File "./manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1265, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 316, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1252, in execute
    super(Command, self).execute(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 353, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/utils.py", line 59, in inner
    ret = func(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1245, in handle
    sqldiff_instance.find_differences()
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 665, in find_differences
    self.find_field_type_differ(meta, table_description, table_name)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 539, in find_field_type_differ
    db_type = self.get_field_db_type(description, field, table_name)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 1068, in get_field_db_type
    db_type = super(PostgresqlSQLDiff, self).get_field_db_type(description, field, table_name)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 342, in get_field_db_type
    field_class = self.get_field_class(reverse_type)
  File "/usr/local/lib/python3.6/site-packages/django_extensions/management/commands/sqldiff.py", line 359, in get_field_class
    module = importlib.import_module(module_path)
  File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.6/site-packages/django_hstore/hstore.py", line 1, in <module>
    from django_hstore.fields import DictionaryField, ReferencesField, SerializedDictionaryField  # noqa
  File "/usr/local/lib/python3.6/site-packages/django_hstore/fields.py", line 11, in <module>
    from .descriptors import HStoreDescriptor, HStoreReferenceDescriptor, SerializedDictDescriptor
  File "/usr/local/lib/python3.6/site-packages/django_hstore/descriptors.py", line 12, in <module>
    class HStoreDescriptor(models.fields.subclassing.Creator):
AttributeError: module 'django.db.models.fields' has no attribute 'subclassing'
```