### PR TITLE
[compat] Remove py34, deprecated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ envlist =
 	precommit
 	safety
 	mypy
-	{py27,py34,py35,py36,py37}-flake8
-	{py27,py34,py35,py36,py37,pypy}-dj111
+	{py27,py35,py36,py37}-flake8
+	{py27,py35,py36,py37,pypy}-dj111
 	{py34,py35,py36,py37,pypy}-dj20
 	{py35,py36,py37,pypy}-dj21
 	{py35,py36,py37,pypy}-dj22


### PR DESCRIPTION
Python 3.4 is no longer updated a deprecated, should not be supported anymore