### PR TITLE
[pypy] Use default travis PyPy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,15 +89,15 @@ matrix:
       env: TOXENV=py38-djmaster-postgres
       services:
         - postgresql
-    - python: pypy2.7-5.10.0
+    - python: pypy
       env: TOXENV=pypy-dj111
-    - python: pypy3.5-5.10.1
+    - python: pypy3
       env: TOXENV=pypy3-dj111
-    - python: pypy3.5-5.10.1
+    - python: pypy3
       env: TOXENV=pypy3-dj20
-    - python: pypy3.5-5.10.1
+    - python: pypy3
       env: TOXENV=pypy3-dj21
-    - python: pypy3.5-5.10.1
+    - python: pypy3
       env: TOXENV=pypy3-djmaster
 
   allow_failures:
@@ -111,9 +111,9 @@ matrix:
       env: TOXENV=py37-djmaster-postgres
     - python: 3.8
       env: TOXENV=py38-djmaster-postgres
-    - python: pypy3.5-5.10.1
+    - python: pypy3
       env: TOXENV=pypy3-djmaster
-    - python: pypy2.7-5.10.0
+    - python: pypy
       env: TOXENV=pypy-dj111
 
 install:


### PR DESCRIPTION
Use latest version of PyPy for both Python 2.x and Python 3.x