### PR TITLE
Syncdata silent failure on DeserializationError

### DIFF
--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -186,7 +186,6 @@ class Command(BaseCommand):
                             except Exception:
                                 import traceback
                                 fixture.close()
-                                transaction.rollback()
                                 if show_traceback:
                                     traceback.print_exc()
                                 raise SyncDataError("Problem installing fixture '%s': %s\n" % (full_path, traceback.format_exc()))

--- a/tests/management/commands/fixtures/fixture_with_nonexistent_field.json
+++ b/tests/management/commands/fixtures/fixture_with_nonexistent_field.json
@@ -1,0 +1,21 @@
+[
+  {
+    "pk" : 3,
+    "fields" : {
+      "is_superuser" : false,
+      "first_name" : "John",
+      "date_joined" : "2019-01-19T13:37:26",
+      "email" : "john@doe.us",
+      "is_active" : true,
+      "last_login" : null,
+      "username" : "jdoe",
+      "is_staff" : false,
+      "user_permissions" : [],
+      "groups" : [],
+      "last_name" : "Doe",
+      "password" : "",
+      "non_existent_field": "something"
+    },
+    "model" : "auth.user"
+  }
+]

--- a/tests/management/commands/test_syncdata.py
+++ b/tests/management/commands/test_syncdata.py
@@ -32,6 +32,12 @@ class SyncDataExceptionsTests(TestCase):
         call_command('syncdata', 'invalid_fixture.xml', verbosity=2)
         self.assertIn("No fixture data found for 'invalid_fixture'. (File format may be invalid.)\n", m_stdout.getvalue())
 
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_should_return_SyncDataError_when_file_has_non_existent_field_in_fixture_data(self, m_stdout):
+        call_command('syncdata', 'fixture_with_nonexistent_field.json', verbosity=1)
+        self.assertIn("Problem installing fixture", m_stdout.getvalue())
+        self.assertIn("django.core.exceptions.FieldDoesNotExist: User has no field named 'non_existent_field'\n", m_stdout.getvalue())
+
     @pytest.mark.skipif(
         LooseVersion(get_version()) < LooseVersion('2.0.0'),
         reason="This test works only on Django greater than 2.x",


### PR DESCRIPTION
Addresses the extra rollback issue in #1215
https://github.com/django-extensions/django-extensions/issues/1215#issuecomment-593774907

When `syncdata` calls `serializers.deserialize(format, fixture)`, it's possible to get a `DeserializationError`, eg from a `django.core.exceptions.FieldDoesNotExist` if the fixture contains a field that as since been deleted.

This exception gets caught by the `except Exception` block, but calling `transaction.rollback()` causes a `TransactionManagementError: This is forbidden when an 'atomic' block is active.` before the traceback gets printed or the appropriate `SyncDataError` gets raised, and then this gets swallowed by the next `except Exception` block.

Since the whole call to `syncdata` is in an atomic transaction context manager, it's safe to just raise the appropriate exception and let the context manager take care of the rollback.

This PR includes a test to expose the error and removes the call to `transaction.rollback()`.

As an aside, it seems that the exit code is always 0, even if there are errors in the command. I haven't looked at other management commands to see if this is consistent across the project, but is there a reason the exit code isn't non-zero if an error occurs? Could make the commands more useful in CI/automation scenarios.
