### PR TITLE
fix shell_plus --command globals / locals error

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -571,7 +571,7 @@ for k, m in shells.import_objects({}, no_style()).items():
 
             if options['command']:
                 imported_objects = self.get_imported_objects(options)
-                exec(options['command'], {}, imported_objects)
+                exec(options['command'], imported_objects)
                 return None
 
             runner()

--- a/tests/management/commands/shell_plus_tests/test_shell_plus.py
+++ b/tests/management/commands/shell_plus_tests/test_shell_plus.py
@@ -4,7 +4,7 @@ import re
 import pytest
 import inspect
 
-from io import StringIO
+from textwrap import dedent
 from django.core.management import call_command
 from django.db.models import Model
 from django.test import override_settings
@@ -12,10 +12,20 @@ from django.test import override_settings
 from django_extensions.management.commands import shell_plus
 
 
+def test_shell_plus_command(capsys):
+    script = dedent('''\
+        def _fn(x): return x * 2
+        print([_fn(i) for i in range(10)])
+        ''')
+    call_command("shell_plus", "--command=" + script)
+    out, err = capsys.readouterr()
+
+    assert out.rstrip().endswith(repr([i * 2 for i in range(10)]))
+
+
 @pytest.mark.django_db()
 @override_settings(SHELL_PLUS_SQLPARSE_ENABLED=False, SHELL_PLUS_PYGMENTS_ENABLED=False)
 def test_shell_plus_print_sql(capsys):
-    out = StringIO()
     try:
         from django.db import connection
         from django.db.backends import utils


### PR DESCRIPTION
When running a "more complex" command via `--command` shell_plus has historically passed an empty globals and the imports as locals. This will cause Python to act strangely for certain inputs such as list comprehensions. This was fixed in Django's shell command [1] and by passing the imports as the only arg Python will use them as both the locals and the globals which is as if the `exec` was happening at the module level.

[1]: https://code.djangoproject.com/ticket/32183

See also: https://stackoverflow.com/questions/45132645/list-comprehension-in-exec-with-empty-locals-nameerror