### PR TITLE
Restore Django 3.0 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Revert 0f0ca99c8d5f3e34399b2f6a6f920167376d7fb9 because the classifier is now available on PyPI.