### PR TITLE
[feat] Add support to list urls for a specified app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ Generate (and view) a graphviz graph of app models::
 Produce a tab-separated list of `(url_pattern, view_function, name)` tuples for a project::
 
     $ python manage.py show_urls
+    $ python manage.py show_urls <app_label>
 
 Check templates for rendering errors::
 


### PR DESCRIPTION
Issue: https://github.com/django-extensions/django-extensions/issues/1443

Added support for listing URLs for a specified app name in `show_urls` management command.
`$ python manage.py show_urls <app_label>`

Example: 
`$ python manage.py show_urls django_extensions`