### PR TITLE
Fix AutoSlugField and add test cases

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -71,9 +71,13 @@ class UniqueFieldMixin(object):
         constraints = getattr(model_instance._meta, 'constraints', None)
         if constraints:
             for constraint in constraints:
-                query &= Q(**{field: getattr(model_instance, field, None) for field in constraint.fields})
-                if constraint.condition:
-                    query &= constraint.condition
+                if self.attname in constraint.fields:
+                    condition = {
+                        field: getattr(model_instance, field, None)
+                        for field in constraint.fields
+                        if field != self.attname
+                    }
+                    query &= Q(**condition)
 
         new = six.next(iterator)
         kwargs[self.attname] = new

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -163,11 +163,20 @@ class SluggedWithConstraintsTestModel(models.Model):
         if django.VERSION >= (2, 2):
             constraints = [
                 UniqueConstraint(
-                    fields=['slug'],
-                    condition=Q(category='self-introduction'),
-                    name="unique_slug_of_self_introduction",
+                    fields=['slug', 'category'],
+                    name="unique_slug_and_category",
                 ),
             ]
+
+
+class SluggedWithUniqueTogetherTestModel(models.Model):
+    title = models.CharField(max_length=42)
+    slug = AutoSlugField(populate_from='title')
+    category = models.CharField(max_length=20, null=True)
+
+    class Meta:
+        app_label = 'django_extensions'
+        unique_together = ['slug', 'category']
 
 
 class OverridedFindUniqueAutoSlugField(AutoSlugField):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -3,7 +3,6 @@ import django
 
 from django.db import models
 from django.contrib.auth import get_user_model
-from django.db.models import Q
 
 from django_extensions.db.fields import AutoSlugField, ModificationDateTimeField, RandomCharField, ShortUUIDField
 from django_extensions.db.fields.json import JSONField


### PR DESCRIPTION
Issue #1384
This is a fix of #1149 PR. (Yes, it's mine.)
I found something new while reading the code. I think a code for `UniqueConstraints.condition` is redundant if `find_unique` will provide a unique slug. It's enough to make `UniqueConstraints.fields` available.