### PR TITLE
Fix sqldiff for missing field/index in model case

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -853,6 +853,10 @@ class MySQLDiff(SQLDiff):
 
             # extra check removed from superclass here, otherwise function is the same
             if len(columns) == 1:
+                if not field:
+                    # both index and field are missing from the model
+                    self.add_difference('index-missing-in-model', table_name, constraint_name)
+                    continue
                 if constraint['primary_key'] and field.primary_key:
                     continue
                 if constraint['foreign_key'] and isinstance(field, models.ForeignKey) and field.db_constraint:


### PR DESCRIPTION
When both the field and index are missing from the model, the function
would error out. Instead report as an index that should be removed.