### PR TITLE
Remove deprecated encoding in json.loads()

### DIFF
--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -26,11 +26,10 @@ def dumps(value):
 
 
 def loads(txt):
-    value = json.loads(
-        txt,
-        encoding=settings.DEFAULT_CHARSET
-    )
-    return value
+    if six.PY2:
+        return json.loads(txt, encoding=settings.DEFAULT_CHARSET)
+    else:
+        return json.loads(txt)
 
 
 class JSONDict(dict):

--- a/django_extensions/mongodb/fields/json.py
+++ b/django_extensions/mongodb/fields/json.py
@@ -38,7 +38,10 @@ def dumps(value):
 
 
 def loads(txt):
-    value = json.loads(txt, parse_float=Decimal, encoding=settings.DEFAULT_CHARSET)
+    if six.PY2:
+        value = json.loads(txt, parse_float=Decimal, encoding=settings.DEFAULT_CHARSET)
+    else:
+        value = json.loads(txt, parse_float=Decimal)
     assert isinstance(value, dict)
     return value
 


### PR DESCRIPTION
The encoding argument in json.loads() has been ignored and deprecated
since Python 3.1 and will be removed in Python 3.9.

Fixes #1465