### PR TITLE
Add --database option on delete squashed migrations

### DIFF
--- a/django_extensions/management/commands/delete_squashed_migrations.py
+++ b/django_extensions/management/commands/delete_squashed_migrations.py
@@ -37,6 +37,10 @@ class Command(BaseCommand):
         parser.add_argument(
             '--dry-run', action='store_true', default=False,
             help='Do not actually delete or change any files')
+        parser.add_argument(
+            '--database', default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to run command for. Defaults to the "%s" database.' % DEFAULT_DB_ALIAS,
+        )
 
     def handle(self, **options):
         self.verbosity = options['verbosity']
@@ -44,9 +48,10 @@ class Command(BaseCommand):
         self.dry_run = options['dry_run']
         app_label = options['app_label']
         squashed_migration_name = options['squashed_migration_name']
+        database = options['database']
 
         # Load the current graph state, check the app and migration they asked for exists
-        loader = MigrationLoader(connections[DEFAULT_DB_ALIAS])
+        loader = MigrationLoader(connections[database])
         if app_label not in loader.migrated_apps:
             raise CommandError(
                 "App '%s' does not have migrations (so delete_squashed_migrations on "

--- a/tests/management/commands/test_delete_squashed_migrations.py
+++ b/tests/management/commands/test_delete_squashed_migrations.py
@@ -100,6 +100,10 @@ class DeleteSquashedMigrationsExceptionsTests(BaseDeleteSquashedMigrationsTestCa
             call_command('delete_squashed_migrations', 'testapp_with_appconfig',
                          '0002')
 
+    def test_should_raise_CommandError_when_database_does_not_exist(self):
+        with self.assertRaisesRegex(CommandError, 'Unknown database non-existing_database'):
+            call_command('delete_squashed_migrations', '--database=non-existing_database')
+
 
 @pytest.mark.xfail
 @pytest.mark.skipif(


### PR DESCRIPTION
Add this option required on #1467. 