### PR TITLE
[ci] Cleanup tox config for env matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,13 @@ envlist =
 	precommit
 	safety
 	mypy
-	{py27,py34,py35,py36,py37}-flake8
-	{py27,py34,py35,py36,py37,pypy}-dj111
-	{py34,py35,py36,py37,pypy}-dj20
-	{py35,py36,py37,pypy}-dj21
-	{py35,py36,py37,pypy}-dj22
-	{py36,py37}-dj30
-	{py35,py36,py37,pypy}-djmaster
+	py{27,34,35,36,37}-flake8
+	py{27,34,35,36,37,py}-dj111
+	py{34,35,36,37,py}-dj20
+	py{35,36,37,py}-dj21
+	py{35,36,37,py}-dj22
+	py{36,37}-dj30
+	py{35,36,37,py}-djmaster
 	py37-dj22-postgres
 	py37-dj22-mysql
 	py37-djmaster-postgres
@@ -54,6 +54,7 @@ deps =
     pygments
     postgres: psycopg2-binary
     mysql: mysqlclient
+    py{27,34,35,36,37}-flake8: flake8
 
 [testenv:precommit]
 deps =
@@ -79,26 +80,16 @@ commands =
 	make compile-catalog
 
 [testenv:py27-flake8]
-deps =
-	flake8
 commands = flake8 django_extensions tests
 
 [testenv:py34-flake8]
-deps =
-	flake8
 commands = flake8 django_extensions tests
 
 [testenv:py35-flake8]
-deps =
-	flake8
 commands = flake8 django_extensions tests
 
 [testenv:py36-flake8]
-deps =
-	flake8
 commands = flake8 django_extensions tests
 
 [testenv:py37-flake8]
-deps =
-	flake8
 commands = flake8 django_extensions tests


### PR DESCRIPTION
Improve the env matrix using `py` prefix