### PR TITLE
add indexes to timestamped models 

### DIFF
--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -25,6 +25,7 @@ class TimeStampedModel(models.Model):
     class Meta:
         get_latest_by = 'modified'
         ordering = ('-modified', '-created',)
+        indexes = [models.Index(fields=["created"]), models.Index(fields=["modified"])]
         abstract = True
 
 

--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -25,7 +25,21 @@ class TimeStampedModel(models.Model):
     class Meta:
         get_latest_by = 'modified'
         ordering = ('-modified', '-created',)
-        indexes = [models.Index(fields=["created"]), models.Index(fields=["modified"])]
+        abstract = True
+
+
+class IndexedTimeStampedModel(TimeStampedModel):
+    """
+    IndexedTimeStampedModel
+
+    An abstract base class model that provides self-managed "created" and
+    "modified" fields with db indices on them.
+    """
+    class Meta(TimeStampedModel.Meta):
+        indexes = [
+            models.Index(fields=["-created", "-modified"]),
+            models.Index(fields=["-created"]), models.Index(fields=["-modified"])
+        ]
         abstract = True
 
 
@@ -40,6 +54,20 @@ class TitleDescriptionModel(models.Model):
     description = models.TextField(_('description'), blank=True, null=True)
 
     class Meta:
+        abstract = True
+
+
+class IndexedTitleDescriptionModel(TitleDescriptionModel):
+    """
+    IndexedTitleDescriptionModel
+
+    An abstract base class model that provides title and description fields
+    with an index on title field.
+    """
+    class Meta(TitleDescriptionModel.Meta):
+        indexes = [
+            models.Index(fields=["title"]),
+        ]
         abstract = True
 
 
@@ -61,6 +89,22 @@ class TitleSlugDescriptionModel(TitleDescriptionModel):
     slug = AutoSlugField(_('slug'), populate_from='title')
 
     class Meta:
+        abstract = True
+
+
+class IndexedTitleSlugDescriptionModel(TitleSlugDescriptionModel):
+    """
+    IndexedTitleSlugDescriptionModel
+
+    An abstract base class model that provides title and description fields
+    and a self-managed "slug" field that populates from the title with indexes
+    on "title" and "slug" fields.
+    """
+    class Meta(TitleSlugDescriptionModel.Meta):
+        indexes = [
+            models.Index(fields=["title", "slug"]),
+            models.Index(fields=["title"]), models.Index(fields=["slug"])
+        ]
         abstract = True
 
 
@@ -135,3 +179,20 @@ class ActivatorModel(models.Model):
         if not self.activate_date:
             self.activate_date = now()
         super(ActivatorModel, self).save(*args, **kwargs)
+
+
+class IndexedActivatorModel(ActivatorModel):
+    """
+    ActivatorModel
+
+    An abstract base class model that provides activate and deactivate fields
+    with indexes on "activate_date" and "deactivate_date".
+    """
+
+    class Meta(ActivatorModel.Meta):
+        indexes = [
+            models.Index(fields=["-activate_date", "-deactivate_date"]),
+            models.Index(fields=["-activate_date"]),
+            models.Index(fields=["-deactivate_date"])
+        ]
+        abstract = True

--- a/docs/model_extensions.rst
+++ b/docs/model_extensions.rst
@@ -42,7 +42,14 @@ and modification, respectively.
 The ``TimeStampedModel`` defines following ```Meta`` options:
 1. ``get_latest_by`` on ``modified`` field.
 2. ``ordering`` based on ``-created`` and ``-modified`` fields.
-3. ``indexes`` on ``created``, ``modified`` fields.
+
+
+* *IndexedTimeStampedModel* - An Abstract Base Class model that provides self-managed
+  ``created`` and ``modified`` fields.
+
+The ``IndexedTimeStampedModel`` defines following ```Meta`` options:
+1. Separate ``indexes`` on ``-created``, ``-modified`` fields and a composite
+   index on ``-created`` and ``-modified``.
 
 Usage:
 
@@ -70,8 +77,15 @@ class:
 
       class Meta(TimeStampedModel.Meta):
           db_table = "sale"
-          indexes = TimeStampedModel.Meta.indexes + [models.Index(fields=["quantity"])]
           ordering = TimeStampedModel.Meta.ordering + ("-bill_id", "quantity")
+
+  class Sale(IndexedTimeStampedModel):
+      quantity = models.IntegerField()
+      bill_id = models.IntergetField()
+
+      class Meta(TimeStampedModel.Meta):
+          db_table = "sale"
+          indexes = TimeStampedModel.Meta.indexes + [models.Index(fields=["quantity"])]
 
 * *TitleSlugDescriptionModel* - An Abstract Base Class model that, like the
   ``TitleDescriptionModel``, provides ``title`` and ``description`` fields

--- a/docs/model_extensions.rst
+++ b/docs/model_extensions.rst
@@ -37,7 +37,41 @@ Both of the fields are customly defined in Django Extensions as
 ``CreationDateTimeField`` and ``ModificationDateTimeField``.
 Those fields are subclasses of Django's ``DateTimeField`` and will store
 the value of ``django.utils.timezone.now()`` on the model's creation
-and modification, respectively
+and modification, respectively.
+
+The ``TimeStampedModel`` defines following ```Meta`` options:
+1. ``get_latest_by`` on ``modified`` field.
+2. ``ordering`` based on ``-created`` and ``-modified`` fields.
+3. ``indexes`` on ``created``, ``modified`` fields.
+
+Usage:
+
+::
+  class Cheese(TimeStampedModel):
+      name = models.CharField(max_length=50, null=True, blank=True)
+
+To override the ``Meta`` class in the concrete class with new options, then
+``Meta`` of the concrete class should inherit from ``TimeStampedModel.Meta``.
+
+::
+  class Sale(TimeStampedModel):
+      quantity = models.IntegerField()
+
+      class Meta(TimeStampedModel.Meta):
+          db_table = "sale"
+
+To override the ``Meta`` options defined by ``TimeStampedModel`` in concrete
+class:
+
+::
+  class Sale(TimeStampedModel):
+      quantity = models.IntegerField()
+      bill_id = models.IntergetField()
+
+      class Meta(TimeStampedModel.Meta):
+          db_table = "sale"
+          indexes = TimeStampedModel.Meta.indexes + [models.Index(fields=["quantity"])]
+          ordering = TimeStampedModel.Meta.ordering + ("-bill_id", "quantity")
 
 * *TitleSlugDescriptionModel* - An Abstract Base Class model that, like the
   ``TitleDescriptionModel``, provides ``title`` and ``description`` fields


### PR DESCRIPTION
Issue Ref: django-extensions/django-extensions#1425

Added indexes in the `Meta` of the `TimeStampedModel`.

Usage:
```
class Cheese(TimeStampedModel):
    name = models.CharField(max_length=50, null=True, blank=True)
```
or
```
class Sale(TimeStampedModel):
    quantity = models.IntegerField()

    class Meta(TimeStampedModel.Meta):
        db_table = "sale"
```

or 

```
class Sale(TimeStampedModel):
    quantity = models.IntegerField()

    class Meta(TimeStampedModel.Meta):
        db_table = "sale"
         indexes = TimeStampedModel.Meta.indexes + [models.Index(fields=["quantity"])]
```