### PR TITLE
Add django-zero-downtime-migrations Postgres DB engine

### DIFF
--- a/django_extensions/settings.py
+++ b/django_extensions/settings.py
@@ -21,6 +21,8 @@ DEFAULT_POSTGRESQL_ENGINES = (
     'django.db.backends.postgis',
     'django.contrib.gis.db.backends.postgis',
     'psqlextra.backend',
+    'django_zero_downtime_migrations.backends.postgres',
+    'django_zero_downtime_migrations.backends.postgis',
 )
 
 SQLITE_ENGINES = getattr(settings, 'DJANGO_EXTENSIONS_RESET_DB_SQLITE_ENGINES', DEFAULT_SQLITE_ENGINES)


### PR DESCRIPTION
From the repo: 
https://github.com/tbicr/django-pg-zero-downtime-migrations

I got an error when running the `reset_db` command while using this engine, which is why I'd like to add it to the list :)