### PR TITLE
update shell_plus to remove boilerplate code to add new shells

### DIFF
--- a/tests/management/commands/shell_plus_tests/test_shell_plus.py
+++ b/tests/management/commands/shell_plus_tests/test_shell_plus.py
@@ -24,7 +24,7 @@ def test_shell_plus_print_sql(capsys):
         from django.db.backends import utils
         CursorDebugWrapper = utils.CursorDebugWrapper
         force_debug_cursor = True if connection.force_debug_cursor else False
-        call_command("shell_plus", plain=True, print_sql=True, command="User.objects.all().exists()")
+        call_command("shell_plus", "--plain", "--print-sql", "--command=User.objects.all().exists()")
     finally:
         utils.CursorDebugWrapper = CursorDebugWrapper
         connection.force_debug_cursor = force_debug_cursor
@@ -35,19 +35,23 @@ def test_shell_plus_print_sql(capsys):
 
 
 def test_shell_plus_plain_startup():
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
+    command = shell_plus.Command()
+    command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
     args = ["--plain"]
     options = parser.parse_args(args=args)
 
-    command = shell_plus.Command()
-    command.tests_mode = True
     retcode = command.handle(**vars(options))
 
     assert retcode == 130
 
 
 def test_shell_plus_plain_startup_with_pythonrc(monkeypatch):
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
+    command = shell_plus.Command()
+    command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
     args = ["--plain", "--use-pythonrc"]
     options = parser.parse_args(args=args)
 
@@ -55,9 +59,6 @@ def test_shell_plus_plain_startup_with_pythonrc(monkeypatch):
     pythonrc_file = os.path.join(tests_dir, 'pythonrc.py')
     assert os.path.isfile(pythonrc_file)
     monkeypatch.setenv('PYTHONSTARTUP', pythonrc_file)
-
-    command = shell_plus.Command()
-    command.tests_mode = True
 
     retcode = command.handle(**vars(options))
     assert retcode == 130
@@ -68,12 +69,12 @@ def test_shell_plus_plain_startup_with_pythonrc(monkeypatch):
 
 
 def test_shell_plus_plain_loading_standard_django_imports(monkeypatch):
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
-    args = ["--plain"]
-    options = parser.parse_args(args=args)
-
     command = shell_plus.Command()
     command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
+    args = ["--plain"]
+    options = parser.parse_args(args=args)
 
     retcode = command.handle(**vars(options))
     assert retcode == 130
@@ -85,12 +86,12 @@ def test_shell_plus_plain_loading_standard_django_imports(monkeypatch):
 
 
 def test_shell_plus_plain_loading_django_extensions_modules(monkeypatch):
-    parser = shell_plus.Command().create_parser("test", "shell_plus")
-    args = ["--plain"]
-    options = parser.parse_args(args=args)
-
     command = shell_plus.Command()
     command.tests_mode = True
+
+    parser = command.create_parser("test", "shell_plus")
+    args = ["--plain"]
+    options = parser.parse_args(args=args)
 
     retcode = command.handle(**vars(options))
     assert retcode == 130


### PR DESCRIPTION
- Change the usage of "shell(s)" in the command handler to use "runner" instead. This change more accurately reflects that some of the runners are not your typical shells (``--notebook`` and ``--lab`` start notebook servers)
- The command handler now started one of the decorated "runners" which allow the runner to define the flag(s) it responds to and its name. This will make it simpler to not have to add the runner to the argument parser *and* also the previous "shells" list (while ensuring someone doesn't place the new shell at the top of the list which alters the "auto shell" behavior)
- Runners are all registered in a mutually exclusive argument parser group so you cannot specify ``--plain`` and ``--notebook`` at the same time and have the priority rely on the ``if/else`` chain which switches between the shells.
- Change the exit code to an error code if a shell could not be started