### PR TITLE
Remove redundant markers

### DIFF
--- a/tests/management/commands/test_delete_squashed_migrations.py
+++ b/tests/management/commands/test_delete_squashed_migrations.py
@@ -37,10 +37,6 @@ class BaseDeleteSquashedMigrationsTestCase(TestCase):
 
 
 @pytest.mark.xfail
-@pytest.mark.skipif(
-    LooseVersion(get_version()) <= LooseVersion('2.0.0'),
-    reason="This test works only on Django greater than 2.0.0",
-)
 class DeleteSquashedMigrationsExceptionsTests(BaseDeleteSquashedMigrationsTestCase):
     """Tests for delete_squashed_migrations command exceptions."""
 
@@ -106,10 +102,6 @@ class DeleteSquashedMigrationsExceptionsTests(BaseDeleteSquashedMigrationsTestCa
 
 
 @pytest.mark.xfail
-@pytest.mark.skipif(
-    LooseVersion(get_version()) <= LooseVersion('2.0.0'),
-    reason="This test works only on Django greater than 2.0.0",
-)
 class DeleteSquashedMigrationsTests(BaseDeleteSquashedMigrationsTestCase):
     """Tests for delete_squashed_migrations command."""
 

--- a/tests/management/commands/test_delete_squashed_migrations.py
+++ b/tests/management/commands/test_delete_squashed_migrations.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-from distutils.version import LooseVersion
 
 import pytest
 from unittest.mock import patch
 
-from django import get_version
 from django.core.management import CommandError, call_command
 from django.db import models
 from django.test import TestCase, override_settings

--- a/tests/management/commands/test_generate_secret_key.py
+++ b/tests/management/commands/test_generate_secret_key.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-from distutils.version import LooseVersion
 from io import StringIO
 
-import pytest
-from django import get_version
 from django.core.management import call_command
 from django.test import TestCase
 

--- a/tests/management/commands/test_generate_secret_key.py
+++ b/tests/management/commands/test_generate_secret_key.py
@@ -13,10 +13,6 @@ from unittest.mock import patch
 class GenerateSecretKeyTests(TestCase):
     """Tests for generate_secret_key command."""
 
-    @pytest.mark.skipif(
-        LooseVersion(get_version()) <= LooseVersion('1.10.0'),
-        reason="This test works only on Django greater than 1.10.x",
-    )
     @patch('django_extensions.management.commands.generate_secret_key.get_random_secret_key')
     @patch('sys.stdout', new_callable=StringIO)
     def test_should_return_random_secret_key(self, m_stdout, m_get_random_secret):

--- a/tests/management/commands/test_generate_secret_key.py
+++ b/tests/management/commands/test_generate_secret_key.py
@@ -21,16 +21,3 @@ class GenerateSecretKeyTests(TestCase):
         call_command('generate_secret_key')
 
         self.assertIn('random_secret_key', m_stdout.getvalue())
-
-    @pytest.mark.skipif(
-        LooseVersion(get_version()) > LooseVersion('1.10.0'),
-        reason="This test works only on Django older than 1.10.x",
-    )
-    @patch('django_extensions.management.commands.generate_secret_key.get_random_string')
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_should_use_get_random_string_for_django_older_than_1_10(self, m_stdout, m_get_random_string):
-        m_get_random_string.return_value = 'random_secret_key'
-
-        call_command('generate_secret_key')
-
-        self.assertIn('random_secret_key', m_stdout.getvalue())

--- a/tests/management/commands/test_pipchecker.py
+++ b/tests/management/commands/test_pipchecker.py
@@ -6,7 +6,6 @@ import sys
 
 import pip
 import pkg_resources
-import pytest
 from django.core.management import call_command
 from django.test import TestCase
 from io import StringIO

--- a/tests/management/commands/test_pipchecker.py
+++ b/tests/management/commands/test_pipchecker.py
@@ -55,7 +55,6 @@ class PipCheckerTests(TestCase):
 
         self.assertTrue(value.endswith('available\n'))
 
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_pipchecker_with_up_to_date_requirement(self):
         requirements_path = './requirements.txt'
         out = StringIO()

--- a/tests/management/commands/test_syncdata.py
+++ b/tests/management/commands/test_syncdata.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
-from distutils.version import LooseVersion
 
 import pytest
-from django import get_version
 from django.contrib.auth.models import User
 from django.core.management import call_command, CommandError
 from django.test import TestCase

--- a/tests/management/commands/test_syncdata.py
+++ b/tests/management/commands/test_syncdata.py
@@ -34,10 +34,6 @@ class SyncDataExceptionsTests(TestCase):
         with pytest.raises(CommandError, match="django.core.exceptions.FieldDoesNotExist: User has no field named 'non_existent_field'"):
             call_command('syncdata', 'fixture_with_nonexistent_field.json', verbosity=1)
 
-    @pytest.mark.skipif(
-        LooseVersion(get_version()) < LooseVersion('2.0.0'),
-        reason="This test works only on Django greater than 2.x",
-    )
     def test_should_return_SyncDataError_when_multiple_fixtures(self):
         with pytest.raises(CommandError, match="Multiple fixtures named 'users' in '{}'. Aborting.".format(TEST_FIXTURE_DIR)):
             call_command('syncdata', 'users', verbosity=2)
@@ -68,10 +64,6 @@ class SyncDataTests(TestCase):
         self.assertTrue(User.objects.filter(username='jdoe').exists())
         self.assertTrue(User.objects.filter(username='foo').exists())
 
-    @pytest.mark.skipif(
-        LooseVersion(get_version()) < LooseVersion('2.0.0'),
-        reason="This test works only on Django greater than 2.x",
-    )
     @patch('sys.stdout', new_callable=StringIO)
     def test_should_delete_old_objects_and_load_data_from_json_fixture(self, m_stdout):
         User.objects.all().delete()


### PR DESCRIPTION
There were several test skip checks aiming towards to python and Django versions which are not supported by this project anymore. I removed those checks.