### PR TITLE
Pipchecker compatibility

### DIFF
--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -6,6 +6,7 @@ from distutils.version import LooseVersion
 
 import pip
 from django.core.management.base import BaseCommand, CommandError
+from pip._internal.req.constructors import install_req_from_line
 
 try:
     try:
@@ -89,6 +90,8 @@ class Command(BaseCommand):
         with PipSession() as session:
             for filename in req_files:
                 for req in parse_requirements(filename, session=session):
+                    if LooseVersion(pip.__version__) >= LooseVersion('20.1'):
+                        req = install_req_from_line(req.requirement)
                     name = req.name if req.name else req.link.filename
                     # url attribute changed to link in pip version 6.1.0 and above
                     if LooseVersion(pip.__version__) > LooseVersion('6.0.8'):

--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -7,7 +7,9 @@ from distutils.version import LooseVersion
 import pip
 from django.core.management.base import BaseCommand, CommandError
 from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_line
+
+if LooseVersion(pip.__version__) >= LooseVersion('19.0'):
+    from pip._internal.req.constructors import install_req_from_line  # noqa
 
 try:
     try:

--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -90,11 +90,13 @@ class Command(BaseCommand):
         with PipSession() as session:
             for filename in req_files:
                 for req in parse_requirements(filename, session=session):
-                    if LooseVersion(pip.__version__) >= LooseVersion('20.1'):
+                    pip_version = LooseVersion(pip.__version__)
+                    if pip_version >= LooseVersion('20.1'):
                         req = install_req_from_line(req.requirement)
                     name = req.name if req.name else req.link.filename
+
                     # url attribute changed to link in pip version 6.1.0 and above
-                    if LooseVersion(pip.__version__) > LooseVersion('6.0.8'):
+                    if pip_version > LooseVersion('6.0.8'):
                         self.reqs[name] = {
                             "pip_req": req,
                             "url": req.link,

--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -27,16 +27,10 @@ except ImportError:
 from django_extensions.management.color import color_style
 from django_extensions.management.utils import signalcommand
 
-try:
-    from urllib.parse import urlparse
-    from urllib.error import HTTPError
-    from urllib.request import Request, urlopen
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    # Python 2
-    from urlparse import urlparse  # type: ignore
-    from urllib2 import HTTPError, Request, urlopen  # type: ignore
-    from xmlrpclib import ServerProxy  # type: ignore
+from urllib.parse import urlparse
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+from xmlrpc.client import ServerProxy
 
 try:
     import requests

--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -6,6 +6,7 @@ from distutils.version import LooseVersion
 
 import pip
 from django.core.management.base import BaseCommand, CommandError
+from pip._internal.req import InstallRequirement
 from pip._internal.req.constructors import install_req_from_line
 
 try:
@@ -84,13 +85,12 @@ class Command(BaseCommand):
         with PipSession() as session:
             for filename in req_files:
                 for req in parse_requirements(filename, session=session):
-                    pip_version = LooseVersion(pip.__version__)
-                    if pip_version >= LooseVersion('20.1'):
+                    if not isinstance(req, InstallRequirement):
                         req = install_req_from_line(req.requirement)
                     name = req.name if req.name else req.link.filename
 
                     # url attribute changed to link in pip version 6.1.0 and above
-                    if pip_version > LooseVersion('6.0.8'):
+                    if LooseVersion(pip.__version__) > LooseVersion('6.0.8'):
                         self.reqs[name] = {
                             "pip_req": req,
                             "url": req.link,

--- a/tests/management/commands/test_pipchecker.py
+++ b/tests/management/commands/test_pipchecker.py
@@ -44,11 +44,7 @@ class PipCheckerTests(TestCase):
         f.close()
 
         subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', requirements_path])
-        if sys.version_info.major == 3:
-            pip._vendor.pkg_resources = importlib.reload(pip._vendor.pkg_resources)
-        else:
-            # Python 2.7
-            pip._vendor.pkg_resources = reload(pip._vendor.pkg_resources)  # noqa
+        pip._vendor.pkg_resources = importlib.reload(pip._vendor.pkg_resources)
         call_command('pipchecker', '-r', requirements_path, stdout=out)
 
         value = out.getvalue()
@@ -68,11 +64,7 @@ class PipCheckerTests(TestCase):
         f.close()
 
         subprocess.call([sys.executable, '-m', 'pip', 'install', '-r', requirements_path])
-        if sys.version_info.major == 3:
-            pip._vendor.pkg_resources = importlib.reload(pip._vendor.pkg_resources)
-        else:
-            # Python 2.7
-            pip._vendor.pkg_resources = reload(pip._vendor.pkg_resources)  # noqa
+        pip._vendor.pkg_resources = importlib.reload(pip._vendor.pkg_resources)
         call_command('pipchecker', '-r', requirements_path, stdout=out)
 
         value = out.getvalue()
@@ -91,11 +83,7 @@ class PipCheckerTests(TestCase):
         f.close()
 
         subprocess.call([sys.executable, '-m', 'pip', 'install', 'django-json-widget'])
-        if sys.version_info.major == 3:
-            pip._vendor.pkg_resources = importlib.reload(pip._vendor.pkg_resources)
-        else:
-            # Python 2.7
-            pip._vendor.pkg_resources = reload(pip._vendor.pkg_resources)  # noqa
+        pip._vendor.pkg_resources = importlib.reload(pip._vendor.pkg_resources)
         call_command('pipchecker', '-r', requirements_path, stdout=out)
 
         value = out.getvalue()


### PR DESCRIPTION
Resolves #1521
On pip 20.1, `parse_requirements()` returns `ParsedRequirement` object. So I updated a code to make `InstallRequirement` object from it.