### PR TITLE
don't replace . for template dirs in the notes command

### DIFF
--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -31,13 +31,12 @@ class Command(BaseCommand):
     @signalcommand
     def handle(self, *args, **options):
         # don't add django internal code
-        apps = [app for app in filter(lambda app: not app.startswith('django.contrib'), settings.INSTALLED_APPS)]
+        apps = [app.replace(".", "/") for app in filter(lambda app: not app.startswith('django.contrib'), settings.INSTALLED_APPS)]
         template_dirs = get_template_setting('DIRS', [])
         base_dir = getattr(settings, 'BASE_DIR')
         if template_dirs:
             apps += template_dirs
         for app_dir in apps:
-            app_dir = app_dir.replace(".", "/")
             if base_dir:
                 app_dir = os.path.join(base_dir, app_dir)
             for top, dirs, files in os.walk(app_dir):

--- a/tests/management/commands/test_notes.py
+++ b/tests/management/commands/test_notes.py
@@ -23,6 +23,28 @@ def test_with_utf8(capsys, settings):
 def test_with_template_dirs(capsys, settings, tmpdir_factory):
     templates_dirs_path = tmpdir_factory.getbasetemp().strpath
     template_path = os.path.join(templates_dirs_path, 'fixme.html')
+    os.mkdir(os.path.join(templates_dirs_path, 'sub.path'))
+    sub_path = os.path.join(templates_dirs_path, 'sub.path', 'todo.html')
+    settings.TEMPLATES[0]['DIRS'] = [templates_dirs_path]
+    with open(template_path, 'w') as f:
+        f.write('''{# FIXME This is a comment. #}
+{# TODO Do not show this. #}''')
+    with open(sub_path, 'w') as f:
+        f.write('''{# FIXME This is a second comment. #}
+{# TODO Do not show this. #}''')
+
+    call_command('notes', '--tag=FIXME')
+    out, err = capsys.readouterr()
+
+    assert '{}:\n  * [  1] FIXME This is a comment.'.format(template_path) in out
+    assert '{}:\n  * [  1] FIXME This is a second comment.'.format(sub_path) in out
+    assert 'TODO Do not show this.' not in out
+
+
+def test_with_template_sub_dirs(capsys, settings, tmpdir_factory):
+    templates_dirs_path = tmpdir_factory.getbasetemp().strpath
+    os.mkdir(os.path.join(templates_dirs_path, 'test.path'))
+    template_path = os.path.join(templates_dirs_path, 'test.path', 'fixme.html')
     settings.TEMPLATES[0]['DIRS'] = [templates_dirs_path]
     with open(template_path, 'w') as f:
         f.write('''{# FIXME This is a comment. #}


### PR DESCRIPTION
This change fixes a test failure when the generated name from `tmpdir_factory.getbasetemp()` contains a `.`.

When the notes command processes the apps list, it replaces all `.` with `/` and tries to walk the resulting path. This breaks when it encounters a template dir that contains a `.`, in which case the resulting path is wrong and can't be found.

The new `test_with_template_sub_dirs` test would fail without the change to the notes command that fixes the issue.