### PR TITLE
DOC: Make notion of deprecated passwd in docs.

### DIFF
--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -89,7 +89,7 @@ Command Extensions
 
 * *notes* - Show all annotations like TODO, FIXME, BUG, HACK, WARNING, NOTE or XXX in your py and HTML files.
 
-* *passwd* - Makes it easy to reset a user's password.
+* *passwd* - DEPRECATED: Use Django's ``changepassword``.
 
 * *pipchecker* - Scan pip requirement file(s)s for out-of-date packages. Similar to
   ``pip list -o`` which used installed packages (in virtualenv) instead of requirements file(s).


### PR DESCRIPTION
`passwd` is deprecated, but it is not specified as such in the docs.

We can also just remove the entry.

We can also add a link to official documentation of Django `changepassword`.