### PR TITLE
[mock] Use unitest mock module now in std lib

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 force_color_support = mock.patch('django.core.management.color.supports_color', autospec=True, side_effect=lambda: True)

--- a/tests/db/fields/test_uniq_field_mixin.py
+++ b/tests/db/fields/test_uniq_field_mixin.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import six
 from django.db import models

--- a/tests/management/commands/test_create_command.py
+++ b/tests/management/commands/test_create_command.py
@@ -7,10 +7,8 @@ from django.core.management import call_command
 from django.test import TestCase
 from six import StringIO
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
+
 
 TEST_APP = 'testapp_with_appconfig'
 

--- a/tests/management/commands/test_create_jobs.py
+++ b/tests/management/commands/test_create_jobs.py
@@ -8,10 +8,7 @@ from django.test import TestCase
 from six import StringIO
 from tests import testapp_with_no_models_file
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 JOBS_DIR = os.path.join(testapp_with_no_models_file.__path__[0], 'jobs')

--- a/tests/management/commands/test_create_template_tags.py
+++ b/tests/management/commands/test_create_template_tags.py
@@ -8,10 +8,7 @@ from django.test import TestCase
 from six import StringIO
 from tests import testapp_with_no_models_file
 
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 TEMPLATETAGS_DIR = os.path.join(testapp_with_no_models_file.__path__[0], 'templatetags')

--- a/tests/management/commands/test_delete_squashed_migrations.py
+++ b/tests/management/commands/test_delete_squashed_migrations.py
@@ -4,6 +4,8 @@ import six
 from distutils.version import LooseVersion
 
 import pytest
+from unittest.mock import patch
+
 from django import get_version
 from django.core.management import CommandError, call_command
 from django.db import models
@@ -11,11 +13,6 @@ from django.test import TestCase, override_settings
 from tests import testapp_with_appconfig
 
 MIGRATIONS_DIR = os.path.join(testapp_with_appconfig.__path__[0], 'migrations')
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
 
 
 @override_settings(MIGRATION_MODULES={'testapp_with_appconfig': 'tests.testapp_with_appconfig.migrations'})

--- a/tests/management/commands/test_drop_test_database.py
+++ b/tests/management/commands/test_drop_test_database.py
@@ -5,10 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from six import StringIO
 
-try:
-    from unittest.mock import MagicMock, Mock, patch
-except ImportError:
-    from mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 
 class DropTestDatabaseExceptionsTests(TestCase):

--- a/tests/management/commands/test_generate_secret_key.py
+++ b/tests/management/commands/test_generate_secret_key.py
@@ -7,10 +7,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from six import StringIO
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class GenerateSecretKeyTests(TestCase):

--- a/tests/management/commands/test_mail_debug.py
+++ b/tests/management/commands/test_mail_debug.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 def test_initialize_mail_server():

--- a/tests/management/commands/test_print_user_for_session.py
+++ b/tests/management/commands/test_print_user_for_session.py
@@ -8,10 +8,7 @@ from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class PrintUserForSessionExceptionsTests(TestCase):

--- a/tests/management/commands/test_reset_db.py
+++ b/tests/management/commands/test_reset_db.py
@@ -7,10 +7,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from six import StringIO
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 class ResetDbExceptionsTests(TestCase):

--- a/tests/management/commands/test_reset_schema.py
+++ b/tests/management/commands/test_reset_schema.py
@@ -5,10 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from six import StringIO
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 class ResetSchemaExceptionsTests(TestCase):

--- a/tests/management/commands/test_runjob.py
+++ b/tests/management/commands/test_runjob.py
@@ -6,10 +6,7 @@ import six
 from django.core.management import call_command
 from django.test import TestCase
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class RunJobTests(TestCase):

--- a/tests/management/commands/test_runserver_plus.py
+++ b/tests/management/commands/test_runserver_plus.py
@@ -2,10 +2,7 @@
 import pytest
 from django.core.management import call_command
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 @pytest.mark.django_db

--- a/tests/management/commands/test_set_default_site.py
+++ b/tests/management/commands/test_set_default_site.py
@@ -8,10 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from six import StringIO
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class SetDefaultSiteTests(TestCase):

--- a/tests/management/commands/test_set_fake_passwords.py
+++ b/tests/management/commands/test_set_fake_passwords.py
@@ -8,10 +8,7 @@ from six import StringIO
 
 from django_extensions.management.commands.set_fake_passwords import DEFAULT_FAKE_PASSWORD
 
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 @pytest.fixture(scope='module')

--- a/tests/management/commands/test_show_urls.py
+++ b/tests/management/commands/test_show_urls.py
@@ -8,10 +8,7 @@ from django.test.utils import override_settings
 from django.views.generic.base import View
 from six import StringIO
 
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 def function_based_view(request):

--- a/tests/management/commands/test_sqlcreate.py
+++ b/tests/management/commands/test_sqlcreate.py
@@ -6,10 +6,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from six import StringIO
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 MYSQL_DATABASE_SETTINGS = {

--- a/tests/management/commands/test_sqldsn.py
+++ b/tests/management/commands/test_sqldsn.py
@@ -5,10 +5,8 @@ from django.test.utils import override_settings
 from six import StringIO
 
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
+
 
 MYSQL_DATABASE_SETTINGS = {
     'ENGINE': 'django.db.backends.mysql',

--- a/tests/management/commands/test_sync_s3.py
+++ b/tests/management/commands/test_sync_s3.py
@@ -11,10 +11,7 @@ from six import StringIO
 
 from django_extensions.management.commands.sync_s3 import Command
 
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 class SyncS3TestsMixin():

--- a/tests/management/commands/test_syncdata.py
+++ b/tests/management/commands/test_syncdata.py
@@ -10,10 +10,8 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from six import StringIO
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
+
 
 TEST_FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
 

--- a/tests/management/commands/test_unreferenced_files.py
+++ b/tests/management/commands/test_unreferenced_files.py
@@ -11,10 +11,7 @@ from six import StringIO
 
 from ...testapp.models import Photo
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class UnreferencedFilesExceptionsTests(TestCase):

--- a/tests/management/test_email_notifications.py
+++ b/tests/management/test_email_notifications.py
@@ -5,10 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from six import StringIO
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class EmailNotificationCommandTests(TestCase):

--- a/tests/test_admin_filter.py
+++ b/tests/test_admin_filter.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+from unittest.mock import Mock
 
 from django.test import RequestFactory, TestCase
 from factory import Iterator

--- a/tests/test_find_template.py
+++ b/tests/test_find_template.py
@@ -3,10 +3,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from six import StringIO
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class FindTemplateTests(TestCase):

--- a/tests/test_logging_filters.py
+++ b/tests/test_logging_filters.py
@@ -6,10 +6,8 @@ from django.test.utils import override_settings
 
 from django_extensions.logging.filters import RateLimiterFilter
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 
 TEST_SUBJECT = 'test_subect'
 

--- a/tests/test_randomchar_field.py
+++ b/tests/test_randomchar_field.py
@@ -9,10 +9,7 @@ from .testapp.models import RandomCharTestModelUppercase, RandomCharTestModelAlp
 from .testapp.models import RandomCharTestModelPunctuation, RandomCharTestModelLowercaseAlphaDigits, RandomCharTestModelUppercaseAlphaDigits
 from .testapp.models import RandomCharTestModelUniqueTogether
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 class RandomCharFieldTest(TestCase):

--- a/tests/test_runserver.py
+++ b/tests/test_runserver.py
@@ -5,10 +5,7 @@ from os.path import join
 
 from django_extensions.management.commands.runserver_plus import Command as RunServerCommand
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 location = join('some', 'strange', 'path')

--- a/tests/test_sqldiff.py
+++ b/tests/test_sqldiff.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-import mock
 import six
 import pytest
+from unittest import mock
+
 from django.conf import settings
 from django.apps import apps
 from django.test import TestCase

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -5,10 +5,7 @@ from django.test import TestCase
 
 from django_extensions.templatetags.widont import widont, widont_html
 
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 # TODO: these tests are far from having decent test coverage

--- a/tests/testapp/jobs/daily/test_daily_job.py
+++ b/tests/testapp/jobs/daily/test_daily_job.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from django_extensions.management.jobs import DailyJob
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 DAILY_JOB_MOCK = mock.MagicMock()

--- a/tests/testapp/jobs/hourly/test_hourly_job.py
+++ b/tests/testapp/jobs/hourly/test_hourly_job.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from django_extensions.management.jobs import HourlyJob
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 HOURLY_JOB_MOCK = mock.MagicMock()

--- a/tests/testapp/jobs/monthly/test_monthly_job.py
+++ b/tests/testapp/jobs/monthly/test_monthly_job.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from django_extensions.management.jobs import MonthlyJob
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 MONTHLY_JOB_MOCK = mock.MagicMock()

--- a/tests/testapp/jobs/weekly/test_weekly_job.py
+++ b/tests/testapp/jobs/weekly/test_weekly_job.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from django_extensions.management.jobs import WeeklyJob
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 WEEKLY_JOB_MOCK = mock.MagicMock()

--- a/tests/testapp/jobs/yearly/test_yearly_job.py
+++ b/tests/testapp/jobs/yearly/test_yearly_job.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from django_extensions.management.jobs import YearlyJob
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 YEARLY_JOB_MOCK = mock.MagicMock()


### PR DESCRIPTION
With current compatibility with Python >= 3.5, no need to use mock external module, it's integrated in the python standard library.