### PR TITLE
Cleanup old compat stuff

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -2,10 +2,8 @@
 #
 # Autocomplete feature for admin panel
 #
-import six
 import operator
-from functools import update_wrapper
-from six.moves import reduce
+from functools import update_wrapper, reduce
 from typing import Tuple, Dict, Callable  # NOQA
 
 from django.apps import apps
@@ -111,7 +109,7 @@ class ForeignKeyAutocompleteAdminMixin:
                 if self.autocomplete_limit:
                     queryset = queryset[:self.autocomplete_limit]
 
-                data = ''.join([six.u('%s|%s\n') % (to_string_function(f), f.pk) for f in queryset])
+                data = ''.join([str('%s|%s\n') % (to_string_function(f), f.pk) for f in queryset])
             elif object_pk:
                 try:
                     obj = queryset.get(pk=object_pk)
@@ -149,7 +147,7 @@ class ForeignKeyAutocompleteAdminMixin:
         if isinstance(db_field, models.ForeignKey) and db_field.name in self.related_search_fields:
             help_text = self.get_help_text(db_field.name, db_field.remote_field.model._meta.object_name)
             if kwargs.get('help_text'):
-                help_text = six.u('%s %s' % (kwargs['help_text'], help_text))
+                help_text = str('%s %s') % (kwargs['help_text'], help_text)
             kwargs['widget'] = ForeignKeySearchInput(db_field.remote_field, self.related_search_fields[db_field.name])
             kwargs['help_text'] = help_text
         return super().formfield_for_dbfield(db_field, **kwargs)

--- a/django_extensions/admin/filter.py
+++ b/django_extensions/admin/filter.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.contrib.admin import FieldListFilter
 from django.contrib.admin.utils import prepare_lookup_value
 from django.utils.translation import gettext_lazy as _

--- a/django_extensions/admin/widgets.py
+++ b/django_extensions/admin/widgets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import six
-from six.moves import urllib
+import urllib
+
 from django import forms
 from django.contrib.admin.sites import site
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
@@ -68,7 +68,7 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
         if value:
             label = self.label_for_value(value)
         else:
-            label = six.u('')
+            label = ''
 
         context = {
             'url': url,
@@ -87,4 +87,4 @@ class ForeignKeySearchInput(ForeignKeyRawIdWidget):
         ), context))
         output.reverse()
 
-        return mark_safe(six.u('').join(output))
+        return mark_safe(''.join(output))

--- a/django_extensions/collision_resolvers.py
+++ b/django_extensions/collision_resolvers.py
@@ -10,11 +10,9 @@ from typing import (  # NOQA
 )
 
 from django.utils.module_loading import import_string
-from six import add_metaclass
 
 
-@add_metaclass(ABCMeta)
-class BaseCR:
+class BaseCR(metaclass=ABCMeta):
     """
     Abstract base collision resolver. All collision resolvers needs to inherit from this class.
     To write custom collision resolver you need to overwrite resolve_collisions function.
@@ -43,8 +41,7 @@ class LegacyCR(BaseCR):
         return result
 
 
-@add_metaclass(ABCMeta)
-class AppsOrderCR(LegacyCR):
+class AppsOrderCR(LegacyCR, metaclass=ABCMeta):
     APP_PRIORITIES = None  # type: List[str]
 
     def resolve_collisions(self, namespace):
@@ -82,8 +79,7 @@ class InstalledAppsOrderCR(AppsOrderCR):
         return getattr(settings, 'INSTALLED_APPS', [])
 
 
-@add_metaclass(ABCMeta)
-class PathBasedCR(LegacyCR):
+class PathBasedCR(LegacyCR, metaclass=ABCMeta):
     """
     Abstract resolver which transforms full model name into alias.
     To use him you need to overwrite transform_import function
@@ -120,8 +116,7 @@ class FullPathCR(PathBasedCR):
         return module_path.replace('.', '_')
 
 
-@add_metaclass(ABCMeta)
-class AppNameCR(PathBasedCR):
+class AppNameCR(PathBasedCR, metaclass=ABCMeta):
     """
     Abstract collision resolver which transform pair (app name, model_name) to alias by changing dots to underscores.
     You must define MODIFICATION_STRING which should be string to format with two keyword arguments:
@@ -184,8 +179,7 @@ class FullPathCustomOrderCR(FullPathCR, InstalledAppsOrderCR):
     pass
 
 
-@add_metaclass(ABCMeta)
-class AppLabelCR(PathBasedCR):
+class AppLabelCR(PathBasedCR, metaclass=ABCMeta):
     """
     Abstract collision resolver which transform pair (app_label, model_name) to alias.
     You must define MODIFICATION_STRING which should be string to format with two keyword arguments:

--- a/django_extensions/compat.py
+++ b/django_extensions/compat.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from io import BytesIO
 
 import csv

--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -6,7 +6,6 @@ Some fields might require additional dependencies to be installed.
 """
 
 import re
-import six
 import string
 
 try:
@@ -82,10 +81,10 @@ class UniqueFieldMixin:
                     }
                     query &= Q(**condition)
 
-        new = six.next(iterator)
+        new = next(iterator)
         kwargs[self.attname] = new
         while not new or queryset.filter(query, **kwargs):
-            new = six.next(iterator)
+            new = next(iterator)
             kwargs[self.attname] = new
         setattr(model_instance, self.attname, new)
         return new
@@ -161,11 +160,11 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
             if not isinstance(populate_from, (list, tuple)):
                 populate_from = (populate_from, )
 
-            if not all(isinstance(e, six.string_types) for e in populate_from):
+            if not all(isinstance(e, str) for e in populate_from):
                 raise TypeError("'populate_from' must be str or list[str] or tuple[str], found `%s`" % populate_from)
 
         self.slugify_function = kwargs.pop('slugify_function', slugify)
-        self.separator = kwargs.pop('separator', six.u('-'))
+        self.separator = kwargs.pop('separator', '-')
         self.overwrite = kwargs.pop('overwrite', False)
         self.check_is_bool('overwrite')
         self.overwrite_on_add = kwargs.pop('overwrite_on_add', True)
@@ -281,7 +280,7 @@ class AutoSlugField(UniqueFieldMixin, SlugField):
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()
         kwargs['populate_from'] = self._populate_from
-        if not self.separator == six.u('-'):
+        if not self.separator == '-':
             kwargs['separator'] = self.separator
         if self.overwrite is not False:
             kwargs['overwrite'] = True
@@ -383,7 +382,7 @@ class RandomCharField(UniqueFieldMixin, CharField):
 
         random_chars = self.random_char_generator(population)
         if not self.unique and not self.in_unique_together(model_instance):
-            new = six.next(random_chars)
+            new = next(random_chars)
             setattr(model_instance, self.attname, new)
             return new
 

--- a/django_extensions/db/fields/json.py
+++ b/django_extensions/db/fields/json.py
@@ -10,12 +10,8 @@ more information.
  class LOL(models.Model):
      extra = json.JSONField()
 """
-from __future__ import absolute_import
-
 import json
 
-import six
-import django
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
@@ -73,7 +69,7 @@ class JSONField(models.TextField):
         if value is None or value == '':
             return {}
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             res = loads(value)
         else:
             res = value
@@ -86,16 +82,12 @@ class JSONField(models.TextField):
         return res
 
     def get_prep_value(self, value):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             return dumps(value)
         return super(models.TextField, self).get_prep_value(value)
 
-    if django.VERSION < (2, ):
-        def from_db_value(self, value, expression, connection, context):
-            return self.to_python(value)
-    else:
-        def from_db_value(self, value, expression, connection):  # type: ignore
-            return self.to_python(value)
+    def from_db_value(self, value, expression, connection):  # type: ignore
+        return self.to_python(value)
 
     def get_db_prep_save(self, value, connection, **kwargs):
         """Convert our JSON object to a string before we save"""
@@ -103,7 +95,7 @@ class JSONField(models.TextField):
             return None
         # default values come in as strings; only non-strings should be
         # run through `dumps`
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             value = dumps(value)
 
         return value

--- a/django_extensions/db/models.py
+++ b/django_extensions/db/models.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from django.db import models
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _

--- a/django_extensions/jobs/daily/cache_cleanup.py
+++ b/django_extensions/jobs/daily/cache_cleanup.py
@@ -5,7 +5,6 @@ Daily cleanup job.
 Can be run as a cronjob to clean out old data from the database (only expired
 sessions at the moment).
 """
-import six
 
 from django.conf import settings
 from django.core.cache import caches
@@ -18,7 +17,7 @@ class Job(DailyJob):
 
     def execute(self):
         if hasattr(settings, 'CACHES'):
-            for cache_name, cache_options in six.iteritems(settings.CACHES):
+            for cache_name, cache_options in settings.CACHES.items():
                 if cache_options['BACKEND'].endswith("DatabaseCache"):
                     cache = caches[cache_name]
                     cache.clear()

--- a/django_extensions/management/color.py
+++ b/django_extensions/management/color.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from django.core.management import color
 from django.utils import termcolors
 

--- a/django_extensions/management/commands/admin_generator.py
+++ b/django_extensions/management/commands/admin_generator.py
@@ -17,7 +17,6 @@ https://github.com/WoLpH/django-admin-generator/
 
 import re
 
-import six
 from django.apps import apps
 from django.conf import settings
 from django.core.management.base import LabelCommand, CommandError
@@ -200,7 +199,7 @@ class AdminModel(UnicodeMixin):
         if field in parent_fields:
             return
 
-        field_name = six.text_type(field.name)
+        field_name = str(field.name)
         self.list_display.append(field_name)
         if isinstance(field, LIST_FILTER):
             if isinstance(field, models.ForeignKey):

--- a/django_extensions/management/commands/delete_squashed_migrations.py
+++ b/django_extensions/management/commands/delete_squashed_migrations.py
@@ -3,7 +3,6 @@ import os
 import inspect
 import re
 
-import six
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.loader import AmbiguityError, MigrationLoader
@@ -155,7 +154,7 @@ class Command(BaseCommand):
         if self.interactive:
             answer = None
             while not answer or answer not in "yn":
-                answer = six.moves.input("Do you wish to proceed? [yN] ")
+                answer = input("Do you wish to proceed? [yN] ")
                 if not answer:
                     answer = "n"
                     break

--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
-from six.moves import input
 
 from django_extensions.management.mysql import parse_mysql_cnf
 from django_extensions.management.utils import signalcommand

--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -31,7 +31,6 @@ Improvements:
 import datetime
 import sys
 
-import six
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
@@ -73,8 +72,8 @@ def orm_item_locator(orm_obj):
             if isinstance(v, datetime.datetime):
                 v = timezone.make_aware(v)
                 clean_dict[key] = StrToCodeChanger('dateutil.parser.parse("%s")' % v.isoformat())
-            elif not isinstance(v, (six.string_types, six.integer_types, float)):
-                clean_dict[key] = six.u("%s" % v)
+            elif not isinstance(v, (str, int, float)):
+                clean_dict[key] = str("%s" % v)
 
     output = """ importer.locate_object(%s, "%s", %s, "%s", %s, %s ) """ % (
         original_class, original_pk_name,
@@ -496,7 +495,7 @@ class Script(Code):
     FILE_HEADER = """
 
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+
 
 # This file has been automatically generated.
 # Instead of changing it, create a file called import_helper.py
@@ -643,7 +642,7 @@ def flatten_blocks(lines, num_indents=-1):
         return ""
 
     # If this is a string, add the indentation and finish here
-    if isinstance(lines, six.string_types):
+    if isinstance(lines, str):
         return INDENTATION * num_indents + lines
 
     # If this is not a string, join the lines and recurse

--- a/django_extensions/management/commands/export_emails.py
+++ b/django_extensions/management/commands/export_emails.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, print_function
 import sys
 import csv
 

--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -4,7 +4,6 @@ import json
 import os
 import tempfile
 
-import six
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.template import loader
@@ -257,7 +256,7 @@ class Command(BaseCommand):
 
     def print_output(self, dotdata, output_file=None):
         """Write model data to file or stdout in DOT (text) format."""
-        if isinstance(dotdata, six.binary_type):
+        if isinstance(dotdata, bytes):
             dotdata = dotdata.decode()
 
         if output_file:

--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import asyncore
 import sys
 from logging import getLogger
@@ -78,10 +76,7 @@ class Command(BaseCommand):
         def inner_run():
             quit_command = (sys.platform == 'win32') and 'CTRL-BREAK' or 'CONTROL-C'
             print("Now accepting mail at %s:%s -- use %s to quit" % (addr, port, quit_command))
-            if sys.version_info < (3, 5):
-                ExtensionDebuggingServer((addr, port), None)
-            else:
-                ExtensionDebuggingServer((addr, port), None, decode_data=True)
+            ExtensionDebuggingServer((addr, port), None, decode_data=True)
             asyncore.loop()
 
         try:

--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
-
 import os
 import re
 

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
-
 import importlib
 
 from django.conf import settings

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -11,7 +11,6 @@ import warnings
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS
-from six.moves import input
 
 from django_extensions.settings import SQLITE_ENGINES, POSTGRESQL_ENGINES, MYSQL_ENGINES
 from django_extensions.management.mysql import parse_mysql_cnf

--- a/django_extensions/management/commands/reset_schema.py
+++ b/django_extensions/management/commands/reset_schema.py
@@ -11,7 +11,6 @@ from django.core.management import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS
 from django.db import connections
 from django.conf import settings
-from six.moves import input
 
 from django_extensions.utils.deprecation import RemovedInNextVersionWarning
 

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import logging
 import os
 import re

--- a/django_extensions/management/commands/show_urls.py
+++ b/django_extensions/management/commands/show_urls.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+
 import functools
 import json
 import re
 
-import django
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
 from django.core.exceptions import ViewDoesNotExist
@@ -13,34 +13,24 @@ from django.utils import translation
 from django_extensions.management.color import color_style, no_style
 from django_extensions.management.utils import signalcommand
 
-if django.VERSION >= (2, 0):
-    from django.urls import URLPattern, URLResolver  # type: ignore
+from django.urls import URLPattern, URLResolver  # type: ignore
 
-    class RegexURLPattern:  # type: ignore
-        pass
 
-    class RegexURLResolver:  # type: ignore
-        pass
+class RegexURLPattern:  # type: ignore
+    pass
 
-    class LocaleRegexURLResolver:  # type: ignore
-        pass
 
-    def describe_pattern(p):
-        return str(p.pattern)
-else:
-    try:
-        from django.urls import RegexURLPattern, RegexURLResolver, LocaleRegexURLResolver  # type: ignore
-    except ImportError:
-        from django.core.urlresolvers import RegexURLPattern, RegexURLResolver, LocaleRegexURLResolver  # type: ignore
+class RegexURLResolver:  # type: ignore
+    pass
 
-    class URLPattern:  # type: ignore
-        pass
 
-    class URLResolver:  # type: ignore
-        pass
+class LocaleRegexURLResolver:  # type: ignore
+    pass
 
-    def describe_pattern(p):
-        return p.regex.pattern
+
+def describe_pattern(p):
+    return str(p.pattern)
+
 
 FMTR = {
     'dense': "{url}\t{module}\t{url_name}\t{decorator}",

--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -23,7 +23,6 @@ KNOWN ISSUES:
 
 import importlib
 import sys
-import six
 import argparse
 from typing import Dict, Union, Callable, Optional  # NOQA
 from django.apps import apps
@@ -399,7 +398,7 @@ class SQLDiff:
                 attname = field.db_column or field.attname
                 db_field_unique = table_indexes.get(attname, {}).get('unique')
                 if not db_field_unique and table_constraints:
-                    db_field_unique = any(constraint['unique'] for contraint_name, constraint in six.iteritems(table_constraints) if [attname] == constraint['columns'])
+                    db_field_unique = any(constraint['unique'] for contraint_name, constraint in table_constraints.items() if [attname] == constraint['columns'])
                 if attname in table_indexes and db_field_unique:
                     continue
 
@@ -413,7 +412,7 @@ class SQLDiff:
                     self.add_difference('index-missing-in-db', table_name, [attname], index_name + '_like', ' text_pattern_ops')
 
         unique_together = self.expand_together(meta.unique_together, meta)
-        db_unique_columns = normalize_together([v['columns'] for v in six.itervalues(table_constraints) if v['unique'] and not v['index']])
+        db_unique_columns = normalize_together([v['columns'] for v in table_constraints.values() if v['unique'] and not v['index']])
 
         for unique_columns in unique_together:
             if unique_columns in db_unique_columns:
@@ -430,7 +429,7 @@ class SQLDiff:
         fields = dict([(field.column, field) for field in all_local_fields(meta)])
         unique_together = self.expand_together(meta.unique_together, meta)
 
-        for constraint_name, constraint in six.iteritems(table_constraints):
+        for constraint_name, constraint in table_constraints.items():
             if not constraint['unique']:
                 continue
             if constraint['index']:
@@ -465,7 +464,7 @@ class SQLDiff:
                         self.add_difference('index-missing-in-db', table_name, [attname], index_name + '_like', ' text_pattern_ops')
 
         index_together = self.expand_together(meta.index_together, meta)
-        db_index_together = normalize_together([v['columns'] for v in six.itervalues(table_constraints) if v['index'] and not v['unique']])
+        db_index_together = normalize_together([v['columns'] for v in table_constraints.values() if v['index'] and not v['unique']])
         for columns in index_together:
             if columns in db_index_together:
                 continue
@@ -481,7 +480,7 @@ class SQLDiff:
         meta_index_names = [idx.name for idx in meta.indexes]
         index_together = self.expand_together(meta.index_together, meta)
 
-        for constraint_name, constraint in six.iteritems(table_constraints):
+        for constraint_name, constraint in table_constraints.items():
             if constraint_name in meta_index_names:
                 continue
             if constraint['unique'] and not constraint['index']:
@@ -523,7 +522,7 @@ class SQLDiff:
 
     def find_field_missing_in_db(self, fieldmap, table_description, table_name):
         db_fields = [row[0] for row in table_description]
-        for field_name, field in six.iteritems(fieldmap):
+        for field_name, field in fieldmap.items():
             if field_name not in db_fields:
                 field_output = []
 
@@ -842,7 +841,7 @@ class MySQLDiff(SQLDiff):
         index_together = self.expand_together(meta.index_together, meta)
         unique_together = self.expand_together(meta.unique_together, meta)
 
-        for constraint_name, constraint in six.iteritems(table_constraints):
+        for constraint_name, constraint in table_constraints.items():
             if constraint_name in meta_index_names:
                 continue
             if constraint['unique'] and not constraint['index']:
@@ -888,7 +887,7 @@ class MySQLDiff(SQLDiff):
                 attname = field.db_column or field.attname
                 db_field_unique = table_indexes.get(attname, {}).get('unique')
                 if not db_field_unique and table_constraints:
-                    db_field_unique = any(constraint['unique'] for contraint_name, constraint in six.iteritems(table_constraints) if [attname] == constraint['columns'])
+                    db_field_unique = any(constraint['unique'] for contraint_name, constraint in table_constraints.items() if [attname] == constraint['columns'])
                 if attname in table_indexes and db_field_unique:
                     continue
 
@@ -904,7 +903,7 @@ class MySQLDiff(SQLDiff):
         unique_together = self.expand_together(meta.unique_together, meta)
 
         # This comparison changed from superclass - otherwise function is the same
-        db_unique_columns = normalize_together([v['columns'] for v in six.itervalues(table_constraints) if v['unique']])
+        db_unique_columns = normalize_together([v['columns'] for v in table_constraints.values() if v['unique']])
 
         for unique_columns in unique_together:
             if unique_columns in db_unique_columns:
@@ -943,7 +942,7 @@ class SqliteSQLDiff(SQLDiff):
 
         unique_columns = [field.db_column or field.attname for field in all_local_fields(meta) if field.unique]
 
-        for constraint in six.itervalues(table_constraints):
+        for constraint in table_constraints.values():
             columns = constraint['columns']
             if len(columns) == 1:
                 column = columns[0]
@@ -951,7 +950,7 @@ class SqliteSQLDiff(SQLDiff):
                     skip_list.append(column)
 
         unique_together = self.expand_together(meta.unique_together, meta)
-        db_unique_columns = normalize_together([v['columns'] for v in six.itervalues(table_constraints) if v['unique']])
+        db_unique_columns = normalize_together([v['columns'] for v in table_constraints.values() if v['unique']])
 
         for unique_columns in unique_together:
             if unique_columns in db_unique_columns:

--- a/django_extensions/management/commands/sync_s3.py
+++ b/django_extensions/management/commands/sync_s3.py
@@ -66,7 +66,7 @@ from typing import List  # NOQA
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from six import StringIO
+from io import StringIO
 
 from django_extensions.management.utils import signalcommand
 

--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -11,7 +11,6 @@ and anything extra will of been deleted.
 
 import os
 
-import six
 from django.apps import apps
 from django.conf import settings
 from django.core import serializers
@@ -73,14 +72,14 @@ class Command(BaseCommand):
                     if obj.pk in remove_these_ones:
                         obj.delete()
                         if verbosity >= 2:
-                            print("Deleted object: %s" % six.u(obj))
+                            print("Deleted object: %s" % str(obj))
 
             if verbosity > 0 and remove_these_ones:
                 num_deleted = len(remove_these_ones)
                 if num_deleted > 1:
-                    type_deleted = six.u(class_._meta.verbose_name_plural)
+                    type_deleted = str(class_._meta.verbose_name_plural)
                 else:
-                    type_deleted = six.u(class_._meta.verbose_name)
+                    type_deleted = str(class_._meta.verbose_name)
 
                 print("Deleted %s %s" % (str(num_deleted), type_deleted))
 

--- a/django_extensions/management/debug_cursor.py
+++ b/django_extensions/management/debug_cursor.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 import time
 import traceback
 from contextlib import contextmanager
@@ -11,7 +10,7 @@ from django.db.backends import utils
 
 
 @contextmanager
-def monkey_patch_cursordebugwrapper(print_sql=None, print_sql_location=False, truncate=None, logger=six.print_, confprefix="DJANGO_EXTENSIONS"):
+def monkey_patch_cursordebugwrapper(print_sql=None, print_sql_location=False, truncate=None, logger=print, confprefix="DJANGO_EXTENSIONS"):
     if not print_sql:
         yield
     else:

--- a/django_extensions/management/jobs.py
+++ b/django_extensions/management/jobs.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import os
 import sys
 from imp import find_module

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -12,7 +12,6 @@ import datetime
 import os
 import re
 
-import six
 from django.apps import apps
 from django.db.models.fields.related import (
     ForeignKey, ManyToManyField, OneToOneField, RelatedField,
@@ -166,7 +165,7 @@ class ModelGraph:
             label = ''
 
         # handle self-relationships and lazy-relationships
-        if isinstance(field.remote_field.model, six.string_types):
+        if isinstance(field.remote_field.model, str):
             if field.remote_field.model == 'self':
                 target_model = field.model
             else:
@@ -416,7 +415,7 @@ class ModelGraph:
 
 
 def generate_dot(graph_data, template='django_extensions/graph_models/digraph.dot'):
-    if isinstance(template, six.string_types):
+    if isinstance(template, str):
         template = loader.get_template(template)
 
     if not isinstance(template, Template) and not (hasattr(template, 'template') and isinstance(template.template, Template)):

--- a/django_extensions/management/mysql.py
+++ b/django_extensions/management/mysql.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from six.moves import configparser
+import configparser
 
 
 def parse_mysql_cnf(dbinfo):

--- a/django_extensions/management/notebook_extension.py
+++ b/django_extensions/management/notebook_extension.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-
 def load_ipython_extension(ipython):
     from django.core.management.color import no_style
     from django_extensions.management.shells import import_objects

--- a/django_extensions/management/shells.py
+++ b/django_extensions/management/shells.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import ast
-import six
 import traceback
 import warnings
 import importlib
@@ -12,7 +11,6 @@ from typing import (  # NOQA
     Union,
 )
 
-from django import VERSION as DJANGO_VERSION
 from django.apps.config import MODELS_MODULE_NAME
 from django.utils.module_loading import import_string
 from django_extensions.collision_resolvers import CollisionResolvingRunner
@@ -27,19 +25,9 @@ SHELL_PLUS_DJANGO_IMPORTS = [
     'from django.db import transaction',
     'from django.db.models import Avg, Case, Count, F, Max, Min, Prefetch, Q, Sum, When',
     'from django.utils import timezone',
+    'from django.urls import reverse',
+    'from django.db.models import Exists, OuterRef, Subquery',
 ]
-if DJANGO_VERSION < (1, 10):
-    SHELL_PLUS_DJANGO_IMPORTS.append(
-        'from django.core.urlresolvers import reverse',
-    )
-else:
-    SHELL_PLUS_DJANGO_IMPORTS.append(
-        'from django.urls import reverse',
-    )
-if DJANGO_VERSION >= (1, 11):
-    SHELL_PLUS_DJANGO_IMPORTS.append(
-        'from django.db.models import Exists, OuterRef, Subquery',
-    )
 
 
 class ObjectImportError(Exception):
@@ -90,10 +78,10 @@ def import_items(import_directives, style, quiet_load=False):
     imported_objects = {}
 
     for directive in import_directives:
-        if isinstance(directive, six.string_types):
+        if isinstance(directive, str):
             directive = directive.strip()
         try:
-            if isinstance(directive, six.string_types) and directive.startswith(("from ", "import ")):
+            if isinstance(directive, str) and directive.startswith(("from ", "import ")):
                 try:
                     node = ast.parse(directive)
                 except Exception as exc:
@@ -130,19 +118,19 @@ def import_items(import_directives, style, quiet_load=False):
             else:
                 warnings.warn("Old style import definitions are deprecated. You should use the new style which is similar to normal Python imports. ", RemovedInNextVersionWarning, stacklevel=2)
 
-                if isinstance(directive, six.string_types):
+                if isinstance(directive, str):
                     imported_object = __import__(directive)
                     imported_objects[directive.split('.')[0]] = imported_object
                     if not quiet_load:
                         print(style.SQL_COLTYPE("import %s" % directive))
                     continue
                 elif isinstance(directive, (list, tuple)) and len(directive) == 2:
-                    if not isinstance(directive[0], six.string_types):
+                    if not isinstance(directive[0], str):
                         if not quiet_load:
                             print(style.ERROR("Unable to import %r: module name must be of type string" % directive[0]))
                         continue
 
-                    if isinstance(directive[1], (list, tuple)) and all(isinstance(e, six.string_types) for e in directive[1]):
+                    if isinstance(directive[1], (list, tuple)) and all(isinstance(e, str) for e in directive[1]):
                         # Try the ('module.submodule', ('classname1', 'classname2')) form
                         imported_object = __import__(directive[0], {}, {}, directive[1])
                         imported_names = []
@@ -156,7 +144,7 @@ def import_items(import_directives, style, quiet_load=False):
                                 imported_names.append(name)
                         if not quiet_load:
                             print(style.SQL_COLTYPE("from %s import %s" % (directive[0], ', '.join(imported_names))))
-                    elif isinstance(directive[1], six.string_types):
+                    elif isinstance(directive[1], str):
                         # If it is a tuple, but the second item isn't a list, so we have something like ('module.submodule', 'classname1')
                         # Check for the special '*' to import all
                         if directive[1] == '*':
@@ -213,7 +201,7 @@ def import_objects(options, style):
         :return: Dict[str, List[str]]. Key is name, value is list of full model's path's.
         """
         models_to_import = {}  # type: Dict[str, List[str]]
-        for app_mod, models in sorted(six.iteritems(load_models)):
+        for app_mod, models in sorted(load_models.items()):
             app_name = get_app_name(app_mod)
             app_aliases = model_aliases.get(app_name, {})
             prefix = app_prefixes.get(app_name)
@@ -292,11 +280,11 @@ def import_objects(options, style):
         if not quiet_load:
             print(style.SQL_TABLE("# Shell Plus User Pre Imports"))
         imports = import_items(SHELL_PLUS_PRE_IMPORTS, style, quiet_load=quiet_load)
-        for k, v in six.iteritems(imports):
+        for k, v in imports.items():
             imported_objects[k] = v
 
     if mongoengine and not dont_load_any_models:
-        for name, mod in six.iteritems(_document_registry):
+        for name, mod in _document_registry.items():
             name = name.split('.')[-1]
             app_name = get_app_name(mod.__module__)
             if app_name in dont_load or ("%s.%s" % (app_name, name)) in dont_load:
@@ -334,7 +322,7 @@ def import_objects(options, style):
         if not quiet_load:
             print(style.SQL_TABLE("# Shell Plus Django Imports"))
         imports = import_items(SHELL_PLUS_DJANGO_IMPORTS, style, quiet_load=quiet_load)
-        for k, v in six.iteritems(imports):
+        for k, v in imports.items():
             imported_objects[k] = v
 
     SHELL_PLUS_IMPORTS = getattr(settings, 'SHELL_PLUS_IMPORTS', {})
@@ -342,7 +330,7 @@ def import_objects(options, style):
         if not quiet_load:
             print(style.SQL_TABLE("# Shell Plus User Imports"))
         imports = import_items(SHELL_PLUS_IMPORTS, style, quiet_load=quiet_load)
-        for k, v in six.iteritems(imports):
+        for k, v in imports.items():
             imported_objects[k] = v
 
     # Perform post-imports after any other imports
@@ -351,7 +339,7 @@ def import_objects(options, style):
         if not quiet_load:
             print(style.SQL_TABLE("# Shell Plus User Post Imports"))
         imports = import_items(SHELL_PLUS_POST_IMPORTS, style, quiet_load=quiet_load)
-        for k, v in six.iteritems(imports):
+        for k, v in imports.items():
             imported_objects[k] = v
 
     return imported_objects

--- a/django_extensions/management/signals.py
+++ b/django_extensions/management/signals.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from django.dispatch import Signal
 
 run_minutely_jobs = Signal()

--- a/django_extensions/management/technical_response.py
+++ b/django_extensions/management/technical_response.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import threading
 
-import six
 from django.core.handlers.wsgi import WSGIHandler
 
 tld = threading.local()
@@ -34,4 +33,4 @@ def null_technical_500_response(request, exc_type, exc_value, tb, status_code=50
     except AttributeError:
         pass
 
-    six.reraise(exc_type, exc_value, tb)
+    raise(exc_type, exc_value, tb)

--- a/django_extensions/mongodb/fields/__init__.py
+++ b/django_extensions/mongodb/fields/__init__.py
@@ -7,7 +7,6 @@ These fields are essentially identical to existing Extensions fields, but South 
 """
 
 import re
-import six
 import datetime
 from django import forms
 from django.db.models.constants import LOOKUP_SEP
@@ -71,7 +70,7 @@ class AutoSlugField(SlugField):
             self._populate_from = populate_from
 
         self.slugify_function = kwargs.pop('slugify_function', slugify)
-        self.separator = kwargs.pop('separator', six.u('-'))
+        self.separator = kwargs.pop('separator', str('-'))
         self.overwrite = kwargs.pop('overwrite', False)
         super().__init__(*args, **kwargs)
 
@@ -165,7 +164,7 @@ class AutoSlugField(SlugField):
         return attr
 
     def pre_save(self, model_instance, add):
-        value = six.u(self.create_slug(model_instance, add))
+        value = str(self.create_slug(model_instance, add))
         setattr(model_instance, self.attname, value)
         return value
 
@@ -258,12 +257,12 @@ class UUIDField(StringField):
 
     def pre_save(self, model_instance, add):
         if self.auto and add:
-            value = six.u(self.create_uuid())
+            value = str(self.create_uuid())
             setattr(model_instance, self.attname, value)
             return value
         else:
             value = super().pre_save(model_instance, add)
             if self.auto and not value:
-                value = six.u(self.create_uuid())
+                value = str(self.create_uuid())
                 setattr(model_instance, self.attname, value)
         return value

--- a/django_extensions/mongodb/fields/json.py
+++ b/django_extensions/mongodb/fields/json.py
@@ -11,13 +11,10 @@ more information.
      extra = json.JSONField()
 """
 
-from __future__ import absolute_import
-
 import datetime
 from decimal import Decimal
 
 import json
-import six
 from django.conf import settings
 from mongoengine.fields import StringField
 
@@ -68,7 +65,7 @@ class JSONField(StringField):
         """ Convert our string value to JSON after we load it from the DB """
         if not value:
             return {}
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             res = loads(value)
             assert isinstance(res, dict)
             return JSONDict(**res)

--- a/django_extensions/mongodb/models.py
+++ b/django_extensions/mongodb/models.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import datetime
 
 from django.utils.translation import gettext_lazy as _

--- a/django_extensions/templatetags/widont.py
+++ b/django_extensions/templatetags/widont.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import re
 
 from django.template import Library

--- a/django_extensions/utils/deprecation.py
+++ b/django_extensions/utils/deprecation.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 
 class MarkedForDeprecationWarning(DeprecationWarning):
     pass

--- a/django_extensions/utils/dia2django.py
+++ b/django_extensions/utils/dia2django.py
@@ -17,8 +17,6 @@ import re
 import sys
 from xml.dom.minidom import Node, parseString
 
-import six
-
 dependclasses = ["User", "Group", "Permission", "Message"]
 
 # Type dictionary translation types SQL -> Django
@@ -79,7 +77,7 @@ def dia2django(archivo):
     datos = ppal.getElementsByTagName("dia:diagram")[0].getElementsByTagName("dia:layer")[0].getElementsByTagName("dia:object")
     clases = {}
     herit = []
-    imports = six.u("")
+    imports = str("")
     for i in datos:
         # Look for the classes
         if i.getAttribute("type") == "UML - Class":
@@ -169,13 +167,13 @@ def dia2django(archivo):
             a = i.getElementsByTagName("dia:string")
             for j in a:
                 if len(j.childNodes[0].data[1:-1]):
-                    imports += six.u("from %s.models import *" % j.childNodes[0].data[1:-1])
+                    imports += str("from %s.models import *" % j.childNodes[0].data[1:-1])
 
     addparentstofks(herit, clases)
     # Ordering the appearance of classes
     # First we make a list of the classes each classs is related to.
     ordered = []
-    for j, k in six.iteritems(clases):
+    for j, k in clases.items():
         k[2] += "\n    def __str__(self):\n        return u\"\"\n"
         for fk in k[0]:
             if fk not in dependclasses:

--- a/django_extensions/validators.py
+++ b/django_extensions/validators.py
@@ -2,7 +2,6 @@
 import unicodedata
 import binascii
 
-
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_str

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 import os
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -117,13 +117,11 @@ for dirpath, dirnames, filenames in os.walk(extensions_dir):
 
 version = __import__('django_extensions').__version__
 
-install_requires = ['six>=1.2']
+install_requires = []
 extras_require = {}
 
 if int(setuptools.__version__.split(".", 1)[0]) < 18:
     assert "bdist_wheel" not in sys.argv, "setuptools 18 or later is required for wheels."
-    if sys.version_info[:2] < (3, 5):
-        install_requires.append('typing')
 elif int(setuptools.__version__.split(".", 1)[0]) >= 36:
     install_requires.append('typing;python_version<"3.5"')
 else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from unittest import mock
-
 
 force_color_support = mock.patch('django.core.management.color.supports_color', autospec=True, side_effect=lambda: True)

--- a/tests/collisions/apps.py
+++ b/tests/collisions/apps.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.apps import AppConfig
 
 

--- a/tests/collisions/models.py
+++ b/tests/collisions/models.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models
 
 

--- a/tests/db/fields/test_uniq_field_mixin.py
+++ b/tests/db/fields/test_uniq_field_mixin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
 
-import six
 from django.db import models
 from django.test import TestCase
 from tests.testapp.models import (
@@ -17,7 +16,7 @@ class UniqFieldMixinTestCase(TestCase):
 
         class MockField(UniqueFieldMixin):
             def __init__(self, **kwargs):
-                for key, value in six.iteritems(kwargs):
+                for key, value in kwargs.items():
                     setattr(self, key, value)
 
         self.uniq_field = MockField(

--- a/tests/management/commands/shell_plus_tests/test_collision_resolver.py
+++ b/tests/management/commands/shell_plus_tests/test_collision_resolver.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 from django.contrib.auth.models import Group, Permission
 from django.test import override_settings
 
@@ -151,7 +150,7 @@ class CRTestCase(AutomaticShellPlusImportsTestCase):
         SHELL_PLUS_MODEL_IMPORTS_RESOLVER='tests.management.commands.shell_plus_tests.test_collision_resolver.TestAppsOrderCR',
     )
     def test_installed_bad_order_collision_resolver(self):
-        with six.assertRaisesRegex(self, AssertionError, "You must define APP_PRIORITIES in your resolver class!"):
+        with self.assertRaisesRegex(AssertionError, "You must define APP_PRIORITIES in your resolver class!"):
             self._assert_models_present_under_names(
                 set(), set(), set(), set(), set(), set(), set(), set(), set(), set(), set(),
             )
@@ -160,13 +159,13 @@ class CRTestCase(AutomaticShellPlusImportsTestCase):
         SHELL_PLUS_MODEL_IMPORTS_RESOLVER='tests.management.commands.shell_plus_tests.test_collision_resolver.TestAppNameCR',
     )
     def test_installed_apps_bad_name_collision_resolver(self):
-        with six.assertRaisesRegex(self, AssertionError, "You must define MODIFICATION_STRING in your resolver class!"):
+        with self.assertRaisesRegex(AssertionError, "You must define MODIFICATION_STRING in your resolver class!"):
             self._assert_models_present_under_names(
                 set(), set(), set(), set(), set(), set(), set(), set(), set(), set(), set(),
             )
 
     def _assert_bad_resolver(self, message):
-        with six.assertRaisesRegex(self, AssertionError, message):
+        with self.assertRaisesRegex(AssertionError, message):
             self._assert_models_present_under_names(
                 set(), set(), set(), set(), set(), set(), set(), set(), set(), set(), set(),
             )
@@ -187,8 +186,8 @@ class CRTestCase(AutomaticShellPlusImportsTestCase):
         SHELL_PLUS_MODEL_IMPORTS_RESOLVER='tests.management.commands.shell_plus_tests.test_collision_resolver.CRNoFunction',
     )
     def test_installed_apps_no_resolve_conflicts_function(self):
-        with six.assertRaisesRegex(
-            self, TypeError, "Can't instantiate abstract class CRNoFunction with abstract methods resolve_collisions"
+        with self.assertRaisesRegex(
+            TypeError, "Can't instantiate abstract class CRNoFunction with abstract methods resolve_collisions"
         ):
             self._assert_models_present_under_names(
                 set(), set(), set(), set(), set(), set(), set(), set(), set(), set(), set(),

--- a/tests/management/commands/shell_plus_tests/test_shell_plus.py
+++ b/tests/management/commands/shell_plus_tests/test_shell_plus.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
 import re
-import six
-import django
 import pytest
 import inspect
 
+from io import StringIO
 from django.core.management import call_command
 from django.db.models import Model
 from django.test import override_settings
@@ -13,11 +12,10 @@ from django.test import override_settings
 from django_extensions.management.commands import shell_plus
 
 
-@pytest.mark.skipif(django.VERSION < (2, 0), reason="This test works only on Django greater than 2.0.0")
 @pytest.mark.django_db()
 @override_settings(SHELL_PLUS_SQLPARSE_ENABLED=False, SHELL_PLUS_PYGMENTS_ENABLED=False)
 def test_shell_plus_print_sql(capsys):
-    out = six.StringIO()
+    out = StringIO()
     try:
         from django.db import connection
         from django.db.backends import utils

--- a/tests/management/commands/shell_plus_tests/test_utils.py
+++ b/tests/management/commands/shell_plus_tests/test_utils.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
-
+from io import StringIO
 from typing import Dict, Set, Type  # noqa
 
-import six
 from django.test import TestCase
 from django_extensions.management.commands import shell_plus
 
@@ -11,8 +10,8 @@ from django_extensions.management.commands import shell_plus
 class AutomaticShellPlusImportsTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        sys.stdout = six.StringIO()
-        sys.stderr = six.StringIO()
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
         self.imported_objects = {}  # type: Dict[str, Type]
         self.output = ""
 

--- a/tests/management/commands/test_admin_generator.py
+++ b/tests/management/commands/test_admin_generator.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+from io import StringIO
+
 from django.core.management import call_command
 from django.db import models
 from django.test import TestCase
-from six import PY3, StringIO
 
 
 class AdminGeneratorTests(TestCase):
@@ -16,12 +17,8 @@ class AdminGeneratorTests(TestCase):
         output = self.out.getvalue()
         self.assertIn("@admin.register(Secret)", output)
         self.assertIn("class SecretAdmin(admin.ModelAdmin):", output)
-        if PY3:
-            self.assertIn("list_display = ('id', 'name', 'text')", output)
-            self.assertIn("search_fields = ('name',)", output)
-        else:
-            self.assertIn("list_display = (u'id', u'name', u'text')", output)
-            self.assertIn("search_fields = (u'name',)", output)
+        self.assertIn("list_display = ('id', 'name', 'text')", output)
+        self.assertIn("search_fields = ('name',)", output)
 
     def test_should_print_warning_if_given_app_is_not_installed(self):
         expected_output = '''This command requires an existing app name as argument

--- a/tests/management/commands/test_clear_cache.py
+++ b/tests/management/commands/test_clear_cache.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
 import os
-import six
+from io import StringIO
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -19,7 +19,7 @@ class ClearCacheTests(TestCase):
         os.environ['DJANGO_SETTINGS_MODULE'] = 'django_extensions.settings'
         DefaultCacheMock.reset_mock()
         OtherCacheMock.reset_mock()
-        self.out = six.StringIO()
+        self.out = StringIO()
 
     def tearDown(self):
         if self._settings:
@@ -55,7 +55,7 @@ class ClearCacheTests(TestCase):
 
     def test_called_with_invalid_arguments(self):
         with self.settings(BASE_DIR=self.project_root):
-            with six.assertRaisesRegex(self, CommandError, 'Using both --all and --cache is not supported'):
+            with self.assertRaisesRegex(CommandError, 'Using both --all and --cache is not supported'):
                 call_command('clear_cache', '--all', '--cache', 'foo')
 
     def test_should_print_that_cache_is_invalid_on_InvalidCacheBackendError(self):

--- a/tests/management/commands/test_create_command.py
+++ b/tests/management/commands/test_create_command.py
@@ -5,7 +5,7 @@ import shutil
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
-from six import StringIO
+from io import StringIO
 
 from unittest.mock import patch
 

--- a/tests/management/commands/test_create_jobs.py
+++ b/tests/management/commands/test_create_jobs.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import shutil
 
 from django.core.management import call_command
 from django.test import TestCase
-from six import StringIO
+from io import StringIO
 from tests import testapp_with_no_models_file
 
 from unittest.mock import patch
@@ -32,8 +31,7 @@ class CreateJobsExceptionsTests(CreateJobsTestsMixin, TestCase):
     def test_should_print_error_notice_on_OSError(self, m__make_writeable, m_stderr):
         call_command('create_jobs', 'testapp_with_no_models_file')
 
-        six.assertRegex(
-            self,
+        self.assertRegex(
             m_stderr.getvalue(),
             r"Notice: Couldn't set permission bits on \S+ You're probably using an uncommon filesystem setup. No problem.",
         )

--- a/tests/management/commands/test_create_template_tags.py
+++ b/tests/management/commands/test_create_template_tags.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import shutil
 
 from django.core.management import call_command
 from django.test import TestCase
-from six import StringIO
+from io import StringIO
 from tests import testapp_with_no_models_file
 
 from unittest.mock import Mock, patch
@@ -39,8 +38,7 @@ class CreateTemplateTagsTests(TestCase):
         with patch.dict('sys.modules', shutil=m_shutil):
             call_command('create_template_tags', 'testapp_with_no_models_file')
 
-        six.assertRegex(
-            self,
+        self.assertRegex(
             m_stderr.getvalue(),
             r"Notice: Couldn't set permission bits on \S+ You're probably using an uncommon filesystem setup. No problem.",
         )

--- a/tests/management/commands/test_delete_squashed_migrations.py
+++ b/tests/management/commands/test_delete_squashed_migrations.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 from distutils.version import LooseVersion
 
 import pytest
@@ -46,16 +45,14 @@ class DeleteSquashedMigrationsExceptionsTests(BaseDeleteSquashedMigrationsTestCa
     """Tests for delete_squashed_migrations command exceptions."""
 
     def test_should_raise_CommandError_if_app_does_not_have_migrations(self):
-        with six.assertRaisesRegex(
-                self,
+        with self.assertRaisesRegex(
                 CommandError,
                 r"App 'testapp_with_no_models_file' does not have migrations \(so delete_squashed_migrations on it makes no sense\)"):
 
             call_command('delete_squashed_migrations', 'testapp_with_no_models_file')
 
     def test_should_raise_CommandEror_if_migration_is_not_squashed(self):
-        with six.assertRaisesRegex(
-                self,
+        with self.assertRaisesRegex(
                 CommandError,
                 "The migration testapp_with_appconfig 0001_initial is not a squashed migration."):
 
@@ -73,8 +70,7 @@ class DeleteSquashedMigrationsExceptionsTests(BaseDeleteSquashedMigrationsTestCa
         call_command('makemigrations', 'testapp_with_appconfig')
         call_command('squashmigrations', 'testapp_with_appconfig', '0002', '--noinput')
 
-        with six.assertRaisesRegex(
-                self,
+        with self.assertRaisesRegex(
                 CommandError,
                 "More than one migration matches '0001' in app 'testapp_with_appconfig'. Please be more specific."):
 
@@ -90,16 +86,14 @@ class DeleteSquashedMigrationsExceptionsTests(BaseDeleteSquashedMigrationsTestCa
 
         call_command('makemigrations', 'testapp_with_appconfig')
 
-        with six.assertRaisesRegex(
-                self,
+        with self.assertRaisesRegex(
                 CommandError,
                 "Cannot find a squashed migration in app 'testapp_with_appconfig'."):
 
             call_command('delete_squashed_migrations', 'testapp_with_appconfig')
 
     def test_should_raise_CommandEror_if_squashed_migration_not_foundee(self):
-        with six.assertRaisesRegex(
-                self,
+        with self.assertRaisesRegex(
                 CommandError,
                 "Cannot find a migration matching '0002' from app 'testapp_with_appconfig'."):
 

--- a/tests/management/commands/test_describe_form.py
+++ b/tests/management/commands/test_describe_form.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import six
+from io import StringIO
 
 from django.test import TestCase
 from django.db import models
@@ -10,7 +10,7 @@ class DescribeFormExceptionsTests(TestCase):
     """Tests for describe_form command exceptions."""
 
     def test_should_raise_CommandError_if_invalid_arg(self):
-        with six.assertRaisesRegex(self, CommandError, "Need application and model name in the form: appname.model"):
+        with self.assertRaisesRegex(CommandError, "Need application and model name in the form: appname.model"):
             call_command('describe_form', 'testapp')
 
 
@@ -18,7 +18,7 @@ class DescribeFormTests(TestCase):
     """Tests for describe_form command."""
 
     def setUp(self):
-        self.out = six.StringIO()
+        self.out = StringIO()
 
         class BaseModel(models.Model):
             title = models.CharField(max_length=50)

--- a/tests/management/commands/test_drop_test_database.py
+++ b/tests/management/commands/test_drop_test_database.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import six
+from io import StringIO
+
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
 
 from unittest.mock import MagicMock, Mock, patch
 
@@ -12,7 +12,7 @@ class DropTestDatabaseExceptionsTests(TestCase):
     """Test for drop_test_database command."""
 
     def test_should_raise_CommandError_if_database_is_unknown(self):
-        with six.assertRaisesRegex(self, CommandError, "Unknown database unknown"):
+        with self.assertRaisesRegex(CommandError, "Unknown database unknown"):
             call_command('drop_test_database', '--database=unknown')
 
     @override_settings(DATABASES={
@@ -24,7 +24,7 @@ class DropTestDatabaseExceptionsTests(TestCase):
     @patch('django_extensions.management.commands.drop_test_database.input')
     def test_should_raise_CommandError_if_unknown_database_engine(self, m_input):
         m_input.return_value = 'yes'
-        with six.assertRaisesRegex(self, CommandError, "Unknown database engine unknown"):
+        with self.assertRaisesRegex(CommandError, "Unknown database engine unknown"):
             call_command('drop_test_database')
 
     @override_settings(DATABASES={
@@ -37,7 +37,7 @@ class DropTestDatabaseExceptionsTests(TestCase):
         }
     })
     def test_shoul_raise_CommandError_if_test_database_name_is_empty(self):
-        with six.assertRaisesRegex(self, CommandError, "You need to specify DATABASE_NAME in your Django settings file."):
+        with self.assertRaisesRegex(CommandError, "You need to specify DATABASE_NAME in your Django settings file."):
             call_command('drop_test_database')
 
 

--- a/tests/management/commands/test_export_emails.py
+++ b/tests/management/commands/test_export_emails.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from django.core.management import call_command
 
 from django_extensions.management.commands.export_emails import full_name

--- a/tests/management/commands/test_generate_password.py
+++ b/tests/management/commands/test_generate_password.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.core.management import call_command
 
 

--- a/tests/management/commands/test_generate_secret_key.py
+++ b/tests/management/commands/test_generate_secret_key.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from distutils.version import LooseVersion
+from io import StringIO
 
 import pytest
 from django import get_version
 from django.core.management import call_command
 from django.test import TestCase
-from six import StringIO
 
 from unittest.mock import patch
 

--- a/tests/management/commands/test_graph_models.py
+++ b/tests/management/commands/test_graph_models.py
@@ -4,11 +4,11 @@ import os
 import re
 import tempfile
 from contextlib import contextmanager
+from io import StringIO
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
-from six import StringIO
 
 
 def assert_looks_like_dotfile(output):

--- a/tests/management/commands/test_notes.py
+++ b/tests/management/commands/test_notes.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 
 from django.core.management import call_command

--- a/tests/management/commands/test_pipchecker.py
+++ b/tests/management/commands/test_pipchecker.py
@@ -9,7 +9,7 @@ import pkg_resources
 import pytest
 from django.core.management import call_command
 from django.test import TestCase
-from six import StringIO
+from io import StringIO
 from pip._internal.exceptions import InstallationError
 
 

--- a/tests/management/commands/test_print_settings.py
+++ b/tests/management/commands/test_print_settings.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.core.management import call_command
 
 

--- a/tests/management/commands/test_print_user_for_session.py
+++ b/tests/management/commands/test_print_user_for_session.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 from importlib import import_module
 from io import StringIO
 
@@ -15,7 +14,7 @@ class PrintUserForSessionExceptionsTests(TestCase):
     """Test if print_user_for_session command raises exception."""
 
     def test_should_raise_CommandError_if_session_key_contains_exclamination_mark(self):
-        with six.assertRaisesRegex(self, CommandError, 'malformed session key'):
+        with self.assertRaisesRegex(CommandError, 'malformed session key'):
             call_command('print_user_for_session', 'l6hxnwblpvrfu8bohelmqjj4soyo2r!?')
 
 

--- a/tests/management/commands/test_reset_db.py
+++ b/tests/management/commands/test_reset_db.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
-import six
+from io import StringIO
 
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
 
 from unittest import mock
 
@@ -14,7 +13,7 @@ class ResetDbExceptionsTests(TestCase):
     """Tests if reset_db command raises exceptions."""
 
     def test_should_raise_CommandError_when_database_does_not_exist(self):
-        with six.assertRaisesRegex(self, CommandError, 'Unknown database non-existing_database'):
+        with self.assertRaisesRegex(CommandError, 'Unknown database non-existing_database'):
             call_command('reset_db', '--database=non-existing_database')
 
     @override_settings(DATABASES={
@@ -24,7 +23,7 @@ class ResetDbExceptionsTests(TestCase):
         }
     })
     def test_should_raise_CommandError_when_unknown_database_engine(self):
-        with six.assertRaisesRegex(self, CommandError, 'Unknown database engine django.db.backends.UNKNOWN'):
+        with self.assertRaisesRegex(CommandError, 'Unknown database engine django.db.backends.UNKNOWN'):
             call_command('reset_db', '--noinput')
 
     @override_settings(DATABASES={
@@ -33,7 +32,7 @@ class ResetDbExceptionsTests(TestCase):
         }
     })
     def test_should_raise_CommandError_when_no_db_name_provided(self):
-        with six.assertRaisesRegex(self, CommandError, 'You need to specify DATABASE_NAME in your Django settings file.'):
+        with self.assertRaisesRegex(CommandError, 'You need to specify DATABASE_NAME in your Django settings file.'):
             call_command('reset_db', '--noinput')
 
 

--- a/tests/management/commands/test_reset_schema.py
+++ b/tests/management/commands/test_reset_schema.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import six
+from io import StringIO
+
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
 
 from unittest import mock
 
@@ -12,7 +12,7 @@ class ResetSchemaExceptionsTests(TestCase):
     """Tests if reset_schema command raises exceptions."""
 
     def test_should_raise_CommandError_when_database_does_not_exist(self):
-        with six.assertRaisesRegex(self, CommandError, 'Unknown database non-existing_database'):
+        with self.assertRaisesRegex(CommandError, 'Unknown database non-existing_database'):
             call_command('reset_schema', '--database=non-existing_database')
 
     @override_settings(DATABASES={
@@ -21,7 +21,7 @@ class ResetSchemaExceptionsTests(TestCase):
         },
     })
     def test_should_raise_CommandError_when_database_ENGINE_different_thant_postgresql(self):
-        with six.assertRaisesRegex(self, CommandError, 'This command can be used only with PostgreSQL databases.'):
+        with self.assertRaisesRegex(CommandError, 'This command can be used only with PostgreSQL databases.'):
             call_command('reset_schema')
 
 

--- a/tests/management/commands/test_runjob.py
+++ b/tests/management/commands/test_runjob.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import sys
-import six
+from io import StringIO
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -12,8 +12,8 @@ from unittest.mock import patch
 class RunJobTests(TestCase):
 
     def setUp(self):
-        sys.stdout = six.StringIO()
-        sys.stderr = six.StringIO()
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
 
         # Remove old loggers, since utils.setup_logger does not clean up after itself
         logger = logging.getLogger("django_extensions.management.commands.runjob")
@@ -32,7 +32,7 @@ class RunJobTests(TestCase):
 
     def test_list_jobs(self):
         call_command('runjob', '-l', verbosity=2)
-        six.assertRegex(self, sys.stdout.getvalue(), "tests.testapp +- sample_job +- +- My sample job.\n")
+        self.assertRegex(sys.stdout.getvalue(), "tests.testapp +- sample_job +- +- My sample job.\n")
 
     def test_list_jobs_appconfig(self):
         with self.modify_settings(INSTALLED_APPS={
@@ -40,7 +40,7 @@ class RunJobTests(TestCase):
             'remove': 'tests.testapp',
         }):
             call_command('runjob', '-l', verbosity=2)
-            six.assertRegex(self, sys.stdout.getvalue(), "tests.testapp +- sample_job +- +- My sample job.\n")
+            self.assertRegex(sys.stdout.getvalue(), "tests.testapp +- sample_job +- +- My sample job.\n")
 
     def test_runs_appconfig(self):
         with self.modify_settings(INSTALLED_APPS={

--- a/tests/management/commands/test_set_default_site.py
+++ b/tests/management/commands/test_set_default_site.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-import six
+from io import StringIO
+
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
 
 from unittest.mock import patch
 
@@ -16,24 +16,24 @@ class SetDefaultSiteTests(TestCase):
 
     @override_settings(SITE_ID=321)
     def test_should_raise_CommandError_when_Site_object_does_not_exist(self):
-        with six.assertRaisesRegex(self, CommandError, "Default site with pk=321 does not exist"):
+        with self.assertRaisesRegex(CommandError, "Default site with pk=321 does not exist"):
             call_command('set_default_site')
 
     @patch('django_extensions.management.commands.set_default_site.socket')
     def test_should_raise_CommandError_if_system_fqdn_return_None(self, m_socket):
         m_socket.getfqdn.return_value = None
-        with six.assertRaisesRegex(self, CommandError, "Cannot find systems FQDN"):
+        with self.assertRaisesRegex(CommandError, "Cannot find systems FQDN"):
             call_command('set_default_site', '--system-fqdn')
 
     def test_should_raise_CommandError_if_both_domain_and_set_as_system_fqdn_are_present(self):
-        with six.assertRaisesRegex(self, CommandError, "The set_as_system_fqdn cannot be used with domain option."):
+        with self.assertRaisesRegex(CommandError, "The set_as_system_fqdn cannot be used with domain option."):
             call_command('set_default_site', '--domain=foo', '--system-fqdn')
 
     @override_settings(INSTALLED_APPS=[
         app for app in settings.INSTALLED_APPS
         if app != 'django.contrib.sites'])
     def test_should_raise_CommandError_Sites_framework_not_installed(self):
-        with six.assertRaisesRegex(self, CommandError, "The sites framework is not installed."):
+        with self.assertRaisesRegex(CommandError, "The sites framework is not installed."):
             call_command('set_default_site', '--domain=foo', '--system-fqdn')
 
     @patch('sys.stdout', new_callable=StringIO)

--- a/tests/management/commands/test_set_fake_emails.py
+++ b/tests/management/commands/test_set_fake_emails.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from io import StringIO
 
 from django.core.management import call_command, CommandError
 from django.contrib.auth.models import User
-from six import StringIO
+
 from django_extensions.management.commands.set_fake_emails import Command
 
 import pytest

--- a/tests/management/commands/test_set_fake_passwords.py
+++ b/tests/management/commands/test_set_fake_passwords.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from io import StringIO
 
 import pytest
 from django.contrib.auth.models import User
 from django.core.management import CommandError, call_command
-from six import StringIO
 
 from django_extensions.management.commands.set_fake_passwords import DEFAULT_FAKE_PASSWORD
 

--- a/tests/management/commands/test_show_template_tags.py
+++ b/tests/management/commands/test_show_template_tags.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+from io import StringIO
+
 from django.core.management import call_command
-from six import StringIO
 
 
 def test_show_template_tags():

--- a/tests/management/commands/test_show_urls.py
+++ b/tests/management/commands/test_show_urls.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-import six
+from io import StringIO
+
 from django.conf.urls import url
 from django.core.management import CommandError, call_command
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.views.generic.base import View
-from six import StringIO
 
 from unittest.mock import Mock, patch
 
@@ -30,17 +30,17 @@ class ShowUrlsExceptionsTests(TestCase):
     """Tests if show_urls command raises exceptions."""
 
     def test_should_raise_CommandError_when_format_style_does_not_exists(self):
-        with six.assertRaisesRegex(self, CommandError, "Format style 'invalid_format' does not exist. Options: aligned, dense, json, pretty-json, table, verbose"):
+        with self.assertRaisesRegex(CommandError, "Format style 'invalid_format' does not exist. Options: aligned, dense, json, pretty-json, table, verbose"):
             call_command('show_urls', '--format=invalid_format')
 
     def test_should_raise_CommandError_when_doesnt_have_urlconf_attr(self):
-        with six.assertRaisesRegex(self, CommandError, "Settings module <Settings \"tests.testapp.settings\"> does not have the attribute INVALID_URLCONF."):
+        with self.assertRaisesRegex(CommandError, "Settings module <Settings \"tests.testapp.settings\"> does not have the attribute INVALID_URLCONF."):
             call_command('show_urls', '--urlconf=INVALID_URLCONF')
 
     @override_settings(INVALID_URLCONF='')
     def test_should_raise_CommandError_when_doesnt_have_urlconf_attr_print_exc(self):
         m_traceback = Mock()
-        with six.assertRaisesRegex(self, CommandError, 'Error occurred while trying to load : Empty module name'):
+        with self.assertRaisesRegex(CommandError, 'Error occurred while trying to load : Empty module name'):
             with patch.dict('sys.modules', traceback=m_traceback):
                 call_command('show_urls', '--urlconf=INVALID_URLCONF', '--traceback')
 

--- a/tests/management/commands/test_sqlcreate.py
+++ b/tests/management/commands/test_sqlcreate.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
+from io import StringIO
 
-import six
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
 
 from unittest.mock import patch
 
@@ -37,7 +36,7 @@ class SqlcreateExceptionsTests(TestCase):
     """Test for sqlcreate exception."""
 
     def test_should_raise_CommandError_if_database_is_unknown(self):
-        with six.assertRaisesRegex(self, CommandError, "Unknown database unknown"):
+        with self.assertRaisesRegex(CommandError, "Unknown database unknown"):
             call_command('sqlcreate', '--database=unknown')
 
 

--- a/tests/management/commands/test_sqldsn.py
+++ b/tests/management/commands/test_sqldsn.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+from io import StringIO
+
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
-
 
 from unittest.mock import patch
 

--- a/tests/management/commands/test_sync_s3.py
+++ b/tests/management/commands/test_sync_s3.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import shutil
 
 from django.conf import settings
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
+from io import StringIO
 
 from django_extensions.management.commands.sync_s3 import Command
 
@@ -31,17 +30,17 @@ class SyncS3ExceptionsTests(SyncS3TestsMixin, TestCase):
 
     def test_should_raise_ImportError_if_boto_is_not_installed(self):
         with patch('django_extensions.management.commands.sync_s3.HAS_BOTO', False):
-            with six.assertRaisesRegex(self, CommandError, r"Please install the 'boto' Python library. \(\$ pip install boto\)"):
+            with self.assertRaisesRegex(CommandError, r"Please install the 'boto' Python library. \(\$ pip install boto\)"):
                 call_command('sync_s3')
 
     @override_settings(AWS_ACCESS_KEY_ID=None)
     def test_should_raise_CommandError_if_AWS_ACCESS_KEY_ID_is_not_set_or_is_set_to_None(self):
-        with six.assertRaisesRegex(self, CommandError, "Missing AWS keys from settings file.  Please supply both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"):
+        with self.assertRaisesRegex(CommandError, "Missing AWS keys from settings file.  Please supply both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"):
             call_command('sync_s3')
 
     @override_settings(AWS_SECRET_ACCESS_KEY=None)
     def test_should_raise_CommandError_if_AWS_SECRET_ACCESS_KEY_is_not_set_or_is_set_to_None(self):
-        with six.assertRaisesRegex(self, CommandError, "Missing AWS keys from settings file.  Please supply both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"):
+        with self.assertRaisesRegex(CommandError, "Missing AWS keys from settings file.  Please supply both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"):
             call_command('sync_s3')
 
     @override_settings(
@@ -50,7 +49,7 @@ class SyncS3ExceptionsTests(SyncS3TestsMixin, TestCase):
         AWS_BUCKET_NAME=''
     )
     def test_should_raise_CommandError_if_AWS_BUCKET_NAME_is_set_to_None(self):
-        with six.assertRaisesRegex(self, CommandError, "AWS_BUCKET_NAME cannot be empty"):
+        with self.assertRaisesRegex(CommandError, "AWS_BUCKET_NAME cannot be empty"):
             call_command('sync_s3')
 
     @override_settings(
@@ -60,7 +59,7 @@ class SyncS3ExceptionsTests(SyncS3TestsMixin, TestCase):
     def test_should_raise_CommandError_if_AWS_BUCKET_NAME_does_not_have_AWS_BUCKET_NAME_attr(self):
         del settings.AWS_BUCKET_NAME
 
-        with six.assertRaisesRegex(self, CommandError, "Missing bucket name from settings file. Please add the AWS_BUCKET_NAME to your settings file."):
+        with self.assertRaisesRegex(CommandError, "Missing bucket name from settings file. Please add the AWS_BUCKET_NAME to your settings file."):
             call_command('sync_s3')
 
     @override_settings(
@@ -70,7 +69,7 @@ class SyncS3ExceptionsTests(SyncS3TestsMixin, TestCase):
         MEDIA_ROOT=None
     )
     def test_should_raise_CommandError_if_MEDIA_ROOT_is_None(self):
-        with six.assertRaisesRegex(self, CommandError, "MEDIA_ROOT must be set in your settings."):
+        with self.assertRaisesRegex(CommandError, "MEDIA_ROOT must be set in your settings."):
             call_command('sync_s3')
 
     @override_settings(
@@ -81,7 +80,7 @@ class SyncS3ExceptionsTests(SyncS3TestsMixin, TestCase):
     def test_should_raise_CommandError_if_settings_does_not_have_MEDIA_ROOT_attr(self):
         del settings.MEDIA_ROOT
 
-        with six.assertRaisesRegex(self, CommandError, "MEDIA_ROOT must be set in your settings."):
+        with self.assertRaisesRegex(CommandError, "MEDIA_ROOT must be set in your settings."):
             call_command('sync_s3')
 
     @override_settings(
@@ -90,7 +89,7 @@ class SyncS3ExceptionsTests(SyncS3TestsMixin, TestCase):
         AWS_BUCKET_NAME='bucket_name',
     )
     def test_should_raise_CommandError_when_media_only_and_static_only_options_together(self):
-        with six.assertRaisesRegex(self, CommandError, "Can't use --media-only and --static-only together. Better not use anything..."):
+        with self.assertRaisesRegex(CommandError, "Can't use --media-only and --static-only together. Better not use anything..."):
             call_command('sync_s3', '--media-only', '--static-only')
 
     @override_settings(
@@ -105,7 +104,7 @@ class SyncS3ExceptionsTests(SyncS3TestsMixin, TestCase):
         self.m_boto.connect_s3.return_value.get_bucket.return_value = m_bucket
         self.m_boto.s3.key.Key.return_value = 'bucket_key'
 
-        with six.assertRaisesRegex(self, CommandError, "An object invalidation was requested but the variable AWS_CLOUDFRONT_DISTRIBUTION is not present in your settings."):
+        with self.assertRaisesRegex(CommandError, "An object invalidation was requested but the variable AWS_CLOUDFRONT_DISTRIBUTION is not present in your settings."):
             call_command('sync_s3', '--media-only', '--invalidate')
 
 

--- a/tests/management/commands/test_syncdata.py
+++ b/tests/management/commands/test_syncdata.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.core.management import call_command, CommandError
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
+from io import StringIO
 
 from unittest.mock import patch
 

--- a/tests/management/commands/test_unreferenced_files.py
+++ b/tests/management/commands/test_unreferenced_files.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import shutil
+from io import StringIO
 from tempfile import mkdtemp
 
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
 
 from ...testapp.models import Photo
 
@@ -18,7 +17,7 @@ class UnreferencedFilesExceptionsTests(TestCase):
 
     @override_settings(MEDIA_ROOT=None)
     def test_should_raise_ComandError_if_MEDIA_ROOT_is_not_set(self):
-        with six.assertRaisesRegex(self, CommandError, 'MEDIA_ROOT is not set, nothing to do'):
+        with self.assertRaisesRegex(CommandError, 'MEDIA_ROOT is not set, nothing to do'):
             call_command('unreferenced_files')
 
 

--- a/tests/management/commands/test_update_permissions.py
+++ b/tests/management/commands/test_update_permissions.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
+from io import StringIO
 
 from django.contrib.auth.models import Permission
 from django.core.management import call_command
 from django.db import models
 from django.test import TestCase
-from six import StringIO
 
 
 class UpdatePermissionsTests(TestCase):

--- a/tests/management/commands/test_validate_templates.py
+++ b/tests/management/commands/test_validate_templates.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import shutil
+from io import StringIO
 from tempfile import mkdtemp
 
 from django.conf import settings
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
 
 
 def test_validate_templates():
@@ -33,7 +32,7 @@ class ValidateTemplatesTests(TestCase):
 
     def test_should_print_that_there_is_error(self):
         with override_settings(INSTALLED_APPS=settings.INSTALLED_APPS + ['tests.testapp_with_template_errors']):
-            with six.assertRaisesRegex(self, CommandError, '1 errors found'):
+            with self.assertRaisesRegex(CommandError, '1 errors found'):
                 call_command('validate_templates', verbosity=3)
 
     def test_should_not_print_any_errors_if_template_in_VALIDATE_TEMPLATES_IGNORES(self):
@@ -65,5 +64,5 @@ class ValidateTemplatesTests(TestCase):
         with open(fn, 'w') as f:
             f.write("""{% invalid_tag %}""")
 
-        with six.assertRaisesRegex(self, CommandError, 'Errors found'):
+        with self.assertRaisesRegex(CommandError, 'Errors found'):
             call_command('validate_templates', '-i', self.tempdir, '-b', verbosity=3)

--- a/tests/management/test_email_notifications.py
+++ b/tests/management/test_email_notifications.py
@@ -3,7 +3,7 @@ from django.core import mail
 from django.core.management import call_command
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import StringIO
+from io import StringIO
 
 from unittest.mock import patch
 

--- a/tests/templatetags/test_highlighting.py
+++ b/tests/templatetags/test_highlighting.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 from django.template import Context, Template, TemplateSyntaxError
 from django.test import TestCase
 
@@ -15,8 +14,7 @@ class HighlightTagExceptionTests(TestCase):
 {% highlight %}
 {% endhighlight %}
 """
-        with six.assertRaisesRegex(
-                self,
+        with self.assertRaisesRegex(
                 TemplateSyntaxError,
                 "'highlight' statement requires an argument"):
             Template(content).render(self.ctx)

--- a/tests/templatetags/test_indent_text.py
+++ b/tests/templatetags/test_indent_text.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 from django.test import TestCase
 from django.template import Context, Template, TemplateSyntaxError
 
@@ -12,7 +11,7 @@ class IndentByTagExceptions(TestCase):
 {% indentby %}
 Hello World
 {% endindentby %}"""
-        with six.assertRaisesRegex(self, TemplateSyntaxError, "indentby tag requires 1 or 3 arguments"):
+        with self.assertRaisesRegex(TemplateSyntaxError, "indentby tag requires 1 or 3 arguments"):
             Template(content).render(Context())
 
 

--- a/tests/templatetags/test_syntax_color.py
+++ b/tests/templatetags/test_syntax_color.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import os
 import shutil
+from html.parser import HTMLParser
 from tempfile import mkdtemp
 
 from django.template import Context, Template
 from django.test import TestCase
-from six.moves.html_parser import HTMLParser
 
 from django_extensions.templatetags.syntax_color import generate_pygments_css
 

--- a/tests/test_autoslug_fields.py
+++ b/tests/test_autoslug_fields.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-import django
 import pytest
-import six
+
 from django.db import migrations, models
 from django.db.migrations.writer import MigrationWriter
 from django.test import TestCase
@@ -169,12 +168,11 @@ class AutoSlugFieldTest(TestCase):
         self.assertEqual(m.slug, 'foo-2')
 
     def test_populate_from_does_not_allow_bytes(self):
-        if six.PY3:
-            with pytest.raises(TypeError):
-                AutoSlugField(populate_from=b'bytes')
+        with pytest.raises(TypeError):
+            AutoSlugField(populate_from=b'bytes')
 
-            with pytest.raises(TypeError):
-                AutoSlugField(populate_from=[b'bytes'])
+        with pytest.raises(TypeError):
+            AutoSlugField(populate_from=[b'bytes'])
 
     def test_populate_from_must_allow_string_or_list_str_or_tuple_str(self):
         AutoSlugField(populate_from='str')
@@ -241,7 +239,6 @@ class AutoSlugFieldTest(TestCase):
         m.save()
         self.assertEqual(m.slug, 'foo-2')
 
-    @pytest.mark.skipif(django.VERSION < (2, 2), reason="This test works only on Django greater than 2.2.0")
     def test_auto_create_slug_with_constraints(self):
         m = SluggedWithConstraintsTestModel(title='foo', category='self-introduction')
         m.save()
@@ -290,12 +287,9 @@ class MigrationTest(TestCase):
         })
         writer = MigrationWriter(migration)
         output = writer.as_string()
-        # It should NOT be unicode.
-        if django.VERSION < (1, 11):
-            self.assertIsInstance(output, six.binary_type, "Migration as_string returned unicode")
-        else:
-            # As of Django 1.11 MigrationWriter.as_string returns unicode not bytes
-            self.assertIsInstance(output, six.text_type, "Migration as_string returned bytes")
+
+        self.assertIsInstance(output, str, "Migration as_string returned bytes")
+
         # We don't test the output formatting - that's too fragile.
         # Just make sure it runs for now, and that things look alright.
         result = self.safe_exec(output)

--- a/tests/test_clean_pyc.py
+++ b/tests/test_clean_pyc.py
@@ -3,7 +3,7 @@ import fnmatch
 import os
 import shutil
 
-import six
+from io import StringIO
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -36,7 +36,7 @@ class CleanPycTests(TestCase):
         self.assertEqual(len(pyc_glob), 0)
 
     def test_takes_path(self):
-        out = six.StringIO()
+        out = StringIO()
         project_root = os.path.join('tests', 'testapp')
         call_command('compile_pyc', path=project_root)
         pyc_glob = self._find_pyc(project_root)
@@ -46,7 +46,7 @@ class CleanPycTests(TestCase):
         self.assertEqual(sorted(pyc_glob), sorted(output))
 
     def test_removes_pyo_files(self):
-        out = six.StringIO()
+        out = StringIO()
         project_root = os.path.join('tests', 'testapp')
         call_command('compile_pyc', path=project_root)
         pyc_glob = self._find_pyc(project_root)

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.test import SimpleTestCase
 from django_extensions.management import color
 from . import force_color_support

--- a/tests/test_compile_pyc.py
+++ b/tests/test_compile_pyc.py
@@ -2,7 +2,7 @@
 import fnmatch
 import os
 
-import six
+from io import StringIO
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -37,7 +37,7 @@ class CompilePycTests(TestCase):
             call_command('clean_pyc')
 
     def test_takes_path(self):
-        out = six.StringIO()
+        out = StringIO()
         with self.settings(BASE_DIR=""):
             call_command('clean_pyc', path=self.project_root)
         pyc_glob = self._find_pyc(self.project_root)

--- a/tests/test_dumpscript.py
+++ b/tests/test_dumpscript.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 
-import six
+from io import StringIO
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
@@ -13,8 +13,8 @@ from .testapp.models import Name, Note, Person, Club
 
 class DumpScriptTests(TestCase):
     def setUp(self):
-        sys.stdout = six.StringIO()
-        sys.stderr = six.StringIO()
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
 
     def test_runs(self):
         # lame test...does it run?
@@ -25,10 +25,10 @@ class DumpScriptTests(TestCase):
 
     def test_replaced_stdout(self):
         # check if stdout can be replaced
-        sys.stdout = six.StringIO()
+        sys.stdout = StringIO()
         n = Name(name='Mike')
         n.save()
-        tmp_out = six.StringIO()
+        tmp_out = StringIO()
         call_command('dumpscript', 'django_extensions', stdout=tmp_out)
         self.assertTrue('Mike' in tmp_out.getvalue())  # script should go to tmp_out
         self.assertEqual(0, len(sys.stdout.getvalue()))  # there should not be any output to sys.stdout
@@ -38,8 +38,8 @@ class DumpScriptTests(TestCase):
         # check if stderr can be replaced, without changing stdout
         n = Name(name='Fred')
         n.save()
-        tmp_err = six.StringIO()
-        sys.stderr = six.StringIO()
+        tmp_err = StringIO()
+        sys.stderr = StringIO()
         call_command('dumpscript', 'django_extensions', stderr=tmp_err)
         self.assertTrue('Fred' in sys.stdout.getvalue())  # script should still go to stdout
         self.assertTrue('Name' in tmp_err.getvalue())  # error output should go to tmp_err
@@ -61,7 +61,7 @@ class DumpScriptTests(TestCase):
         note2 = Note(note="This is the second note.")
         note2.save()
         p2.notes.add(note1, note2)
-        tmp_out = six.StringIO()
+        tmp_out = StringIO()
         call_command('dumpscript', 'django_extensions', stdout=tmp_out)
         ast_syntax_tree = ast.parse(tmp_out.getvalue())
         if hasattr(ast_syntax_tree, 'body'):

--- a/tests/test_find_template.py
+++ b/tests/test_find_template.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
 from django.test import TestCase
-from six import StringIO
+from io import StringIO
 
 from unittest.mock import patch
 

--- a/tests/test_json_field.py
+++ b/tests/test_json_field.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 from django.test import TestCase
 
 from .testapp.models import JSONFieldTestModel
@@ -99,12 +98,12 @@ class JsonFieldTest(TestCase):
         j_field = JSONField()
 
         self.assertEqual(
-            six.u(dumps([{'a': 'a'}])),
+            str(dumps([{'a': 'a'}])),
             j_field.get_prep_value(value=[{'a': 'a'}]),
         )
 
         self.assertEqual(
-            six.u(dumps([{'a': 'a'}])),
+            str(dumps([{'a': 'a'}])),
             j_field.get_prep_value(value='[{"a": "a"}]'),
         )
 
@@ -112,12 +111,12 @@ class JsonFieldTest(TestCase):
         j_field = JSONField()
 
         self.assertEqual(
-            six.u(dumps([{'a': 'a'}])),
+            str(dumps([{'a': 'a'}])),
             j_field.get_db_prep_save(value=[{'a': 'a'}], connection=None),
         )
 
         self.assertEqual(
-            six.u('[{"a": "a"}]'),
+            str('[{"a": "a"}]'),
             j_field.get_db_prep_save(value='[{"a": "a"}]', connection=None),
         )
 

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import mock
 import logging
 import importlib
-import pytest
-import sys
 
 from django.conf import settings
 from django.core.management import call_command, find_commands, load_command_class
 from django.test import TestCase
-from six import StringIO
+from io import StringIO
 
 from django_extensions.management.modelviz import use_model, generate_graph_data
 from django_extensions.management.commands.merge_model_instances import get_model_to_deduplicate, get_field_names, keep_first_or_last_instance
@@ -74,11 +71,11 @@ class DescribeFormTests(TestCase):
         call_command('describe_form', 'django_extensions.Secret', stdout=out)
         output = out.getvalue()
         self.assertIn("class SecretForm(forms.Form):", output)
-        six.assertRegex(self, output, r"name = forms.CharField\(.*max_length=255")
-        six.assertRegex(self, output, r"name = forms.CharField\(.*required=False")
-        six.assertRegex(self, output, r"name = forms.CharField\(.*label=u?'Name'")
-        six.assertRegex(self, output, r"text = forms.CharField\(.*required=False")
-        six.assertRegex(self, output, r"text = forms.CharField\(.*label=u?'Text'")
+        self.assertRegex(output, r"name = forms.CharField\(.*max_length=255")
+        self.assertRegex(output, r"name = forms.CharField\(.*required=False")
+        self.assertRegex(output, r"name = forms.CharField\(.*label=u?'Name'")
+        self.assertRegex(output, r"text = forms.CharField\(.*required=False")
+        self.assertRegex(output, r"text = forms.CharField\(.*label=u?'Text'")
 
 
 class CommandSignalTests(TestCase):
@@ -293,7 +290,6 @@ class ListModelInfoTests(TestCase):
         self.assertIn('__class__()', self.output)
         self.assertIn('validate_unique()', self.output)
 
-    @pytest.mark.skipif(sys.version_info < (3, 3), reason="inspect.Signature requires python3.3 or higher")
     def test_signature(self):
         out = StringIO()
         call_command('list_model_info', '--model', 'django_extensions.MultipleFieldsAndMethods', '--signature', stdout=out)

--- a/tests/test_parse_mysql_cnf.py
+++ b/tests/test_parse_mysql_cnf.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import os
 import shutil
 from tempfile import mkdtemp

--- a/tests/test_runscript.py
+++ b/tests/test_runscript.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import sys
 import importlib
 
+from io import StringIO
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
@@ -13,8 +13,8 @@ from django_extensions.management.commands.runscript import BadCustomDirectoryEx
 class RunScriptTests(TestCase):
 
     def setUp(self):
-        sys.stdout = six.StringIO()
-        sys.stderr = six.StringIO()
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
 
     def test_runs(self):
         # lame test...does it run?
@@ -55,14 +55,14 @@ class InvalidImportScriptsTests(RunScriptTests):
     def test_prints_import_error_on_script_with_invalid_imports_by_default(self):
         call_command('runscript', 'invalid_import_script')
         self.assertIn("Cannot import module 'tests.testapp.scripts.invalid_import_script'", sys.stdout.getvalue())
-        six.assertRegex(self, sys.stdout.getvalue(), 'No module named (\')?(invalidpackage)\1?')
+        self.assertRegex(sys.stdout.getvalue(), 'No module named (\')?(invalidpackage)\1?')
 
     def test_prints_import_error_on_script_with_invalid_imports_reliably(self):
         if hasattr(importlib, 'util') and hasattr(importlib.util, 'find_spec'):
             with self.settings(BASE_DIR=os.path.dirname(os.path.abspath(__file__))):
                 call_command('runscript', 'invalid_import_script')
                 self.assertIn("Cannot import module 'tests.testapp.scripts.invalid_import_script'", sys.stdout.getvalue())
-                six.assertRegex(self, sys.stdout.getvalue(), 'No module named (\')?(invalidpackage)\1?')
+                self.assertRegex(sys.stdout.getvalue(), 'No module named (\')?(invalidpackage)\1?')
 
 
 class InvalidScriptsTests(RunScriptTests):
@@ -167,8 +167,7 @@ class ChangingDirectoryTests(RunScriptTests):
 
     @override_settings(RUNSCRIPT_CHDIR='bad path')
     def test_custom_policy_django_settings_bad_path(self):
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             BadCustomDirectoryException,
             'bad path is not a directory! If --dir-policy is custom than you must set '
             'correct directory in --dir option or in settings.RUNSCRIPT_CHDIR'

--- a/tests/test_shortuuid_field.py
+++ b/tests/test_shortuuid_field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import six
+
 from django.test import TestCase
 
 from .testapp.models import (
@@ -10,21 +10,21 @@ from .testapp.models import (
 
 class ShortUUIDFieldTest(TestCase):
     def test_UUID_field_create(self):
-        j = ShortUUIDTestModel_field.objects.create(a=6, uuid_field=six.u('vytxeTZskVKR7C7WgdSP3d'))
-        self.assertEqual(j.uuid_field, six.u('vytxeTZskVKR7C7WgdSP3d'))
+        j = ShortUUIDTestModel_field.objects.create(a=6, uuid_field='vytxeTZskVKR7C7WgdSP3d')
+        self.assertEqual(j.uuid_field, 'vytxeTZskVKR7C7WgdSP3d')
 
     def test_UUID_field_pk_create(self):
-        j = ShortUUIDTestModel_pk.objects.create(uuid_field=six.u('vytxeTZskVKR7C7WgdSP3d'))
-        self.assertEqual(j.uuid_field, six.u('vytxeTZskVKR7C7WgdSP3d'))
-        self.assertEqual(j.pk, six.u('vytxeTZskVKR7C7WgdSP3d'))
+        j = ShortUUIDTestModel_pk.objects.create(uuid_field='vytxeTZskVKR7C7WgdSP3d')
+        self.assertEqual(j.uuid_field, 'vytxeTZskVKR7C7WgdSP3d')
+        self.assertEqual(j.pk, 'vytxeTZskVKR7C7WgdSP3d')
 
     def test_UUID_field_pk_agregate_create(self):
         j = ShortUUIDTestAgregateModel.objects.create(a=6)
         self.assertEqual(j.a, 6)
-        self.assertIsInstance(j.pk, six.string_types)
+        self.assertIsInstance(j.pk, str)
         self.assertTrue(len(j.pk) < 23)
 
     def test_UUID_field_manytomany_create(self):
-        j = ShortUUIDTestManyToManyModel.objects.create(uuid_field=six.u('vytxeTZskVKR7C7WgdSP3e'))
-        self.assertEqual(j.uuid_field, six.u('vytxeTZskVKR7C7WgdSP3e'))
-        self.assertEqual(j.pk, six.u('vytxeTZskVKR7C7WgdSP3e'))
+        j = ShortUUIDTestManyToManyModel.objects.create(uuid_field='vytxeTZskVKR7C7WgdSP3e')
+        self.assertEqual(j.uuid_field, 'vytxeTZskVKR7C7WgdSP3e')
+        self.assertEqual(j.pk, 'vytxeTZskVKR7C7WgdSP3e')

--- a/tests/test_sqldiff.py
+++ b/tests/test_sqldiff.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import six
+import mock
 import pytest
-from unittest import mock
+from io import StringIO
 
 from django.conf import settings
 from django.apps import apps
@@ -17,8 +17,8 @@ class SqlDiffTests(TestCase):
         self.parser = Command().create_parser("test", "sqldiff")
         self.args = ["-a"]
         self.options = self.parser.parse_args(args=self.args)
-        self.tmp_out = six.StringIO()
-        self.tmp_err = six.StringIO()
+        self.tmp_out = StringIO()
+        self.tmp_err = StringIO()
 
     def _include_proxy_models_testing(self, should_include_proxy_models):  # type: (bool) -> ()
         if should_include_proxy_models:
@@ -102,7 +102,7 @@ class SqlDiffTests(TestCase):
         self.assertEqual(postgresql_dict, [{'BAR': 2, 'foo': 1}])
 
     # def test_sql_diff_run(self):
-    #     tmp_out = six.StringIO()
+    #     tmp_out = StringIO()
     #     call_command("sqldiff", all_applications=True, migrate_for_tests=True, stdout=tmp_out)
     #     self.assertEqual('-- No differences', tmp_out.getvalue())
     #     tmp_out.close()

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import six
 from django.template import engines
 from django.test import TestCase
 
@@ -12,11 +11,11 @@ from unittest.mock import MagicMock
 class TemplateTagsTests(TestCase):
     def test_widont(self):
         self.assertEqual(widont('Test Value'), 'Test&nbsp;Value')
-        self.assertEqual(widont(six.u('Test Value')), six.u('Test&nbsp;Value'))
+        self.assertEqual(widont(str('Test Value')), str('Test&nbsp;Value'))
 
     def test_widont_html(self):
         self.assertEqual(widont_html('Test Value'), 'Test&nbsp;Value')
-        self.assertEqual(widont_html(six.u('Test Value')), six.u('Test&nbsp;Value'))
+        self.assertEqual(widont_html(str('Test Value')), str('Test&nbsp;Value'))
 
 
 class DebuggerTagsTests(TestCase):

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-import django
-
 from django.db import models
 from django.contrib.auth import get_user_model
+from django.db.models import UniqueConstraint
 from django.db.models.signals import pre_save
 
 from django_extensions.db.fields import AutoSlugField, ModificationDateTimeField, RandomCharField, ShortUUIDField
@@ -10,9 +9,6 @@ from django_extensions.db.fields.json import JSONField
 from django_extensions.db.models import ActivatorModel, TimeStampedModel
 
 from .fields import UniqField
-
-if django.VERSION >= (2, 2):
-    from django.db.models import UniqueConstraint
 
 
 class Secret(models.Model):
@@ -198,13 +194,12 @@ class SluggedWithConstraintsTestModel(models.Model):
 
     class Meta:
         app_label = 'django_extensions'
-        if django.VERSION >= (2, 2):
-            constraints = [
-                UniqueConstraint(
-                    fields=['slug', 'category'],
-                    name="unique_slug_and_category",
-                ),
-            ]
+        constraints = [
+            UniqueConstraint(
+                fields=['slug', 'category'],
+                name="unique_slug_and_category",
+            ),
+        ]
 
 
 class SluggedWithUniqueTogetherTestModel(models.Model):


### PR DESCRIPTION
Remove lot of artefacts from old python / django version compatibility:
- No need of `six` when PY3 only
- Remove `__future__` imports
- Remove specific cases for older version of Python / Django