### PR TITLE
Graph-models now permit the combination of includes and excludes

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -381,18 +381,18 @@ class ModelGraph(object):
         Decide whether to use a model, based on the model name and the lists of
         models to exclude and include.
         """
+        # Check against include list.
+        if self.include_models:
+            for model_pattern in self.include_models:
+                model_pattern = '^%s$' % model_pattern.replace('*', '.*')
+                if re.search(model_pattern, model_name):
+                    return True
         # Check against exclude list.
         if self.exclude_models:
             for model_pattern in self.exclude_models:
                 model_pattern = '^%s$' % model_pattern.replace('*', '.*')
                 if re.search(model_pattern, model_name):
                     return False
-        # Check against exclude list.
-        elif self.include_models:
-            for model_pattern in self.include_models:
-                model_pattern = '^%s$' % model_pattern.replace('*', '.*')
-                if re.search(model_pattern, model_name):
-                    return True
         # Return `True` if `include_models` is falsey, otherwise return `False`.
         return not self.include_models
 

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -138,6 +138,7 @@ class GraphModelsTests(TestCase):
             '*WildcardPrefixExclude',
             'WildcardSuffixExclude*',
             '*WildcardBothExclude*',
+            '*Include',
         ]
         # Any model name should be used if neither include or exclude
         # are defined.
@@ -219,6 +220,19 @@ class GraphModelsTests(TestCase):
             'MyWildcardBothExcludeModel',
             None,
             exclude_models,
+        ))
+        # Test with `exclude_models` and `include_models` combined
+        # where the user wants to exclude some models through a wildcard
+        # while still being able to include given models
+        self.assertTrue(use_model(
+            'MyWildcardPrefixInclude',
+            include_models,
+            exclude_models
+        ))
+        self.assertFalse(use_model(
+            'MyInclude',
+            include_models,
+            exclude_models
         ))
 
     def test_no_models_dot_py(self):


### PR DESCRIPTION
This change allows users to provide both --include (-I) and --exclude (-X) to filter given wildcard patterns, while being still able to only include given model names or given wildcards to match.

For example, one might want to exclude all models, using --include, then filter out some unwanted models through --exclude, e.g. M2M serving as translation service.

This would result to the following usage:
```
./manage.py -I 'Attribute*' -X '*Translation' <...>
```

Which basically tells graph-models to exclude all models, and only keep the ones having their name starting by "Attribute" and remove any of those that ends by the word "Translation".

---

Closes #1409.