### PR TITLE
Set minimum django version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     cmdclass=cmdclasses,
     package_data=package_data,
     python_requires=">=3.6",
-    install_requires=[],
+    install_requires=["Django>=2.2"],
     extras_require={},
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This adds django 2.2 to the requirements list. Without it listed like this, dependency management tools will think that this versions > 3.0 of django extensions can be installed on older versions of django. In our case, dependabot recommended that we upgrade to version 3.11 of this library, but we do not have a compatible version of django (yes, I know, we should; we're getting there!)

It'd be great to get this small fix in place so that dependabot and other compatibility checkers can ensure that only compatible versions are installed.