### PR TITLE
Add more documentation for `reset_db`-command

### DIFF
--- a/django_extensions/settings.py
+++ b/django_extensions/settings.py
@@ -21,6 +21,8 @@ DEFAULT_POSTGRESQL_ENGINES = (
     'django.db.backends.postgis',
     'django.contrib.gis.db.backends.postgis',
     'psqlextra.backend',
+    'django_zero_downtime_migrations.backends.postgres',
+    'django_zero_downtime_migrations.backends.postgis',
 )
 
 SQLITE_ENGINES = getattr(settings, 'DJANGO_EXTENSIONS_RESET_DB_SQLITE_ENGINES', DEFAULT_SQLITE_ENGINES)

--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -18,6 +18,7 @@ Command Extensions
    list_signals
    merge_model_instances
    print_settings
+   reset_db
    runprofileserver
    runserver_plus
    sync_s3
@@ -106,7 +107,7 @@ Command Extensions
   test via some automated system (BuildBot, Jenkins, etc) and making sure that
   the test database is always dropped at the end.
 
-* *reset_db* - Resets a database (currently sqlite3, mysql, postgres). Uses "DROP DATABASE" and "CREATE DATABASE".
+* :doc:`reset_db` - Resets a database (currently sqlite3, mysql, postgres). Uses "DROP DATABASE" and "CREATE DATABASE".
 
 * *runjob* - Run a single maintenance job.  Part of the jobs system.
 

--- a/docs/reset_db.rst
+++ b/docs/reset_db.rst
@@ -1,0 +1,69 @@
+reset_db
+========
+
+:synopsis: Fully resets your database by running DROP DATABASE and CREATE DATABASE
+
+Django command that resets your Django database, removing all data from all
+tables. This allows you to run all migrations again.
+
+By default the command will prompt you to confirm that all data will be
+deleted. This can be turned off with the ``--no-input``-argument.
+
+Supported engines
+-----------------
+The command detects whether you're using a SQLite, MySQL, or Postgres database
+by looking up your Django database engine in the following lists.
+
+::
+
+  DEFAULT_SQLITE_ENGINES = (
+      'django.db.backends.sqlite3',
+      'django.db.backends.spatialite',
+  )
+  DEFAULT_MYSQL_ENGINES = (
+      'django.db.backends.mysql',
+      'django.contrib.gis.db.backends.mysql',
+      'mysql.connector.django',
+  )
+  DEFAULT_POSTGRESQL_ENGINES = (
+      'django.db.backends.postgresql',
+      'django.db.backends.postgresql_psycopg2',
+      'django.db.backends.postgis',
+      'django.contrib.gis.db.backends.postgis',
+      'psqlextra.backend',
+      'django_zero_downtime_migrations.backends.postgres',
+      'django_zero_downtime_migrations.backends.postgis',
+  )
+
+If the engine you're using is not listed above, check the optional settings
+section below.
+
+
+Example Usage
+-------------
+
+::
+
+  # Reset the DB so that it contains no data and migrations can be run again
+  $ ./manage.py reset_db mybucket
+
+::
+
+  # Don't ask for a confirmation before doing the reset
+  $ ./manage.py reset_db --no-input
+
+::
+
+  # Use a different user and password than the one from settings.py
+  $ ./manage.py reset_db --user db_root --password H4rd2Guess
+
+Optional settings
+-----------------
+
+It is possible to use a Django DB engine not in the lists above -- to do that add
+the approriate setting as shown below to your Django settings file::
+
+  # settings.py
+  DJANGO_EXTENSIONS_RESET_DB_SQLITE_ENGINES = ['your_custom_sqlite_engine']
+  DJANGO_EXTENSIONS_RESET_DB_MYSQL_ENGINES = ['your_custom_mysql_engine']
+  DJANGO_EXTENSIONS_RESET_DB_POSTGRESQL_ENGINES = ['your_custom_postgres_engine']


### PR DESCRIPTION
Adds full page to document the `reset_db`-command. It does not cover most options, but that follows the pattern from other pages.

For me, the big thing is documenting the `DJANGO_EXTENSIONS_RESET_DB_*_ENGINES`-settings which is added to this page.