### PR TITLE
Don't pass encoding to json.loads for Python 3.8

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -27,8 +27,7 @@ def dumps(value):
 
 def loads(txt):
     value = json.loads(
-        txt,
-        encoding=settings.DEFAULT_CHARSET
+        txt
     )
     return value
 


### PR DESCRIPTION
This parameter is ignored and deprecated, and passing it triggers this warning:

`DeprecationWarning: 'encoding' is ignored and deprecated. It will be removed in Python 3.9`