### PR TITLE
Always add the manage.py directory to PYTHONPATH

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -217,7 +217,7 @@ class Command(BaseCommand):
 
             manage_py_dir, manage_py = os.path.split(os.path.realpath(sys.argv[0]))
 
-            if manage_py == 'manage.py' and os.path.isdir(manage_py_dir) and manage_py_dir != os.getcwd():
+            if manage_py == 'manage.py' and os.path.isdir(manage_py_dir):
                 pythonpath = ks.env.get('PYTHONPATH', os.environ.get('PYTHONPATH', ''))
                 pythonpath = pythonpath.split(os.pathsep)
                 if manage_py_dir not in pythonpath:


### PR DESCRIPTION
Checking for the manage.py directory being the current directory is not actually needed. If the path ends up being included twice it isn't a very big issue (the first match still wins), but if you want to store notebooks in a directory other than the root of the mange.py directory you currently have to use relative imports to achieve this. This change fixes that so you can always refer to your django package as if it was an installed package.

Fixes: #865