### PR TITLE
Add a templatetag for breakpoint() debugging

### DIFF
--- a/django_extensions/templatetags/debugger_tags.py
+++ b/django_extensions/templatetags/debugger_tags.py
@@ -35,3 +35,9 @@ def wdb(obj):  # pragma: no cover
     """Web debugger filter."""
     __import__('wdb').set_trace()
     return obj
+
+
+@register.simple_tag
+def debugger():  # pragma: no cover
+    breakpoint()
+    return ''


### PR DESCRIPTION
PEP 553 introduced the breakpoint() builtin which is short for

```
import pdb; pdb.set_trace()
```

it either uses the default debugger or whatever is set in $PYTHONBREAKPOINT
e.g to use pudb
```
export PYTHONBREAKPOINT=pudb.set_trace
```

Usage should be `{% debugger %}`