### PR TITLE
Drop install/extras_require for Python < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,10 +122,6 @@ extras_require = {}
 
 if int(setuptools.__version__.split(".", 1)[0]) < 18:
     assert "bdist_wheel" not in sys.argv, "setuptools 18 or later is required for wheels."
-elif int(setuptools.__version__.split(".", 1)[0]) >= 36:
-    install_requires.append('typing;python_version<"3.5"')
-else:
-    extras_require[":python_version<'3.5'"] = ["typing"]
 
 long_description = """django-extensions bundles several useful
 additions for Django projects. See the project page for more information:


### PR DESCRIPTION
Only Python 3.5+ is supported