### PR TITLE
Feat: use session backend on print user for session command

### DIFF
--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -4,7 +4,6 @@ from __future__ import print_function, unicode_literals
 import importlib
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.sessions.backends.base import VALID_KEY_CHARS
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.module_loading import import_string

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.backends.base import VALID_KEY_CHARS
 from django.core.management.base import BaseCommand, CommandError
+from django.utils.module_loading import import_string
 
 from django_extensions.management.utils import signalcommand
 
@@ -39,8 +40,8 @@ class Command(BaseCommand):
 
         print('Session to Expire: %s' % session.get_expiry_date())
         print('Raw Data: %s' % data)
-
         uid = data.get('_auth_user_id', None)
+        backend_path = data.get('_auth_user_backend', None)
 
         if uid is None:
             print('No user associated with session')
@@ -48,10 +49,9 @@ class Command(BaseCommand):
 
         print(u"User id: %s" % uid)
 
-        User = get_user_model()
-        try:
-            user = User.objects.get(pk=uid)
-        except User.DoesNotExist:
+        backend = import_string(backend_path)()
+        user = backend.get_user(user_id=uid)
+        if user is None:
             print("No user associated with that id.")
             return
 

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -4,10 +4,9 @@ from __future__ import print_function, unicode_literals
 import importlib
 
 from django.conf import settings
+from django.contrib.auth import load_backend, BACKEND_SESSION_KEY, SESSION_KEY
 from django.contrib.sessions.backends.base import VALID_KEY_CHARS
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.module_loading import import_string
-
 from django_extensions.management.utils import signalcommand
 
 
@@ -39,8 +38,12 @@ class Command(BaseCommand):
 
         print('Session to Expire: %s' % session.get_expiry_date())
         print('Raw Data: %s' % data)
-        uid = data.get('_auth_user_id', None)
-        backend_path = data.get('_auth_user_backend', None)
+        uid = data.get(SESSION_KEY, None)
+        backend_path = data.get(BACKEND_SESSION_KEY, None)
+
+        if backend_path is None:
+            print('No authentication backend associated with session')
+            return
 
         if uid is None:
             print('No user associated with session')
@@ -48,7 +51,7 @@ class Command(BaseCommand):
 
         print(u"User id: %s" % uid)
 
-        backend = import_string(backend_path)()
+        backend = load_backend(backend_path)
         user = backend.get_user(user_id=uid)
         if user is None:
             print("No user associated with that id.")

--- a/tests/management/commands/test_print_user_for_session.py
+++ b/tests/management/commands/test_print_user_for_session.py
@@ -58,6 +58,7 @@ class PrintUserForSessionTests(TestCase):
         session.create()
 
         call_command('print_user_for_session', session.session_key)
+
         self.assertIn('No user associated with that id.', m_stdout.getvalue())
 
     @patch('sys.stdout', new_callable=StringIO)

--- a/tests/management/commands/test_print_user_for_session.py
+++ b/tests/management/commands/test_print_user_for_session.py
@@ -47,6 +47,21 @@ class PrintUserForSessionTests(TestCase):
 
         self.assertIn('No user associated with session', m_stdout.getvalue())
 
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_should_print_that_there_is_no_backend_associated_with_given_session(self, m_stdout):
+        session = self.engine.SessionStore()
+        session.update({
+            '_auth_user_id': 1234,
+            '_auth_user_hash': 'b67352fde8582b12f068c10fd9d29f9fa1af0459',
+        })
+        session.create()
+
+        call_command('print_user_for_session', session.session_key)
+
+        self.assertIn('No authentication backend associated with session', m_stdout.getvalue())
+
+
     @patch('sys.stdout', new_callable=StringIO)
     def test_should_print_that_there_is_no_user_associated_with_id(self, m_stdout):
         session = self.engine.SessionStore()

--- a/tests/management/commands/test_print_user_for_session.py
+++ b/tests/management/commands/test_print_user_for_session.py
@@ -58,7 +58,6 @@ class PrintUserForSessionTests(TestCase):
         session.create()
 
         call_command('print_user_for_session', session.session_key)
-
         self.assertIn('No user associated with that id.', m_stdout.getvalue())
 
     @patch('sys.stdout', new_callable=StringIO)

--- a/tests/management/commands/test_print_user_for_session.py
+++ b/tests/management/commands/test_print_user_for_session.py
@@ -47,7 +47,6 @@ class PrintUserForSessionTests(TestCase):
 
         self.assertIn('No user associated with session', m_stdout.getvalue())
 
-
     @patch('sys.stdout', new_callable=StringIO)
     def test_should_print_that_there_is_no_backend_associated_with_given_session(self, m_stdout):
         session = self.engine.SessionStore()
@@ -60,7 +59,6 @@ class PrintUserForSessionTests(TestCase):
         call_command('print_user_for_session', session.session_key)
 
         self.assertIn('No authentication backend associated with session', m_stdout.getvalue())
-
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_should_print_that_there_is_no_user_associated_with_id(self, m_stdout):


### PR DESCRIPTION
#1312

This PR adapts the command 'print_user_for_session' to use the session's backend model.