### PR TITLE
Support multiple DBs in the debug_cursor code

### DIFF
--- a/django_extensions/management/debug_cursor.py
+++ b/django_extensions/management/debug_cursor.py
@@ -109,6 +109,6 @@ def monkey_patch_cursordebugwrapper(print_sql=None, print_sql_location=False, tr
         if postgresql_base:
             postgresql_base.CursorDebugWrapper = _PostgreSQLCursorDebugWrapper
 
-        if connection:
+        if connections:
             for connection_name in connections:
                 connections[connection_name].force_debug_cursor = _force_debug_cursor[connection_name]

--- a/django_extensions/management/debug_cursor.py
+++ b/django_extensions/management/debug_cursor.py
@@ -75,10 +75,12 @@ def monkey_patch_cursordebugwrapper(print_sql=None, print_sql_location=False, tr
             pass
 
         try:
-            from django.db import connection
-            _force_debug_cursor = connection.force_debug_cursor
+            from django.db import connections
+            _force_debug_cursor = {}
+            for connection_name in connections:
+                _force_debug_cursor[connection_name] = connections[connection_name].force_debug_cursor
         except Exception:
-            connection = None
+            connections = None
 
         utils.CursorDebugWrapper = PrintCursorQueryWrapper
 
@@ -96,8 +98,9 @@ def monkey_patch_cursordebugwrapper(print_sql=None, print_sql_location=False, tr
         if postgresql_base:
             postgresql_base.CursorDebugWrapper = PostgreSQLPrintCursorDebugWrapper
 
-        if connection:
-            connection.force_debug_cursor = True
+        if connections:
+            for connection_name in connections:
+                connections[connection_name].force_debug_cursor = True
 
         yield
 
@@ -107,4 +110,5 @@ def monkey_patch_cursordebugwrapper(print_sql=None, print_sql_location=False, tr
             postgresql_base.CursorDebugWrapper = _PostgreSQLCursorDebugWrapper
 
         if connection:
-            connection.force_debug_cursor = _force_debug_cursor
+            for connection_name in connections:
+                connections[connection_name].force_debug_cursor = _force_debug_cursor[connection_name]


### PR DESCRIPTION
I work on a django app with multilple DBs and I've been using this hack for a while in my site-packages folder and thought I'd push it upstream.

If you'd like me to add a test, I'll need some help with that. The basic case of 1 DB is tested but not explicitly, just that `--print-sql` prints the SQL rather than which DB it is from.

```
In [2]: User.objects.exists()
SELECT (1) AS "a"
  FROM "wave_auth_user"
 LIMIT 1

Execution time: 0.026820s [Database: default]
Out[2]: False

In [4]: from businesses.models import Business

In [5]: Business.objects.using('shard_0001').exists()
SELECT (1) AS "a"
  FROM "businesses_business"
 LIMIT 1

Execution time: 0.008085s [Database: shard_0001]
Out[5]: False
```