### PR TITLE
Adds missing GIS engine for MySql to defaults.

### DIFF
--- a/django_extensions/settings.py
+++ b/django_extensions/settings.py
@@ -12,6 +12,7 @@ DEFAULT_SQLITE_ENGINES = (
 )
 DEFAULT_MYSQL_ENGINES = (
     'django.db.backends.mysql',
+    'django.contrib.gis.db.backends.mysql',
 )
 DEFAULT_POSTGRESQL_ENGINES = (
     'django.db.backends.postgresql',


### PR DESCRIPTION
To address:

https://github.com/django-extensions/django-extensions/issues/1371