### PR TITLE
Patches to make MySQL sqldiff work (at least on our projects)

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -822,16 +822,107 @@ class MySQLDiff(SQLDiff):
         if field:
             # MySQL isn't really sure about char's and varchar's like sqlite
             field_type = self.get_field_model_type(field)
+
             # Fix char/varchar inconsistencies
             if self.strip_parameters(field_type) == 'char' and self.strip_parameters(db_type) == 'varchar':
                 db_type = db_type.lstrip("var")
-            # They like to call 'bool's 'tinyint(1)' and introspection makes that a integer
-            # just convert it back to it's proper type, a bool is a bool and nothing else.
-            if db_type == 'integer' and description[1] == FIELD_TYPE.TINY and description[2] == 1:
-                db_type = 'bool'
+
+            # They like to call bools various integer types and introspection makes that a integer
+            # just convert them all to bools
+            if self.strip_parameters(field_type) == 'bool':
+                if db_type == 'integer':
+                    db_type = 'bool'
+
             if (table_name, field.column) in self.auto_increment and 'AUTO_INCREMENT' not in db_type:
                 db_type += ' AUTO_INCREMENT'
         return db_type
+
+
+    def find_index_missing_in_model(self, meta, table_indexes, table_constraints, table_name):
+        fields = dict([(field.column, field) for field in all_local_fields(meta)])
+        meta_index_names = [idx.name for idx in meta.indexes]
+        index_together = self.expand_together(meta.index_together, meta)
+        unique_together = self.expand_together(meta.unique_together, meta)
+
+
+        for constraint_name, constraint in six.iteritems(table_constraints):
+            if constraint_name in meta_index_names:
+                continue
+            if constraint['unique'] and not constraint['index']:
+                # unique constraints are handled by find_unique_missing_in_model
+                continue
+
+            columns = constraint['columns']
+            field = fields.get(columns[0])
+
+            # extra check removed from superclass here, otherwise function is the same
+            if len(columns) == 1:
+                if constraint['primary_key'] and field.primary_key:
+                    continue
+                if constraint['foreign_key'] and isinstance(field, models.ForeignKey) and field.db_constraint:
+                    continue
+                if constraint['unique'] and field.unique:
+                    continue
+                if constraint['index'] and constraint['type'] == 'idx' and constraint.get('orders') and field.unique:
+                    # django automatically creates a _like varchar_pattern_ops/text_pattern_ops index see https://code.djangoproject.com/ticket/12234
+                    # note: mysql does not have and/or introspect and fill the 'orders' attribute of constraint information
+                    continue
+                if constraint['index'] and field.db_index:
+                    continue
+                if constraint['check'] and field.db_check(connection=connection):
+                    continue
+                if getattr(field, 'spatial_index', False):
+                    continue
+            else:
+                if constraint['index'] and tuple(columns) in index_together:
+                    continue
+                if constraint['index'] and constraint['unique'] and tuple(columns) in unique_together:
+                    continue
+
+            self.add_difference('index-missing-in-model', table_name, constraint_name)
+
+
+    def find_unique_missing_in_db(self, meta, table_indexes, table_constraints, table_name, skip_list=None):
+
+        schema_editor = connection.SchemaEditorClass(connection)
+        for field in all_local_fields(meta):
+            if skip_list and field.attname in skip_list:
+                continue
+            if field.unique and meta.managed:
+                attname = field.db_column or field.attname
+                db_field_unique = table_indexes.get(attname, {}).get('unique')
+                if not db_field_unique and table_constraints:
+                    db_field_unique = any(constraint['unique'] for contraint_name, constraint in six.iteritems(table_constraints) if [attname] == constraint['columns'])
+                if attname in table_indexes and db_field_unique:
+                    continue
+
+                index_name = schema_editor._create_index_name(table_name, [attname])
+
+                self.add_difference('unique-missing-in-db', table_name, [attname], index_name + "_uniq")
+                db_type = field.db_type(connection=connection)
+                if db_type.startswith('varchar'):
+                    self.add_difference('index-missing-in-db', table_name, [attname], index_name + '_like', ' varchar_pattern_ops')
+                if db_type.startswith('text'):
+                    self.add_difference('index-missing-in-db', table_name, [attname], index_name + '_like', ' text_pattern_ops')
+
+        unique_together = self.expand_together(meta.unique_together, meta)
+
+        # This comparison changed from superclass - otherwise function is the same
+        db_unique_columns = normalize_together([v['columns'] for v in six.itervalues(table_constraints) if v['unique']])
+
+        for unique_columns in unique_together:
+            if unique_columns in db_unique_columns:
+                continue
+
+            if skip_list and unique_columns in skip_list:
+                continue
+
+            index_name = schema_editor._create_index_name(table_name, unique_columns)
+            self.add_difference('unique-missing-in-db', table_name, unique_columns, index_name + "_uniq")
+
+
+
+
 
 
 class SqliteSQLDiff(SQLDiff):

--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -815,7 +815,6 @@ class MySQLDiff(SQLDiff):
     # Fixing one bug in MySQL creates another issue. So just keep in mind
     # that this is way unreliable for MySQL atm.
     def get_field_db_type(self, description, field=None, table_name=None):
-        from MySQLdb.constants import FIELD_TYPE
         db_type = super().get_field_db_type(description, field, table_name)
         if not db_type:
             return
@@ -837,13 +836,11 @@ class MySQLDiff(SQLDiff):
                 db_type += ' AUTO_INCREMENT'
         return db_type
 
-
     def find_index_missing_in_model(self, meta, table_indexes, table_constraints, table_name):
         fields = dict([(field.column, field) for field in all_local_fields(meta)])
         meta_index_names = [idx.name for idx in meta.indexes]
         index_together = self.expand_together(meta.index_together, meta)
         unique_together = self.expand_together(meta.unique_together, meta)
-
 
         for constraint_name, constraint in six.iteritems(table_constraints):
             if constraint_name in meta_index_names:
@@ -880,7 +877,6 @@ class MySQLDiff(SQLDiff):
                     continue
 
             self.add_difference('index-missing-in-model', table_name, constraint_name)
-
 
     def find_unique_missing_in_db(self, meta, table_indexes, table_constraints, table_name, skip_list=None):
 
@@ -919,10 +915,6 @@ class MySQLDiff(SQLDiff):
 
             index_name = schema_editor._create_index_name(table_name, unique_columns)
             self.add_difference('unique-missing-in-db', table_name, unique_columns, index_name + "_uniq")
-
-
-
-
 
 
 class SqliteSQLDiff(SQLDiff):


### PR DESCRIPTION
This Pull Request makes sqldiff (appear to) work for MySQL in our projects.

I am not sure if this is the best way to implement the fixes as I basically copy 2 whole functions from the superclass into the MySQL class and then tweak them.  That leaves them a bit vulnerable to not picking up changes in the superclass but I wasn't sure what else to do.

There may still be issues with MySQL but this eliminates a lot of false positives.
