### PR TITLE
Mention required change in settings.py on main page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,9 @@ If you want to install it from source, grab the git repository and run setup.py:
  $ cd django-extensions
  $ python setup.py install
 
+Then you will need to add the *django_extensions* application to the
+``INSTALLED_APPS`` setting of your Django project *settings.py* file.
+
 For more detailed instructions check out our :doc:`installation_instructions`. Enjoy.
 
 Compatibility with versions of Python and Django


### PR DESCRIPTION
It took me quite a while to realize that the installation instructions on the main page are only partial, and they continue in another page. Mentioning the `pip` command alone is worse than simply pointing the user to the installation instructions page. This way the instructions are complete, and allows the user to have a quick start.