### PR TITLE
Support unique_together with RandomCharField

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -340,6 +340,12 @@ class RandomCharField(UniqueFieldMixin, CharField):
             yield ''.join(get_random_string(self.length, chars))
         raise RuntimeError('max random character attempts exceeded (%s)' % self.max_unique_query_attempts)
 
+    def in_unique_together(self, model_instance):
+        for params in model_instance._meta.unique_together:
+            if self.attname in params:
+                return True
+        return False
+
     def pre_save(self, model_instance, add):
         if not add and getattr(model_instance, self.attname) != '':
             return getattr(model_instance, self.attname)
@@ -360,7 +366,7 @@ class RandomCharField(UniqueFieldMixin, CharField):
             population += string.punctuation
 
         random_chars = self.random_char_generator(population)
-        if not self.unique:
+        if not self.unique and not self.in_unique_together(model_instance):
             new = six.next(random_chars)
             setattr(model_instance, self.attname, new)
             return new

--- a/tests/test_randomchar_field.py
+++ b/tests/test_randomchar_field.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from .testapp.models import RandomCharTestModel, RandomCharTestModelUnique, RandomCharTestModelLowercase
 from .testapp.models import RandomCharTestModelUppercase, RandomCharTestModelAlpha, RandomCharTestModelDigits
 from .testapp.models import RandomCharTestModelPunctuation, RandomCharTestModelLowercaseAlphaDigits, RandomCharTestModelUppercaseAlphaDigits
+from .testapp.models import RandomCharTestModelUniqueTogether
 
 try:
     from unittest import mock
@@ -84,5 +85,17 @@ class RandomCharFieldTest(TestCase):
             m.save()
 
             m = RandomCharTestModelUnique()
+            with pytest.raises(RuntimeError):
+                m.save()
+
+    def testRandomCharTestModelUniqueTogether(self):
+        with mock.patch('django_extensions.db.fields.get_random_string') as mock_sample:
+            mock_sample.return_value = 'aaa'
+            m = RandomCharTestModelUniqueTogether()
+            m.common_field = 'bbb'
+            m.save()
+
+            m = RandomCharTestModelUniqueTogether()
+            m.common_field = 'bbb'
             with pytest.raises(RuntimeError):
                 m.save()

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -351,6 +351,15 @@ class RandomCharTestModelPunctuation(models.Model):
         app_label = 'django_extensions'
 
 
+class RandomCharTestModelUniqueTogether(models.Model):
+    random_char_field = RandomCharField(length=8)
+    common_field = models.CharField(max_length=10)
+
+    class Meta:
+        app_label = 'django_extensions'
+        unique_together = ('random_char_field', 'common_field')
+
+
 class TimestampedTestModel(TimeStampedModel):
     class Meta:
         app_label = 'django_extensions'


### PR DESCRIPTION
AutoSlugField already supports unique_together through find_unique() in UniqueFieldMixin.  Add support for unique_together in RandomCharField as well by checking for the attribute name in unique_together before short-circuiting find_unique() there.