### PR TITLE
Turn ModificationDateTimeField name changeable

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -410,7 +410,7 @@ class ModificationDateTimeField(CreationDateTimeField):
 
     def pre_save(self, model_instance, add):
         if not getattr(model_instance, 'update_modified', True):
-            return model_instance.modified
+            return getattr(model_instance, self.attname)
         return super(ModificationDateTimeField, self).pre_save(model_instance, add)
 
 

--- a/tests/test_modificationdatetime_fields.py
+++ b/tests/test_modificationdatetime_fields.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from django.test import TestCase
+
+from .testapp.models import (
+    ModelModificationDateTimeField,
+    CustomModelModificationDateTimeField,
+    DisabledUpdateModelModificationDateTimeField,
+)
+
+
+class ModificationDatetimeFieldTest(TestCase):
+    def test_update_model_with_modification_field(self):
+        m = ModelModificationDateTimeField.objects.create()
+        current_updated_time = m.modified
+        m.field_to_update = False
+        m.save()
+        self.assertNotEqual(m.modified, current_updated_time)
+
+    def test_custom_modification_field_name(self):
+        m = CustomModelModificationDateTimeField.objects.create()
+        current_updated_time = m.custom_modified
+        m.field_to_update = False
+        m.save()
+        self.assertNotEqual(m.custom_modified, current_updated_time)
+
+    def test_disabled_update_modification_field(self):
+        m = DisabledUpdateModelModificationDateTimeField.objects.create(modified=datetime.now())
+        current_updated_time = m.modified
+        m.field_to_update = False
+        m.save()
+        self.assertEqual(m.modified, current_updated_time)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.db import models
 
-from django_extensions.db.fields import AutoSlugField, RandomCharField, ShortUUIDField
+from django_extensions.db.fields import AutoSlugField, RandomCharField, ShortUUIDField, ModificationDateTimeField
 from django_extensions.db.fields.json import JSONField
 from django_extensions.db.models import ActivatorModel, TimeStampedModel
 
@@ -297,3 +297,29 @@ class SqlDiffUniqueTogether(models.Model):
 
 class Photo(models.Model):
     photo = models.FileField()
+
+
+class CustomModelModificationDateTimeField(models.Model):
+    field_to_update = models.BooleanField(default=True)
+    custom_modified = ModificationDateTimeField()
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
+class ModelModificationDateTimeField(models.Model):
+    field_to_update = models.BooleanField(default=True)
+    modified = ModificationDateTimeField()
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
+class DisabledUpdateModelModificationDateTimeField(models.Model):
+    field_to_update = models.BooleanField(default=True)
+    modified = ModificationDateTimeField()
+
+    update_modified = False
+
+    class Meta:
+        app_label = 'django_extensions'


### PR DESCRIPTION
PR related to issue #1322

This PR removes the hardcoded 'modified' on the ModificationDateTimeField and implements some basic tests to the field.