### PR TITLE
Improve sqlcreate to supports PostgreSQL unix domain socket

### DIFF
--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -70,11 +70,20 @@ The envisioned use case is something like this:
         elif engine in ('postgresql', 'postgresql_psycopg2', 'postgis'):
             if options['drop']:
                 print("DROP DATABASE IF EXISTS %s;" % (dbname,))
-                print("DROP USER IF EXISTS %s;" % (dbuser,))
+                if dbuser:
+                    print("DROP USER IF EXISTS %s;" % (dbuser,))
 
-            print("CREATE USER %s WITH ENCRYPTED PASSWORD '%s' CREATEDB;" % (dbuser, dbpass))
-            print("CREATE DATABASE %s WITH ENCODING 'UTF-8' OWNER \"%s\";" % (dbname, dbuser))
-            print("GRANT ALL PRIVILEGES ON DATABASE %s TO %s;" % (dbname, dbuser))
+            if dbuser and dbpass:
+                print("CREATE USER %s WITH ENCRYPTED PASSWORD '%s' CREATEDB;" % (dbuser, dbpass))
+                print("CREATE DATABASE %s WITH ENCODING 'UTF-8' OWNER \"%s\";" % (dbname, dbuser))
+                print("GRANT ALL PRIVILEGES ON DATABASE %s TO %s;" % (dbname, dbuser))
+            else:
+                print(
+                    "-- Assuming that unix domain socket connection mode is being used because\n"
+                    "-- USER or PASSWORD are blank in Django DATABASES configuration."
+                )
+                print("CREATE DATABASE %s WITH ENCODING 'UTF-8';" % (dbname, ))
+
         elif engine == 'sqlite3':
             sys.stderr.write("-- manage.py migrate will automatically create a sqlite3 database file.\n")
         else:

--- a/docs/sqlcreate.rst
+++ b/docs/sqlcreate.rst
@@ -29,6 +29,11 @@ PostgreSQL
 ~~~~~~~~~~
   $ ./manage.py sqlcreate [--database=<databasename>] | psql -U <db_administrator> -W
 
+.. note::
+    If `USER` or `PASSWORD` are empty string or None, the `sqlcreate` assumes that unix domain
+    socket connection mode is being used, and because of that the SQL clauses `CREATE USER` and
+    privilege grants to the database and database user are not generated.
+
 
 MySQL
 ~~~~~

--- a/tests/management/commands/test_sqlcreate.py
+++ b/tests/management/commands/test_sqlcreate.py
@@ -31,6 +31,15 @@ POSTGRESQL_DATABASE_SETTINGS = {
     'PORT': '5432',
 }
 
+POSTGRESQL_DATABASE_SETTINGS_SOCKET_MODE = {
+    'ENGINE': 'django.db.backends.postgresql',
+    'NAME': 'database',
+    'USER': '',
+    'PASSWORD': '',
+    'HOST': '',
+    'PORT': '',
+}
+
 
 class SqlcreateExceptionsTests(TestCase):
     """Test for sqlcreate exception."""
@@ -67,6 +76,18 @@ GRANT ALL PRIVILEGES ON dbatabase.* to 'foo'@'tumbleweed' identified by 'bar';
         expected_statement = """CREATE USER foo WITH ENCRYPTED PASSWORD 'bar' CREATEDB;
 CREATE DATABASE database WITH ENCODING 'UTF-8' OWNER "foo";
 GRANT ALL PRIVILEGES ON DATABASE database TO foo;
+"""
+
+        call_command('sqlcreate')
+
+        self.assertEqual(expected_statement, m_stdout.getvalue())
+
+    @override_settings(DATABASES={'default': POSTGRESQL_DATABASE_SETTINGS_SOCKET_MODE})
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_should_print_SQL_create_database_statement_only_for_postgresql_when_unix_domain_socket_mode_is_used(self, m_stdout):
+        expected_statement = """-- Assuming that unix domain socket connection mode is being used because
+-- USER or PASSWORD are blank in Django DATABASES configuration.
+CREATE DATABASE database WITH ENCODING 'UTF-8';
 """
 
         call_command('sqlcreate')


### PR DESCRIPTION
### The problem:

Currently the `sqlcreate` generate invalid SQL statements, like:

```sql
CREATE USER  WITH ENCRYPTED PASSWORD '' CREATEDB;
CREATE DATABASE mydatabase WITH ENCODING 'UTF-8' OWNER "";
GRANT ALL PRIVILEGES ON DATABASE mydatabase TO ;
```

if a Django database is configured to use Unix domain socket, like:


```python
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.postgresql',
        'NAME': 'mydatabase',
        'USER': '',
        'PASSWORD': '',
        'HOST': '',
        'PORT': '',
    }
}
```
then errors can be obtained when using `python manage.py sqlcreate |  sudo -u postgres psql -U postgres` like:

```sql
ERROR:  syntax error at or near "WITH"
LINE 1: CREATE USER  WITH ENCRYPTED PASSWORD '' CREATEDB;
                     ^
ERROR:  zero-length delimited identifier at or near """"
LINE 1: CREATE DATABASE mydatabase WITH ENCODING 'UTF-8' OWNER "";
                                                             ^
ERROR:  syntax error at or near ";"
LINE 1: GRANT ALL PRIVILEGES ON DATABASE mydatabase TO ;
```

### Solution

The solution I propose with this pull-request, is to change the logic so that, if `USER` or `PASSWORD` is not informed on django database configuration, then only SQL `CREATE DATABASE` will be generated, like:

`python manage.py sqlcreate`
```sql
-- Assuming that unix domain socket connection mode is being used because
-- USER or PASSWORD are blank in Django DATABASES configuration.
CREATE DATABASE mydatabase WITH ENCODING 'UTF-8';
```


--
Pull-request sponsored by 
[![image](https://cdn.shopify.com/s/files/1/0304/6901/files/Feldroy-450x200_180x.jpg?v=1584585866)]( https://www.feldroy.com/)