### PR TITLE
docs: Fix simple typo, writeable -> writable

### DIFF
--- a/django_extensions/management/utils.py
+++ b/django_extensions/management/utils.py
@@ -8,7 +8,7 @@ from django_extensions.management.signals import post_command, pre_command
 
 def _make_writeable(filename):
     """
-    Make sure that the file is writeable. Useful if our source is
+    Make sure that the file is writable. Useful if our source is
     read-only.
     """
     import stat

--- a/tests/management/commands/test_graph_models.py
+++ b/tests/management/commands/test_graph_models.py
@@ -28,7 +28,7 @@ def assert_looks_like_jsonfile(output):
 
 @contextmanager
 def temp_output_file(extension=""):
-    """Create writeable tempfile in filesystem and ensure it gets deleted"""
+    """Create writable tempfile in filesystem and ensure it gets deleted"""
     tmpfile = tempfile.NamedTemporaryFile(suffix=extension, delete=False)
     tmpfile.close()
     yield tmpfile.name


### PR DESCRIPTION
There is a small typo in django_extensions/management/utils.py, tests/management/commands/test_graph_models.py.

Should read `writable` rather than `writeable`.

