### PR TITLE
issue #1374 extend support for custom slugify function in AutoSlugFied

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -99,6 +99,34 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
     overwrite
         If set to True, overwrites the slug on every save (default: False)
 
+    slugify_function
+        Defines the function which will be used to "slugify" a content
+        (default: :py:func:`~django.template.defaultfilters.slugify` )
+
+    It is possible to provide custom "slugify" function with
+    the ``slugify_function`` function in a model class.
+
+    ``slugify_function`` function in a model class takes priority over
+    ``slugify_function`` given as an argument to :py:class:`~AutoSlugField`.
+
+    Example
+
+    .. code-block:: python
+
+        # models.py
+
+        from django.db import models
+
+        from django_extensions.db.fields import AutoSlugField
+
+
+        class MyModel(models.Model):
+            def slugify_function(self, content):
+                return content.replace('_', '-').lower()
+
+            title = models.CharField(max_length=42)
+            slug = AutoSlugField(populate_from='title')
+
     Inspired by SmileyChris' Unique Slugify snippet:
     http://www.djangosnippets.org/snippets/690/
     """
@@ -143,9 +171,10 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
         value = re.sub('%s+' % re_sep, self.separator, value)
         return re.sub(r'^%s+|%s+$' % (re_sep, re_sep), '', value)
 
-    def slugify_func(self, content):
+    @staticmethod
+    def slugify_func(content, slugify_function):
         if content:
-            return self.slugify_function(content)
+            return slugify_function(content)
         return ''
 
     def slug_generator(self, original_slug, start):
@@ -179,10 +208,15 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
         populate_from = self._populate_from
         if not isinstance(populate_from, (list, tuple)):
             populate_from = (populate_from, )
+
         slug_field = model_instance._meta.get_field(self.attname)
+        slugify_function = getattr(model_instance, 'slugify_function', self.slugify_function)
 
         # slugify the original field content and set next step to 2
-        slug_for_field = lambda lookup_value: self.slugify_func(self.get_slug_fields(model_instance, lookup_value))
+        slug_for_field = lambda lookup_value: self.slugify_func(
+            self.get_slug_fields(model_instance, lookup_value),
+            slugify_function=slugify_function
+        )
         slug = self.separator.join(map(slug_for_field, populate_from))
         start = 2
 

--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -48,6 +48,13 @@ class TitleSlugDescriptionModel(TitleDescriptionModel):
 
     An abstract base class model that provides title and description fields
     and a self-managed "slug" field that populates from the title.
+
+    .. note ::
+        If you want to use custom "slugify" function, you could
+        define ``slugify_function`` which then will be used
+        in :py:class:`AutoSlugField` to slugify ``populate_from`` field.
+
+        See :py:class:`AutoSlugField` for more details.
     """
 
     slug = AutoSlugField(_('slug'), populate_from='title')

--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -20,6 +20,58 @@ Current Database Model Field Extensions
 
     slug = AutoSlugField(populate_from=['related_model__title', 'related_model__get_readable_name'])
 
+  AutoSlugField uses Django's slugify_ function by default to "slugify" ``populate_from`` field.
+
+  .. _slugify: https://docs.djangoproject.com/en/dev/ref/utils/#django.utils.text.slugify
+
+  To provide custom "slugify" function you could either provide the function as
+  an argument to :py:class:`~AutoSlugField` or define your ``slugify_function``
+  method within a model.
+
+1. ``slugify_function`` as an argument to :py:class:`~AutoSlugField`.
+
+  .. code-block:: python
+
+    # models.py
+
+    from django.db import models
+
+    from django_extensions.db.fields import AutoSlugField
+
+
+    def my_slugify_function(content):
+        return content.replace('_', '-').lower()
+
+
+    class MyModel(models.Model):
+
+        title = models.CharField(max_length=42)
+        slug = AutoSlugField(populate_from='title', slugify_function=my_slugify_function)
+
+2. ``slugify_function`` as a method within a model class.
+
+  .. code-block:: python
+
+    # models.py
+
+    from django.db import models
+
+    from django_extensions.db.fields import AutoSlugField
+
+
+    class MyModel(models.Model):
+
+        title = models.CharField(max_length=42)
+        slug = AutoSlugField(populate_from='title')
+
+        def slugify_function(self, content):
+            return content.replace('_', '-').lower()
+
+  **Important.**
+  If you both provide ``slugify_function`` in a model class and
+  pass ``slugify_function`` to :py:class:`~AutoSlugField` field,
+  then model's ``slugify_function`` method will take precedence.
+
 * *RandomCharField* - AutoRandomCharField will automatically create a
   unique random character field with the specified length. By default
   upper/lower case and digits are included as possible characters. Given

--- a/docs/model_extensions.rst
+++ b/docs/model_extensions.rst
@@ -43,6 +43,28 @@ and modification, respectively
   ``TitleDescriptionModel``, provides ``title`` and ``description`` fields
   but also provides a self-managed ``slug`` field which populates from the title.
 
-That field's class is a custom defined ``AutoSlugField``, based on Django's
+That field's class is a custom defined `AutoSlugField <field_extensions.html>`_, based on Django's
 ``SlugField``. By default, it uses ``-`` as a separator, is unique and does
-not accept blank values
+not accept blank values.
+It is possible to customize ``slugify_function``
+by defining your custom function within a model:
+
+.. code-block:: python
+
+    # models.py
+
+    from django.db import models
+
+    from django_extensions.db.models import TitleSlugDescriptionModel
+
+
+    class MyModel(TitleSlugDescriptionModel, models.Model):
+
+        def slugify_function(self, content):
+            """
+            This function will be used to slugify
+            the title (default `populate_from` field)
+            """
+            return content.replace('_', '-').lower()
+
+See `AutoSlugField docs <field_extensions.html>`_ for more details.

--- a/tests/test_autoslug_fields.py
+++ b/tests/test_autoslug_fields.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
-import pytest
 import django
+import pytest
+import six
 from django.db import migrations, models
 from django.db.migrations.writer import MigrationWriter
 from django.test import TestCase
 from django.utils.encoding import force_bytes
-import six
 
 import django_extensions  # noqa
 from django_extensions.db.fields import AutoSlugField
 
-from .testapp.models import ChildSluggedTestModel, SluggedTestModel, SluggedTestNoOverwriteOnAddModel
-from .testapp.models import FKSluggedTestModel, FKSluggedTestModelCallable, FunctionSluggedTestModel
-from .testapp.models import ModelMethodSluggedTestModel
+from .testapp.models import (
+    ChildSluggedTestModel, CustomFuncPrecedenceSluggedTestModel, CustomFuncSluggedTestModel,
+    FKSluggedTestModel, FKSluggedTestModelCallable, FunctionSluggedTestModel,
+    ModelMethodSluggedTestModel, SluggedTestModel, SluggedTestNoOverwriteOnAddModel,
+)
 
 
 @pytest.mark.usefixtures("admin_user")
@@ -21,6 +23,8 @@ class AutoSlugFieldTest(TestCase):
         super(AutoSlugFieldTest, self).tearDown()
 
         SluggedTestModel.objects.all().delete()
+        CustomFuncSluggedTestModel.objects.all().delete()
+        CustomFuncPrecedenceSluggedTestModel.objects.all().delete()
 
     def test_auto_create_slug(self):
         m = SluggedTestModel(title='foo')
@@ -184,6 +188,34 @@ class AutoSlugFieldTest(TestCase):
         m = SluggedTestNoOverwriteOnAddModel(slug='slug', title='title')
         m.save()
         self.assertEqual(m.slug, 'slug')
+
+    def test_slugify_func(self):
+        to_upper = lambda c: c.upper()
+        to_lower = lambda c: c.lower()
+
+        content_n_func_n_expected = (
+            ('test', to_upper, 'TEST'),
+            ('', to_upper, ''),
+            ('TEST', to_lower, 'test'),
+        )
+
+        for content, slugify_function, expected in content_n_func_n_expected:
+            self.assertEqual(
+                AutoSlugField.slugify_func(content, slugify_function),
+                expected
+            )
+
+    def test_use_custom_slug_function(self):
+        m = CustomFuncSluggedTestModel(title='test')
+        m.save()
+        self.assertEqual(m.slug, 'TEST')
+
+    def test_precedence_custom_slug_function(self):
+        m = CustomFuncPrecedenceSluggedTestModel(title='test')
+        m.save()
+        self.assertEqual(m.slug, 'TEST')
+        self.assertTrue(hasattr(m._meta.get_field('slug'), 'slugify_function'))
+        self.assertEqual(m._meta.get_field('slug').slugify_function('TEST'), 'test')
 
 
 class MigrationTest(TestCase):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -91,6 +91,34 @@ class SluggedTestModel(models.Model):
         app_label = 'django_extensions'
 
 
+class CustomFuncSluggedTestModel(models.Model):
+
+    def slugify_function(self, content):
+        return content.upper()
+
+    title = models.CharField(max_length=42)
+    slug = AutoSlugField(populate_from='title')
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
+class CustomFuncPrecedenceSluggedTestModel(models.Model):
+    def custom_slug_one(self, content):
+        return content.upper()
+
+    def custom_slug_two(content):
+        return content.lower()
+
+    slugify_function = custom_slug_one
+
+    title = models.CharField(max_length=42)
+    slug = AutoSlugField(populate_from='title', slugify_function=custom_slug_two)
+
+    class Meta:
+        app_label = 'django_extensions'
+
+
 class ChildSluggedTestModel(SluggedTestModel):
     class Meta:
         app_label = 'django_extensions'


### PR DESCRIPTION
The [issue](https://github.com/django-extensions/django-extensions/issues/1374)

Extended support for custom `slugify_function` in `AutoSlugField`. Added support for `slugify_function` attribute within a model class.

Added documentation
Added tests