### PR TITLE
Replace deprecated `force_text()` with `force_str()`

### DIFF
--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -27,7 +27,7 @@ from django.db.models import DateTimeField, CharField, SlugField, Q
 from django.db.models.constants import LOOKUP_SEP
 from django.template.defaultfilters import slugify
 from django.utils.crypto import get_random_string
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 MAX_UNIQUE_QUERY_ATTEMPTS = getattr(settings, 'EXTENSIONS_MAX_UNIQUE_QUERY_ATTEMPTS', 100)
@@ -269,7 +269,7 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
         return attr
 
     def pre_save(self, model_instance, add):
-        value = force_text(self.create_slug(model_instance, add))
+        value = force_str(self.create_slug(model_instance, add))
         return value
 
     def get_internal_type(self):
@@ -523,12 +523,12 @@ class UUIDFieldMixin(object):
         value = super().pre_save(model_instance, add)
 
         if self.auto and add and value is None:
-            value = force_text(self.create_uuid())
+            value = force_str(self.create_uuid())
             setattr(model_instance, self.attname, value)
             return value
         else:
             if self.auto and not value:
-                value = force_text(self.create_uuid())
+                value = force_str(self.create_uuid())
                 setattr(model_instance, self.attname, value)
 
         return value

--- a/django_extensions/management/commands/describe_form.py
+++ b/django_extensions/management/commands/describe_form.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.apps import apps
 from django.core.management.base import CommandError, LabelCommand
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from django_extensions.management.utils import signalcommand
 
@@ -55,7 +55,7 @@ def describe_form(label, fields):
                 if k == 'widget':
                     attrs[k] = v.__class__
                 elif k in ['help_text', 'label']:
-                    attrs[k] = str(force_text(v).strip())
+                    attrs[k] = str(force_str(v).strip())
                 else:
                     attrs[k] = v
 

--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -42,7 +42,7 @@ from django.db.models import (
 )
 from django.db.models.deletion import Collector
 from django.utils import timezone
-from django.utils.encoding import force_text, smart_text
+from django.utils.encoding import force_str, smart_text
 
 from django_extensions.management.utils import signalcommand
 
@@ -668,7 +668,7 @@ def get_attribute_value(item, field, context, force=False, skip_autofield=True):
 
     # Post file-storage-refactor, repr() on File/ImageFields no longer returns the path
     elif isinstance(field, FileField):
-        return repr(force_text(value))
+        return repr(force_str(value))
 
     # ForeignKey fields, link directly using our stored python variable name
     elif isinstance(field, ForeignKey) and value is not None:

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -19,7 +19,7 @@ from django.db.models.fields.related import (
 )
 from django.contrib.contenttypes.fields import GenericRelation
 from django.template import Context, Template, loader
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 from django.utils.translation import activate as activate_language
 
@@ -119,7 +119,7 @@ class ModelGraph(object):
 
     def add_attributes(self, field, abstract_fields):
         if self.verbose_names and field.verbose_name:
-            label = force_text(field.verbose_name)
+            label = force_str(field.verbose_name)
             if label.islower():
                 label = label.capitalize()
         else:
@@ -142,7 +142,7 @@ class ModelGraph(object):
 
     def add_relation(self, field, model, extras=""):
         if self.verbose_names and field.verbose_name:
-            label = force_text(field.verbose_name)
+            label = force_str(field.verbose_name)
             if label.islower():
                 label = label.capitalize()
         else:
@@ -153,7 +153,7 @@ class ModelGraph(object):
             related_query_name = field.related_query_name()
             if self.verbose_names and related_query_name.islower():
                 related_query_name = related_query_name.replace('_', ' ').capitalize()
-            label = u'{} ({})'.format(label, force_text(related_query_name))
+            label = u'{} ({})'.format(label, force_str(related_query_name))
         if self.hide_edge_labels:
             label = ''
 
@@ -219,7 +219,7 @@ class ModelGraph(object):
         }
 
         if self.verbose_names and appmodel._meta.verbose_name:
-            context['label'] = force_text(appmodel._meta.verbose_name)
+            context['label'] = force_str(appmodel._meta.verbose_name)
         else:
             context['label'] = context['name']
 

--- a/django_extensions/templatetags/widont.py
+++ b/django_extensions/templatetags/widont.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import re
 
 from django.template import Library
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 register = Library()
@@ -29,9 +29,9 @@ def widont(value, count=1):
     NoEffect
     """
     def replace(matchobj):
-        return force_text('&nbsp;%s' % matchobj.group(1))
+        return force_str('&nbsp;%s' % matchobj.group(1))
     for i in range(count):
-        value = re_widont.sub(replace, force_text(value))
+        value = re_widont.sub(replace, force_str(value))
     return value
 
 
@@ -54,8 +54,8 @@ def widont_html(value):
     leading&nbsp;text  <p>test me&nbsp;out</p>  trailing&nbsp;text
     """
     def replace(matchobj):
-        return force_text('%s&nbsp;%s%s' % matchobj.groups())
-    return re_widont_html.sub(replace, force_text(value))
+        return force_str('%s&nbsp;%s%s' % matchobj.groups())
+    return re_widont_html.sub(replace, force_str(value))
 
 
 if __name__ == "__main__":

--- a/django_extensions/validators.py
+++ b/django_extensions/validators.py
@@ -5,7 +5,7 @@ import binascii
 
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 
@@ -24,7 +24,7 @@ class NoControlCharactersValidator:
             self.whitelist = whitelist
 
     def __call__(self, value):
-        value = force_text(value)
+        value = force_str(value)
         whitelist = self.whitelist
         category = unicodedata.category
         for character in value:
@@ -55,7 +55,7 @@ class NoWhitespaceValidator:
             self.code = code
 
     def __call__(self, value):
-        value = force_text(value)
+        value = force_str(value)
         if value != value.strip():
             params = {'value': value}
             raise ValidationError(self.message, code=self.code, params=params)
@@ -88,7 +88,7 @@ class HexValidator:
             self.code = code
 
     def __call__(self, value):
-        value = force_text(value)
+        value = force_str(value)
         if self.length and len(value) != self.length:
             raise ValidationError(self.messages['length'], code='hex_only_length', params={'length': self.length})
         if self.min_length and len(value) < self.min_length:


### PR DESCRIPTION
`force_text()` has been deprecated since Django 3.0 and was an alias for
`force_str()` since Django 2.0:
https://docs.djangoproject.com/en/dev/releases/3.0/#deprecated-features-3-0

It's set to be removed in Django 4.0.