### PR TITLE
shell_plus: fix handling of extra_args in --notebook

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -121,8 +121,6 @@ class Command(BaseCommand):
         return super(Command, self).run_from_argv(argv)
 
     def get_ipython_arguments(self, options):
-        if self.extra_args:
-            return self.extra_args
         ipython_args = 'IPYTHON_ARGUMENTS'
         arguments = getattr(settings, ipython_args, [])
         if not arguments:
@@ -130,8 +128,6 @@ class Command(BaseCommand):
         return arguments
 
     def get_notebook_arguments(self, options):
-        if self.extra_args:
-            return self.extra_args
         notebook_args = 'NOTEBOOK_ARGUMENTS'
         arguments = getattr(settings, notebook_args, [])
         if not arguments:
@@ -211,13 +207,25 @@ class Command(BaseCommand):
     def run_notebookapp(self, app, options, use_kernel_specs=True):
         no_browser = options['no_browser']
 
+        if self.extra_args:
+            # if another '--' is found split the arguments notebook, ipython
+            if '--' in self.extra_args:
+                idx = self.extra_args.index('--')
+                notebook_arguments = self.extra_args[:idx]
+                ipython_arguments = self.extra_args[idx + 1:]
+            # otherwise pass the arguments to the notebook
+            else:
+                notebook_arguments = self.extra_args
+                ipython_arguments = []
+        else:
+            notebook_arguments = self.get_notebook_arguments(options)
+            ipython_arguments = self.get_ipython_arguments(options)
+
         # Treat IPYTHON_ARGUMENTS from settings
-        ipython_arguments = self.get_ipython_arguments(options)
         if 'django_extensions.management.notebook_extension' not in ipython_arguments:
             ipython_arguments.extend(['--ext', 'django_extensions.management.notebook_extension'])
 
         # Treat NOTEBOOK_ARGUMENTS from settings
-        notebook_arguments = self.get_notebook_arguments(options)
         if no_browser and '--no-browser' not in notebook_arguments:
             notebook_arguments.append('--no-browser')
         if '--notebook-dir' not in notebook_arguments and not any(e.startswith('--notebook-dir=') for e in notebook_arguments):
@@ -368,7 +376,7 @@ class Command(BaseCommand):
 
             def run_ipython():
                 imported_objects = self.get_imported_objects(options)
-                ipython_arguments = self.get_ipython_arguments(options)
+                ipython_arguments = self.extra_args or self.get_ipython_arguments(options)
                 start_ipython(argv=ipython_arguments, user_ns=imported_objects)
             return run_ipython
         except ImportError:

--- a/tests/management/commands/shell_plus_tests/test_shell_plus.py
+++ b/tests/management/commands/shell_plus_tests/test_shell_plus.py
@@ -24,7 +24,7 @@ def test_shell_plus_print_sql(capsys):
         from django.db.backends import utils
         CursorDebugWrapper = utils.CursorDebugWrapper
         force_debug_cursor = True if connection.force_debug_cursor else False
-        call_command("shell_plus", plain=True, print_sql=True, command="User.objects.all().exists()")
+        call_command("shell_plus", "--plain", "--print-sql", "--command=User.objects.all().exists()")
     finally:
         utils.CursorDebugWrapper = CursorDebugWrapper
         connection.force_debug_cursor = force_debug_cursor
@@ -35,19 +35,23 @@ def test_shell_plus_print_sql(capsys):
 
 
 def test_shell_plus_plain_startup():
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
+    command = shell_plus.Command()
+    command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
     args = ["--plain"]
     options = parser.parse_args(args=args)
 
-    command = shell_plus.Command()
-    command.tests_mode = True
     retcode = command.handle(**vars(options))
 
     assert retcode == 130
 
 
 def test_shell_plus_plain_startup_with_pythonrc(monkeypatch):
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
+    command = shell_plus.Command()
+    command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
     args = ["--plain", "--use-pythonrc"]
     options = parser.parse_args(args=args)
 
@@ -55,9 +59,6 @@ def test_shell_plus_plain_startup_with_pythonrc(monkeypatch):
     pythonrc_file = os.path.join(tests_dir, 'pythonrc.py')
     assert os.path.isfile(pythonrc_file)
     monkeypatch.setenv('PYTHONSTARTUP', pythonrc_file)
-
-    command = shell_plus.Command()
-    command.tests_mode = True
 
     retcode = command.handle(**vars(options))
     assert retcode == 130
@@ -68,12 +69,12 @@ def test_shell_plus_plain_startup_with_pythonrc(monkeypatch):
 
 
 def test_shell_plus_plain_loading_standard_django_imports(monkeypatch):
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
-    args = ["--plain"]
-    options = parser.parse_args(args=args)
-
     command = shell_plus.Command()
     command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
+    args = ["--plain"]
+    options = parser.parse_args(args=args)
 
     retcode = command.handle(**vars(options))
     assert retcode == 130
@@ -85,12 +86,12 @@ def test_shell_plus_plain_loading_standard_django_imports(monkeypatch):
 
 
 def test_shell_plus_plain_loading_django_extensions_modules(monkeypatch):
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
-    args = ["--plain"]
-    options = parser.parse_args(args=args)
-
     command = shell_plus.Command()
     command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
+    args = ["--plain"]
+    options = parser.parse_args(args=args)
 
     retcode = command.handle(**vars(options))
     assert retcode == 130


### PR DESCRIPTION
Updated to be based off of #1511 which is moving around the `run_notebook` code.

In `run_notebook` after `get_ipython_arguments` is called and the result is modified, but since both `get_ipython_arguments` and `get_notebook_arguments` refer to the same list this produces an invalid command line.

Simply returning new lists does not fix the problem because both the notebook and the kernel fail on invalid flags. This fix handles extra_args explicitly to ensure the command line is built correctly.
