### PR TITLE
Fix broken import

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -219,7 +219,8 @@ class Command(BaseCommand):
 
     def inner_run(self, options):
         try:
-            from werkzeug import run_simple, DebuggedApplication
+            from werkzeug import run_simple
+            from werkzeug.debug import DebuggedApplication
             from werkzeug.serving import WSGIRequestHandler as _WSGIRequestHandler
 
             # Set colored output


### PR DESCRIPTION
Werkzeug removed a deprecated way to import DebuggedApplication.

The correct import is now:
`from werkzeug.debug import DebuggedApplication`

modified:   django_extensions/management/commands/runserver_plus.py