### PR TITLE
Make runserver_plus command survive syntax and configuration errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     tests_require=[
         'Django',
         'Werkzeug',
-        'factory-boy',
+        'factory-boy<3.0.0',
         'mock',
         'pytest',
         'pytest-cov',


### PR DESCRIPTION
This will make it behave like the standard runserver command which doesn't
exit when we have a syntax or configuration error but simply wait for the
error to be fixed before the site is accessible again.

This should solve #1081

The solution turned out to be quite simple. Does it seem acceptable to you?