### PR TITLE
fix: Handle warnings for default_app_config

### DIFF
--- a/django_extensions/__init__.py
+++ b/django_extensions/__init__.py
@@ -19,4 +19,11 @@ def get_version(version):
 
 __version__ = get_version(VERSION)
 
-default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'
+try:
+    import django
+
+    if django.VERSION < (3, 2):
+        default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'
+except ModuleNotFoundError:
+    # this part is useful for allow setup.py to be used for version checks
+    pass

--- a/tests/management/commands/test_notes.py
+++ b/tests/management/commands/test_notes.py
@@ -8,7 +8,7 @@ def test_without_args(capsys, settings):
     call_command('notes')
 
     out, err = capsys.readouterr()
-    assert 'tests/testapp/__init__.py:\n  * [  4] TODO  this is a test todo\n\n' in out
+    assert 'tests/testapp/__init__.py:\n  * [  8] TODO  this is a test todo\n\n' in out
 
 
 def test_with_utf8(capsys, settings):

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Test Compatility between different django versions"""
+import django
+import pytest
+
+import django_extensions
+
+
+class TestDefaultAppConfigDefinition:
+    @pytest.mark.skipif(django.VERSION < (3, 2), reason='app config is automatically defined by django')
+    def test_app_config_not_defined(self):
+        assert hasattr(django_extensions, 'default_app_config') is False
+
+    @pytest.mark.skipif(django.VERSION >= (3, 2), reason='app config is  not automatically defined by django')
+    def test_app_config_defined(self):
+        assert hasattr(django_extensions, 'default_app_config') is True

--- a/tests/testapp/__init__.py
+++ b/tests/testapp/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
-default_app_config = 'tests.testapp.apps.TestAppConfig'
+import django
+
+
+if django.VERSION < (3, 2):
+    default_app_config = 'tests.testapp.apps.TestAppConfig'
 
 # TODO: this is a test todo


### PR DESCRIPTION
- they are only defined for django versions < 3.2

closes #1649