### PR TITLE
Add arrow_shape argument in graph_models

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -168,10 +168,10 @@ class Command(BaseCommand):
             },
             '--arrow-shape': {
                 'action': 'store',
+                'default': 'dot',
                 'dest': 'arrow_shape',
-                'help': 'Arrow shape to use for relations. \
-                    Default is dot. Available shapes: box, crow, \
-                    curve, icurve, diamond, dot, inv, none, normal, tee, vee.',
+                'choices': ['box', 'crow', 'curve', 'icurve', 'diamond', 'dot', 'inv', 'none', 'normal', 'tee', 'vee'],
+                'help': 'Arrow shape to use for relations. Default is dot. Available shapes: box, crow, curve, icurve, diamond, dot, inv, none, normal, tee, vee.',
             }
         }
 

--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -165,6 +165,13 @@ class Command(BaseCommand):
                 'default': False,
                 'dest': 'hide_edge_labels',
                 'help': 'Do not showrelations labels in the graph.',
+            },
+            '--arrow-shape': {
+                'action': 'store',
+                'dest': 'arrow_shape',
+                'help': 'Arrow shape to use for relations. \
+                    Default is dot. Available shapes: box, crow, \
+                    curve, icurve, diamond, dot, inv, none, normal, tee, vee.',
             }
         }
 

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -55,26 +55,6 @@ def parse_file_or_list(arg):
     return [e.strip() for e in arg.split(',')]
 
 
-def parse_arrow_shape(arg):
-    shapes = (
-        "box",
-        "crow",
-        "curve",
-        "icurve",
-        "diamond",
-        "dot",
-        "inv",
-        "none",
-        "normal",
-        "tee",
-        "vee"
-    )
-    if arg in shapes:
-        return arg
-    else:
-        return "dot"
-
-
 class ModelGraph(object):
     def __init__(self, app_labels, **kwargs):
         self.graphs = []
@@ -100,7 +80,7 @@ class ModelGraph(object):
             kwargs.get('exclude_models', "")
         )
         self.hide_edge_labels = kwargs.get('hide_edge_labels', False)
-        self.arrow_shape = parse_arrow_shape(kwargs.get("arrow_shape", None))
+        self.arrow_shape = kwargs.get("arrow_shape")
         if self.all_applications:
             self.app_labels = [app.label for app in apps.get_app_configs()]
         else:

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -55,6 +55,26 @@ def parse_file_or_list(arg):
     return [e.strip() for e in arg.split(',')]
 
 
+def parse_arrow_shape(arg):
+    shapes = (
+        "box",
+        "crow",
+        "curve",
+        "icurve",
+        "diamond",
+        "dot",
+        "inv",
+        "none",
+        "normal",
+        "tee",
+        "vee"
+    )
+    if arg in shapes:
+        return arg
+    else:
+        return "dot"
+
+
 class ModelGraph(object):
     def __init__(self, app_labels, **kwargs):
         self.graphs = []
@@ -80,6 +100,7 @@ class ModelGraph(object):
             kwargs.get('exclude_models', "")
         )
         self.hide_edge_labels = kwargs.get('hide_edge_labels', False)
+        self.arrow_shape = parse_arrow_shape(kwargs.get("arrow_shape", None))
         if self.all_applications:
             self.app_labels = [app.label for app in apps.get_app_configs()]
         else:
@@ -326,7 +347,7 @@ class ModelGraph(object):
         if isinstance(field, OneToOneField):
             relation = self.add_relation(field, newmodel, '[arrowhead=none, arrowtail=none, dir=both]')
         elif isinstance(field, ForeignKey):
-            relation = self.add_relation(field, newmodel, '[arrowhead=none, arrowtail=dot, dir=both]')
+            relation = self.add_relation(field, newmodel, f'[arrowhead=none, arrowtail={self.arrow_shape}, dir=both]')
         else:
             relation = None
         if relation is not None:
@@ -340,7 +361,7 @@ class ModelGraph(object):
         relation = None
         if isinstance(field, ManyToManyField):
             if hasattr(field.remote_field.through, '_meta') and field.remote_field.through._meta.auto_created:
-                relation = self.add_relation(field, newmodel, '[arrowhead=dot arrowtail=dot, dir=both]')
+                relation = self.add_relation(field, newmodel, f'[arrowhead={self.arrow_shape} arrowtail={self.arrow_shape}, dir=both]')
         elif isinstance(field, GenericRelation):
             relation = self.add_relation(field, newmodel, mark_safe('[style="dotted", arrowhead=normal, arrowtail=normal, dir=both]'))
         if relation is not None:

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -345,9 +345,17 @@ class ModelGraph(object):
             # excluding fields inherited from abstract classes. they too show as local_fields
             return newmodel
         if isinstance(field, OneToOneField):
-            relation = self.add_relation(field, newmodel, '[arrowhead=none, arrowtail=none, dir=both]')
+            relation = self.add_relation(
+                field, newmodel, '[arrowhead=none, arrowtail=none, dir=both]'
+            )
         elif isinstance(field, ForeignKey):
-            relation = self.add_relation(field, newmodel, f'[arrowhead=none, arrowtail={self.arrow_shape}, dir=both]')
+            relation = self.add_relation(
+                field,
+                newmodel,
+                '[arrowhead=none, arrowtail={}, dir=both]'.format(
+                    self.arrow_shape
+                ),
+            )
         else:
             relation = None
         if relation is not None:
@@ -361,7 +369,13 @@ class ModelGraph(object):
         relation = None
         if isinstance(field, ManyToManyField):
             if hasattr(field.remote_field.through, '_meta') and field.remote_field.through._meta.auto_created:
-                relation = self.add_relation(field, newmodel, f'[arrowhead={self.arrow_shape} arrowtail={self.arrow_shape}, dir=both]')
+                relation = self.add_relation(
+                    field,
+                    newmodel,
+                    '[arrowhead={} arrowtail={}, dir=both]'.format(
+                        self.arrow_shape, self.arrow_shape
+                    ),
+                )
         elif isinstance(field, GenericRelation):
             relation = self.add_relation(field, newmodel, mark_safe('[style="dotted", arrowhead=normal, arrowtail=normal, dir=both]'))
         if relation is not None:


### PR DESCRIPTION
This pull requests adds new optional argument '--arrow-shape' in graph_models. It allows to change arrow shape of a relation from 'dot' to other [alternatives](https://www.graphviz.org/doc/info/arrows.html).

I think it would be a great addition. I don't like the dot arrow and I had to change it manually in text editor after generating .dot file with graph_models.