### PR TITLE
[feat] Database Option

### DIFF
--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -10,11 +10,11 @@ import json
 
 from django.conf import settings as default_settings
 from django.core.management.base import BaseCommand, CommandError
-
-from django_extensions.management.utils import signalcommand
 from django.views.debug import SafeExceptionReporterFilter
 
-DEFAULT_FORMAT = 'simple'
+from django_extensions.management.utils import signalcommand
+
+DEFAULT_FORMAT = "simple"
 DEFAULT_INDENT = 4
 DEFAULT_SECRETS = False
 
@@ -25,29 +25,27 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
-            'setting',
-            nargs='*',
-            help='Specifies setting to be printed.'
+            "setting", nargs="*", help="Specifies setting to be printed."
         )
         parser.add_argument(
-            '--format',
+            "--format",
             default=DEFAULT_FORMAT,
-            dest='format',
-            help='Specifies output format.'
+            dest="format",
+            help="Specifies output format.",
         )
         parser.add_argument(
-            '--indent',
+            "--indent",
             default=DEFAULT_INDENT,
-            dest='indent',
+            dest="indent",
             type=int,
-            help='Specifies indent level for JSON and YAML'
+            help="Specifies indent level for JSON and YAML",
         )
         parser.add_argument(
-            '--show-secrets',
+            "--show-secrets",
             default=DEFAULT_SECRETS,
-            dest='show secrets',
+            dest="show secrets",
             type=bool,
-            help='Specifies if should be reveald the value of secrets'
+            help="Specifies if should be reveald the value of secrets",
         )
 
     @signalcommand
@@ -59,31 +57,33 @@ class Command(BaseCommand):
 
         if show_secrets:
             for attr in dir(default_settings):
-                if self.include_attr(attr, options['setting']):
+                if self.include_attr(attr, options["setting"]):
                     value = getattr(default_settings, attr)
                     a_dict[attr] = value
         else:
             settings = SafeExceptionReporterFilter().get_safe_settings()
             for key in settings.keys():
-                if key in options['setting'] or not options['setting']:
+                if key in options["setting"] or not options["setting"]:
                     a_dict[key] = settings.get(key)
 
         for setting in args:
             if setting not in a_dict:
-                raise CommandError('%s not found in settings.' % setting)
+                raise CommandError("%s not found in settings." % setting)
 
-        if output_format == 'json':
+        if output_format == "json":
             print(json.dumps(a_dict, indent=indent))
-        elif output_format == 'yaml':
+        elif output_format == "yaml":
             import yaml  # requires PyYAML
+
             print(yaml.dump(a_dict, indent=indent))
-        elif output_format == 'pprint':
+        elif output_format == "pprint":
             from pprint import pprint
+
             pprint(a_dict)
-        elif output_format == 'text':
+        elif output_format == "text":
             for key, value in a_dict.items():
                 print("%s = %s" % (key, value))
-        elif output_format == 'value':
+        elif output_format == "value":
             for value in a_dict.values():
                 print(value)
         else:
@@ -92,15 +92,15 @@ class Command(BaseCommand):
     @staticmethod
     def get_defaults(options):
         a_options = [
-            options.get('show secrets', DEFAULT_SECRETS),
-            options.get('format', DEFAULT_FORMAT),
-            options.get('indent', DEFAULT_INDENT)
+            options.get("show secrets", DEFAULT_SECRETS),
+            options.get("format", DEFAULT_FORMAT),
+            options.get("indent", DEFAULT_INDENT),
         ]
         return a_options
 
     @staticmethod
     def include_attr(attr, settings):
-        if attr.startswith('__'):
+        if attr.startswith("__"):
             return False
         elif settings == []:
             return True
@@ -110,4 +110,4 @@ class Command(BaseCommand):
     @staticmethod
     def print_simple(a_dict):
         for key, value in a_dict.items():
-            print('%-40s = %r' % (key, value))
+            print("%-40s = %r" % (key, value))

--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -8,9 +8,11 @@ Django command similar to 'diffsettings' but shows all active Django settings.
 
 import json
 
+from django.conf import settings as default_settings
 from django.core.management.base import BaseCommand, CommandError
 
 from django_extensions.management.utils import signalcommand
+from django.views.debug import SafeExceptionReporterFilter
 
 DEFAULT_FORMAT = 'simple'
 DEFAULT_INDENT = 4
@@ -55,6 +57,16 @@ class Command(BaseCommand):
 
         a_dict = {}
 
+        if show_secrets:
+            for attr in dir(default_settings):
+                if self.include_attr(attr, options['setting']):
+                    value = getattr(default_settings, attr)
+                    a_dict[attr] = value
+        else:
+            settings = SafeExceptionReporterFilter().get_safe_settings()
+            for key in settings.keys():
+                if key in options['setting'] or not options['setting']:
+                    a_dict[key] = settings.get(key)
 
         for setting in args:
             if setting not in a_dict:

--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             default=DEFAULT_SECRETS,
             dest="show secrets",
             type=bool,
-            help="Specifies if should be reveald the value of secrets",
+            help="Specifies if should be revealed the value of secrets",
         )
 
     @signalcommand

--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
                     value = getattr(default_settings, attr)
                     a_dict[attr] = value
         else:
-            settings = SafeExceptionReporterFilter().get_safe_settings()
+            settings = self.safe_settings()
             for key in settings.keys():
                 if key in options["setting"] or not options["setting"]:
                     a_dict[key] = settings.get(key)
@@ -111,3 +111,13 @@ class Command(BaseCommand):
     def print_simple(a_dict):
         for key, value in a_dict.items():
             print("%-40s = %r" % (key, value))
+
+    @staticmethod
+    def safe_settings():
+        try:
+            return SafeExceptionReporterFilter().get_safe_settings()
+        except AttributeError:
+            # In django < 3.0 does not have this class
+            # We have to make a different import
+            from django.views.debug import get_safe_settings
+            return get_safe_settings()

--- a/tests/management/commands/test_print_settings.py
+++ b/tests/management/commands/test_print_settings.py
@@ -5,65 +5,60 @@ from django.core.management import call_command
 
 
 def test_without_args(capsys):
-    call_command('print_settings')
+    call_command("print_settings")
 
     out, err = capsys.readouterr()
-    assert 'DEBUG' in out
-    assert 'INSTALLED_APPS' in out
+    assert "DEBUG" in out
+    assert "INSTALLED_APPS" in out
 
 
 def test_with_setting_args(capsys):
-    call_command('print_settings', 'DEBUG')
+    call_command("print_settings", "DEBUG")
 
     out, err = capsys.readouterr()
-    assert 'DEBUG' in out
-    assert 'INSTALLED_APPS' not in out
+    assert "DEBUG" in out
+    assert "INSTALLED_APPS" not in out
 
 
 def test_with_multiple_setting_args(capsys):
     call_command(
-        'print_settings',
-        'SECRET_KEY',
-        'DATABASES',
-        'INSTALLED_APPS',
-        '--show-secrets=True'
+        "print_settings",
+        "SECRET_KEY",
+        "DATABASES",
+        "INSTALLED_APPS",
+        "--show-secrets=True",
     )
 
     out, err = capsys.readouterr()
-    assert 'DEBUG' not in out
-    assert 'SECRET_KEY' in out
-    assert 'DATABASES' in out
-    assert 'INSTALLED_APPS' in out
+    assert "DEBUG" not in out
+    assert "SECRET_KEY" in out
+    assert "DATABASES" in out
+    assert "INSTALLED_APPS" in out
+
 
 def test_with_not_show_secrets(capsys):
     call_command(
-        'print_settings',
-        'SECRET_KEY',
+        "print_settings", "SECRET_KEY",
     )
 
     out, err = capsys.readouterr()
 
-    assert '*******' in out
+    assert "*******" in out
 
 
 def test_format(capsys):
     call_command(
-        'print_settings',
-        'DEBUG',
-        '--format=text',
+        "print_settings", "DEBUG", "--format=text",
     )
 
     out, err = capsys.readouterr()
-    expected = 'DEBUG = False\n'
+    expected = "DEBUG = False\n"
     assert expected == out
 
 
 def test_format_json_without_indent(capsys):
     call_command(
-        'print_settings',
-        'DEBUG',
-        '--format=json',
-        '--indent=0',
+        "print_settings", "DEBUG", "--format=json", "--indent=0",
     )
 
     expected = '{\n"DEBUG": false\n}\n'

--- a/tests/management/commands/test_print_settings.py
+++ b/tests/management/commands/test_print_settings.py
@@ -26,6 +26,7 @@ def test_with_multiple_setting_args(capsys):
         'SECRET_KEY',
         'DATABASES',
         'INSTALLED_APPS',
+        '--show-secrets=True'
     )
 
     out, err = capsys.readouterr()
@@ -33,6 +34,16 @@ def test_with_multiple_setting_args(capsys):
     assert 'SECRET_KEY' in out
     assert 'DATABASES' in out
     assert 'INSTALLED_APPS' in out
+
+def test_with_not_show_secrets(capsys):
+    call_command(
+        'print_settings',
+        'SECRET_KEY',
+    )
+
+    out, err = capsys.readouterr()
+
+    assert '*******' in out
 
 
 def test_format(capsys):

--- a/tests/management/commands/test_print_settings.py
+++ b/tests/management/commands/test_print_settings.py
@@ -10,6 +10,7 @@ def test_without_args(capsys):
     out, err = capsys.readouterr()
     assert "DEBUG" in out
     assert "INSTALLED_APPS" in out
+    assert "DATABASE_ENGINE" not in out
 
 
 def test_with_setting_args(capsys):
@@ -64,3 +65,12 @@ def test_format_json_without_indent(capsys):
     expected = '{\n"DEBUG": false\n}\n'
     out, err = capsys.readouterr()
     assert expected == out
+
+
+def test_show_database_option(capsys):
+    call_command(
+        "print_settings", "--database",
+    )
+
+    out, err = capsys.readouterr()
+    assert "DATABASE_ENGINE" in out


### PR DESCRIPTION
Feature requested in the #1467. I added a new option in `print_settings.py` to show the current database. But we need to approve and merge the #1553 PR, because I made some refactoring in this file through this PR