### PR TITLE
Fixes deprecation on Django 3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ minutes Eric walks you through a half a dozen command extensions. There is also 
 Requirements
 ============
 
-Django Extensions requires Django 1.11 or later.
+Django Extensions requires Django 2.2 or later.
 
 
 Getting It

--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -52,7 +52,7 @@ class ForeignKeyAutocompleteAdminMixin:
     autocomplete_limit = getattr(settings, 'FOREIGNKEY_AUTOCOMPLETE_LIMIT', None)
 
     def get_urls(self):
-        from django.conf.urls import url
+        from django.urls import path
 
         def wrap(view):
             def wrapper(*args, **kwargs):
@@ -60,7 +60,7 @@ class ForeignKeyAutocompleteAdminMixin:
             return update_wrapper(wrapper, view)
 
         return [
-            url(r'foreignkey_autocomplete/$', wrap(self.foreignkey_autocomplete),
+            path('foreignkey_autocomplete/', wrap(self.foreignkey_autocomplete),
                 name='%s_%s_autocomplete' % (self.model._meta.app_label, self.model._meta.model_name))
         ] + super().get_urls()
 

--- a/django_extensions/conf/app_template/urls.py.tmpl
+++ b/django_extensions/conf/app_template/urls.py.tmpl
@@ -1,3 +1,3 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 # place app url patterns here

--- a/django_extensions/management/signals.py
+++ b/django_extensions/management/signals.py
@@ -10,5 +10,5 @@ run_weekly_jobs = Signal()
 run_monthly_jobs = Signal()
 run_yearly_jobs = Signal()
 
-pre_command = Signal(providing_args=["args", "kwargs"])
-post_command = Signal(providing_args=["args", "kwargs", "outcome"])
+pre_command = Signal()
+post_command = Signal()


### PR DESCRIPTION
URL routing imports now raise a warning, change needs Django 2.0+

Update documentation that only Django 2.2+ is supported now (According to commit on April 21st)