### PR TITLE
Fix silent errors when using syncdata

### DIFF
--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -179,7 +179,8 @@ class Command(BaseCommand):
                             except Exception:
                                 import traceback
                                 fixture.close()
-                                transaction.rollback()
+                                if transaction.get_rollback(self.using):
+                                    transaction.rollback(self.using)
                                 if show_traceback:
                                     traceback.print_exc()
                                 raise SyncDataError("Problem installing fixture '%s': %s\n" % (full_path, traceback.format_exc()))


### PR DESCRIPTION
There is an issue while importing broken fixtures (i.e. when there is an invalid UUID).
The fixture fails silently and interrupts the whole process, resulting in a success message `Installed x objects from y fixtures`.

This happens because another exception is thrown when attempting to rollback a failed transaction, which was the case.