### PR TITLE
Remove deprecated Python version (3.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ jobs:
       env: TOXENV=mypy
     - python: 3.8
       env: TOXENV=compile-catalog
-    # Django 2.2: Python 3.5, 3.6, 3.7 or 3.8 / PyPy 3.x
-    - python: 3.5
-      env: TOXENV=py35-dj22
+    # Django 2.2: 3.6, 3.7 or 3.8 / PyPy 3.x
     - python: 3.6
       env: TOXENV=py36-dj22
     - python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     packages=packages,
     cmdclass=cmdclasses,
     package_data=package_data,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[],
     extras_require={},
     classifiers=[
@@ -122,7 +122,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,10 @@ envlist =
     safety
     mypy
     {py37,py38}-flake8
-    {py35,py36,py37,pypy}-dj22
+    {py36,py37,pypy}-dj22
     {py36,py37,py38}-dj30
     {py36,py37,py38}-dj31
-    {py35,py36,py37,pypy}-djmaster
+    {py36,py37,pypy}-djmaster
     py38-dj31-postgres
     py38-dj31-mysql
     py38-djmaster-postgres


### PR DESCRIPTION
Security fixes for Python 3.5 is ended at 2020-09-30