### PR TITLE
fix: Update codebase to use newer django syntax

### DIFF
--- a/django_extensions/management/__init__.py
+++ b/django_extensions/management/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from django_extensions.management.base import _BaseDjangoExtensionsCommand  # noqa: F401

--- a/django_extensions/management/base.py
+++ b/django_extensions/management/base.py
@@ -1,13 +1,24 @@
 # -*- coding: utf-8 -*-
 import sys
+from typing import List, Tuple, Union
 
-from django.core.management.base import BaseCommand
+from django.core.checks import Tags
+from django.core.management import BaseCommand
 from logging import getLogger
 
 logger = getLogger('django.commands')
 
 
-class LoggingBaseCommand(BaseCommand):
+class _BaseDjangoExtensionsCommand(BaseCommand):
+    """
+    This is an internally used command.
+    It is used for defining suitable defaults for all subclasses that require to inherit from _BaseDjangoExtensionsCommand.
+    All instances of potential BaseCommad usage should inherit from this."""
+    # Django4: bool is provided for backward compatability. Remove bool after django4 is released
+    requires_system_checks: Union[bool, Tuple[Tags, ...], List[Tags], str]
+
+
+class LoggingBaseCommand(_BaseDjangoExtensionsCommand):
     """
     A subclass of BaseCommand that logs run time errors to `django.commands`.
     To use this, create a management command subclassing LoggingBaseCommand:

--- a/django_extensions/management/commands/clean_pyc.py
+++ b/django_extensions/management/commands/clean_pyc.py
@@ -4,15 +4,16 @@ import os
 from os.path import join as _j
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Removes all python bytecode compiled files from the project."
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django_extensions/management/commands/clear_cache.py
+++ b/django_extensions/management/commands/clear_cache.py
@@ -3,12 +3,13 @@
 from django.conf import settings
 from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.core.cache.backends.base import InvalidCacheBackendError
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     """A simple management command which clears the site-wide cache."""
 
     help = 'Fully clear site-wide cache.'

--- a/django_extensions/management/commands/compile_pyc.py
+++ b/django_extensions/management/commands/compile_pyc.py
@@ -5,14 +5,15 @@ import py_compile
 from os.path import join as _j
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Compile python bytecode files for the project."
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
 
     def add_arguments(self, parser):
         parser.add_argument('--path', '-p', action='store', dest='path',

--- a/django_extensions/management/commands/create_command.py
+++ b/django_extensions/management/commands/create_command.py
@@ -12,7 +12,7 @@ from django_extensions.management.utils import _make_writeable, signalcommand
 class Command(AppCommand):
     help = "Creates a Django management command directory structure for the given app name in the app's directory."
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/create_jobs.py
+++ b/django_extensions/management/commands/create_jobs.py
@@ -12,7 +12,7 @@ from django_extensions.management.utils import _make_writeable, signalcommand
 class Command(AppCommand):
     help = "Creates a Django jobs command directory structure for the given app name in the current directory."
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/create_template_tags.py
+++ b/django_extensions/management/commands/create_template_tags.py
@@ -21,7 +21,7 @@ class Command(AppCommand):
             help='The name to use for the template tag base name. Defaults to `appname`_tags.'
         )
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/delete_squashed_migrations.py
+++ b/django_extensions/management/commands/delete_squashed_migrations.py
@@ -3,9 +3,12 @@ import os
 import inspect
 import re
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.loader import AmbiguityError, MigrationLoader
+
+from django_extensions.management import _BaseDjangoExtensionsCommand
+
 
 REPLACES_REGEX = re.compile(r'\s+replaces\s*=\s*\[[^\]]+\]\s*')
 PYC = '.pyc'
@@ -15,7 +18,7 @@ def py_from_pyc(pyc_fn):
     return pyc_fn[:-len(PYC)] + '.py'
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Deletes left over migrations that have been replaced by a "
     "squashed migration and converts squashed migration into a normal "
     "migration. Modifies your source tree! Use with care!"

--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -5,17 +5,18 @@ import logging
 import warnings
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.db import DEFAULT_DB_ALIAS
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 
 from django_extensions.settings import SQLITE_ENGINES, POSTGRESQL_ENGINES, MYSQL_ENGINES
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.mysql import parse_mysql_cnf
 from django_extensions.management.utils import signalcommand
 from django_extensions.utils.deprecation import RemovedInNextVersionWarning
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Drops test database for this project."
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -34,15 +34,15 @@ import sys
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.management.base import BaseCommand
 from django.db import router
 from django.db.models import (
     AutoField, BooleanField, DateField, DateTimeField, FileField, ForeignKey,
 )
 from django.db.models.deletion import Collector
 from django.utils import timezone
-from django.utils.encoding import force_str, smart_text
+from django.utils.encoding import force_str, smart_str
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
@@ -83,7 +83,7 @@ def orm_item_locator(orm_obj):
     return output
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = 'Dumps the data as a customised python script.'
 
     def add_arguments(self, parser):
@@ -205,7 +205,7 @@ class ModelCode(Code):
         Return a dictionary of import statements, with the variable being
         defined as the key.
         """
-        return {self.model.__name__: smart_text(self.model.__module__)}
+        return {self.model.__name__: smart_str(self.model.__module__)}
     imports = property(get_imports)
 
     def get_lines(self):

--- a/django_extensions/management/commands/export_emails.py
+++ b/django_extensions/management/commands/export_emails.py
@@ -5,8 +5,9 @@ import csv
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
@@ -40,7 +41,7 @@ def full_name(**kwargs):
     return ""
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Export user email address list in one of a number of formats."
     args = "[output file]"
     label = 'filename to save to'

--- a/django_extensions/management/commands/generate_password.py
+++ b/django_extensions/management/commands/generate_password.py
@@ -3,14 +3,15 @@ try:
     from django.contrib.auth.base_user import BaseUserManager
 except ImportError:
     from django.contrib.auth.models import BaseUserManager
-from django.core.management.base import BaseCommand
+
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Generates a new password that can be used for a user password. This uses Django core's default password generator `BaseUserManager.make_random_password()`."
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django_extensions/management/commands/generate_secret_key.py
+++ b/django_extensions/management/commands/generate_secret_key.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-from django.core.management.base import BaseCommand
 from django.core.management.utils import get_random_secret_key
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Generates a new SECRET_KEY that can be used in a project settings file."
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
 
     @signalcommand
     def handle(self, *args, **options):

--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -5,9 +5,10 @@ import os
 import tempfile
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.template import loader
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.modelviz import ModelGraph, generate_dot
 from django_extensions.management.utils import signalcommand
 
@@ -27,7 +28,7 @@ except ImportError:
     HAS_PYDOT = False
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Creates a GraphViz dot file for the specified app names. You can pass multiple app names and they will all be combined into a single model. Output is usually directed to a dot file."
 
     can_import_settings = True

--- a/django_extensions/management/commands/list_model_info.py
+++ b/django_extensions/management/commands/list_model_info.py
@@ -4,8 +4,9 @@ import inspect
 
 from django.apps import apps as django_apps
 from django.conf import settings
-from django.core.management.base import BaseCommand
 from django.db import connection
+
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.color import color_style
 from django_extensions.management.utils import signalcommand
 
@@ -13,7 +14,7 @@ TAB = "        "
 HALFTAB = "    "
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     """A simple management command which lists model fields and methods."""
 
     help = "List out the fields and methods for each model"

--- a/django_extensions/management/commands/list_signals.py
+++ b/django_extensions/management/commands/list_signals.py
@@ -8,12 +8,13 @@ import weakref
 from collections import defaultdict
 
 from django.apps import apps
-from django.core.management.base import BaseCommand
 from django.db.models.signals import (
     ModelSignal, pre_init, post_init, pre_save, post_save, pre_delete,
     post_delete, m2m_changed, pre_migrate, post_migrate
 )
 from django.utils.encoding import force_str
+
+from django_extensions.management import _BaseDjangoExtensionsCommand
 
 
 MSG = '{module}.{name} #{line}'
@@ -31,7 +32,7 @@ SIGNAL_NAMES = {
 }
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = 'List all signals by model and signal type'
 
     def handle(self, *args, **options):

--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -4,8 +4,9 @@ import sys
 from logging import getLogger
 from smtpd import SMTPServer
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import setup_logger, signalcommand
 
 logger = getLogger(__name__)
@@ -29,11 +30,11 @@ class ExtensionDebuggingServer(SMTPServer):
         logger.info('------------ END MESSAGE ------------')
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Starts a test mail server for development."
     args = '[optional port number or ippaddr:port]'
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/django_extensions/management/commands/merge_model_instances.py
+++ b/django_extensions/management/commands/merge_model_instances.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey
-from django.core.management import BaseCommand
 from django.db import transaction
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
@@ -85,7 +85,7 @@ def get_generic_fields():
     return generic_fields
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = """
         Removes duplicate model instances based on a specified
         model and field name(s).

--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -3,8 +3,8 @@ import os
 import re
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.compat import get_template_setting
 from django_extensions.management.utils import signalcommand
 
@@ -12,7 +12,7 @@ ANNOTATION_RE = re.compile(r"\{?#[\s]*?(TODO|FIXME|BUG|HACK|WARNING|NOTE|XXX)[\s
 ANNOTATION_END_RE = re.compile(r"(.*)#\}(.*)")
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = 'Show all annotations like TODO, FIXME, BUG, HACK, WARNING, NOTE or XXX in your py and HTML files.'
     label = 'annotation tag (TODO, FIXME, BUG, HACK, WARNING, NOTE, XXX)'
 

--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -10,7 +10,8 @@ from xmlrpc.client import ServerProxy, Fault
 
 import pip
 from time import sleep
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.color import color_style
 from django_extensions.management.utils import signalcommand
 from pip._internal.req import InstallRequirement
@@ -28,9 +29,9 @@ try:
 except ImportError:
     # pip < 10
     try:
-        from pip import get_installed_distributions  # type:ignore
-        from pip.download import PipSession  # type:ignore
-        from pip.req import parse_requirements  # type:ignore
+        from pip import get_installed_distributions  # type: ignore
+        from pip.download import PipSession  # type: ignore
+        from pip.req import parse_requirements  # type: ignore
     except ImportError:
         raise CommandError("Pip version 6 or higher is required")
 
@@ -41,7 +42,7 @@ except ImportError:
     HAS_REQUESTS = False
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Scan pip requirement files for out-of-date packages."
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -10,12 +10,13 @@ import fnmatch
 import json
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Print the active Django settings."
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -4,11 +4,13 @@ import importlib
 from django.conf import settings
 from django.contrib.auth import load_backend, BACKEND_SESSION_KEY, SESSION_KEY
 from django.contrib.sessions.backends.base import VALID_KEY_CHARS
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
+
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = ("print the user information for the provided session key. "
             "this is very helpful when trying to track down the person who "
             "experienced a site crash.")

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -9,16 +9,17 @@ import logging
 import warnings
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.db import DEFAULT_DB_ALIAS
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.settings import SQLITE_ENGINES, POSTGRESQL_ENGINES, MYSQL_ENGINES
 from django_extensions.management.mysql import parse_mysql_cnf
 from django_extensions.management.utils import signalcommand
 from django_extensions.utils.deprecation import RemovedInNextVersionWarning
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Resets the database for this project."
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/reset_schema.py
+++ b/django_extensions/management/commands/reset_schema.py
@@ -7,16 +7,17 @@ schema while there are active connections.
 
 import warnings
 
-from django.core.management import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.db import DEFAULT_DB_ALIAS
 from django.db import connections
 from django.conf import settings
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.settings import POSTGRESQL_ENGINES
 from django_extensions.utils.deprecation import RemovedInNextVersionWarning
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     """`reset_schema` command implementation."""
 
     help = "Recreates the public schema for this project."

--- a/django_extensions/management/commands/runjob.py
+++ b/django_extensions/management/commands/runjob.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from django.core.management.base import BaseCommand
+from django_extensions.management import _BaseDjangoExtensionsCommand
 
 from django_extensions.management.jobs import get_job, print_jobs
 from django_extensions.management.utils import setup_logger, signalcommand
@@ -9,7 +9,7 @@ from django_extensions.management.utils import setup_logger, signalcommand
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Run a single maintenance job."
     missing_args_message = "test"
 

--- a/django_extensions/management/commands/runjobs.py
+++ b/django_extensions/management/commands/runjobs.py
@@ -2,15 +2,15 @@
 import logging
 
 from django.apps import apps
-from django.core.management.base import BaseCommand
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.jobs import get_jobs, print_jobs
 from django_extensions.management.utils import setup_logger, signalcommand
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Runs scheduled maintenance jobs."
 
     when_options = ['minutely', 'quarter_hourly', 'hourly', 'daily', 'weekly', 'monthly', 'yearly']

--- a/django_extensions/management/commands/runprofileserver.py
+++ b/django_extensions/management/commands/runprofileserver.py
@@ -15,9 +15,10 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib.staticfiles.handlers import StaticFilesHandler
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.core.servers.basehttp import get_internal_wsgi_application
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 USE_STATICFILES = 'django.contrib.staticfiles' in settings.INSTALLED_APPS
@@ -88,7 +89,7 @@ class KCacheGrind:
         out_file.write('%d %d\n' % (lineno, totaltime))
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Starts a lightweight Web server with profiling enabled."
     args = '[optional port number, or ipaddr:port]'
 

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -11,7 +11,7 @@ from typing import Set
 
 import django
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError, SystemCheckError
+from django.core.management.base import CommandError, SystemCheckError
 from django.core.management.color import color_style
 from django.core.servers.basehttp import get_internal_wsgi_application
 from django.dispatch import Signal
@@ -44,6 +44,7 @@ try:
 except ImportError:
     HAS_OPENSSL = False
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.technical_response import null_technical_500_response
 from django_extensions.management.utils import RedirectHandler, has_ipdb, setup_logger, signalcommand
 from django_extensions.management.debug_cursor import monkey_patch_cursordebugwrapper
@@ -124,11 +125,11 @@ def check_errors(fn):
     return wrapper
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Starts a lightweight Web server for development."
 
     # Validation is called explicitly each time the server is reloaded.
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
     DEFAULT_CRT_EXTENSION = ".crt"
     DEFAULT_KEY_EXTENSION = ".key"
 

--- a/django_extensions/management/commands/set_default_site.py
+++ b/django_extensions/management/commands/set_default_site.py
@@ -2,13 +2,14 @@
 import socket
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
 from django.apps import apps
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Set parameters of the default django.contrib.sites Site"
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/set_fake_emails.py
+++ b/django_extensions/management/commands/set_fake_emails.py
@@ -10,16 +10,17 @@ set_fake_emails.py
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 DEFAULT_FAKE_EMAIL = '%(username)s@example.com'
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = '''DEBUG only: give all users a new email based on their account data ("%s" by default). Possible parameters are: username, first_name, last_name''' % (DEFAULT_FAKE_EMAIL, )
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/django_extensions/management/commands/set_fake_passwords.py
+++ b/django_extensions/management/commands/set_fake_passwords.py
@@ -9,16 +9,17 @@ set_fake_passwords.py
 """
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 DEFAULT_FAKE_PASSWORD = 'password'
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = 'DEBUG only: sets all user passwords to a common value ("%s" by default)' % (DEFAULT_FAKE_PASSWORD, )
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -7,9 +7,10 @@ import warnings
 
 from django.db import connections
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.utils.datastructures import OrderedSet
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.shells import import_objects
 from django_extensions.management.utils import signalcommand
 from django_extensions.management.debug_cursor import monkey_patch_cursordebugwrapper
@@ -42,7 +43,7 @@ def shell_runner(flags, name, help=None):
     return decorator
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Like the 'shell' command but autoloads the models of all installed Django apps."
     extra_args = None
     tests_mode = False

--- a/django_extensions/management/commands/show_template_tags.py
+++ b/django_extensions/management/commands/show_template_tags.py
@@ -6,10 +6,10 @@ import re
 
 from django.apps import apps
 from django.core.management import color
-from django.core.management import BaseCommand
 from django.utils import termcolors
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.compat import load_tag_library
 from django_extensions.management.color import _dummy_style_func
 from django_extensions.management.utils import signalcommand
@@ -41,7 +41,7 @@ def format_block(block, nlspaces=0):
     http://code.activestate.com/recipes/145672/
     """
     # separate block into lines
-    lines = smart_text(block).split('\n')
+    lines = smart_str(block).split('\n')
 
     # remove leading/trailing empty lines
     while lines and not lines[0]:
@@ -67,7 +67,7 @@ def format_block(block, nlspaces=0):
     return '\n'.join(flines) + '\n'
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Displays template tags and filters available in the current project."
     results = ""
 

--- a/django_extensions/management/commands/show_urls.py
+++ b/django_extensions/management/commands/show_urls.py
@@ -7,9 +7,10 @@ import re
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
 from django.core.exceptions import ViewDoesNotExist
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.utils import translation
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.color import color_style, no_style
 from django_extensions.management.utils import signalcommand
 
@@ -42,7 +43,7 @@ FMTR = {
 }
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Displays all of the url matching routes for the project."
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -4,22 +4,23 @@ import sys
 import warnings
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.db import DEFAULT_DB_ALIAS
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 from django_extensions.utils.deprecation import RemovedInNextVersionWarning
 from django_extensions.settings import SQLITE_ENGINES, POSTGRESQL_ENGINES, MYSQL_ENGINES
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = """Generates the SQL to create your database for you, as specified in settings.py
 The envisioned use case is something like this:
 
     ./manage.py sqlcreate [--database=<databasename>] | mysql -u <db_administrator> -p
     ./manage.py sqlcreate [--database=<databasname>] | psql -U <db_administrator> -W"""
 
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
     can_import_settings = True
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -26,13 +26,14 @@ import sys
 import argparse
 from typing import Dict, Union, Callable, Optional  # NOQA
 from django.apps import apps
-from django.core.management import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.core.management.base import OutputWrapper
 from django.core.management.color import no_style
 from django.db import connection, transaction, models
 from django.db.models.fields import AutoField, IntegerField
 from django.db.models.options import normalize_together
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 ORDERING_FIELD = IntegerField('_order', null=True)
@@ -1257,7 +1258,7 @@ DATABASE_SQLDIFF_CLASSES = {
 }
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = """Prints the (approximated) difference between models and fields in the database for the given app name(s).
 
 It indicates how columns in the database are different from the sql that would

--- a/django_extensions/management/commands/sqldsn.py
+++ b/django_extensions/management/commands/sqldsn.py
@@ -9,16 +9,18 @@ import sys
 import warnings
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.core.management.color import color_style
 from django.db import DEFAULT_DB_ALIAS
+
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.settings import SQLITE_ENGINES, POSTGRESQL_ENGINES, MYSQL_ENGINES
 from django_extensions.utils.deprecation import RemovedInNextVersionWarning
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Prints DSN on stdout, as specified in settings.py"
-    requires_system_checks = False
+    requires_system_checks = []  # type: ignore
     can_import_settings = True
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/sync_s3.py
+++ b/django_extensions/management/commands/sync_s3.py
@@ -65,9 +65,10 @@ import time
 from typing import List  # NOQA
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from io import StringIO
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
@@ -79,7 +80,7 @@ else:
     HAS_BOTO = True
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     # Extra variables to avoid passing these around
     AWS_ACCESS_KEY_ID = ''
     AWS_SECRET_ACCESS_KEY = ''

--- a/django_extensions/management/commands/syncdata.py
+++ b/django_extensions/management/commands/syncdata.py
@@ -14,11 +14,12 @@ import os
 from django.apps import apps
 from django.conf import settings
 from django.core import serializers
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.core.management.color import no_style
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
 from django.template.defaultfilters import pluralize
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
@@ -30,7 +31,7 @@ class SyncDataError(Exception):
     pass
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     """ syncdata command """
 
     help = 'Makes the current database have the same data as the fixture(s), no more, no less.'

--- a/django_extensions/management/commands/unreferenced_files.py
+++ b/django_extensions/management/commands/unreferenced_files.py
@@ -4,13 +4,14 @@ from collections import defaultdict
 
 from django.apps import apps
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.db import models
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = "Prints a list of all files in MEDIA_ROOT that are not referenced in the database."
 
     @signalcommand

--- a/django_extensions/management/commands/update_permissions.py
+++ b/django_extensions/management/commands/update_permissions.py
@@ -4,12 +4,12 @@ from django.apps import apps as django_apps
 from django.contrib.auth.management import create_permissions, _get_all_permissions
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.core.management.base import BaseCommand
 
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     help = 'reloads permissions for specified apps, or all apps if no args are specified'
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/validate_templates.py
+++ b/django_extensions/management/commands/validate_templates.py
@@ -4,11 +4,12 @@ import fnmatch
 
 from django.apps import apps
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.core.management.color import color_style
 from django.template.loader import get_template
 
 from django_extensions.compat import get_template_setting
+from django_extensions.management import _BaseDjangoExtensionsCommand
 from django_extensions.management.utils import signalcommand
 
 
@@ -17,7 +18,7 @@ from django_extensions.management.utils import signalcommand
 #
 
 
-class Command(BaseCommand):
+class Command(_BaseDjangoExtensionsCommand):
     args = ''
     help = "Validate templates on syntax and compile errors"
     ignores = set([

--- a/django_extensions/management/email_notifications.py
+++ b/django_extensions/management/email_notifications.py
@@ -4,12 +4,13 @@ import traceback
 
 from django.conf import settings
 from django.core.mail import send_mail
-from django.core.management import BaseCommand
+
+from django_extensions.management import _BaseDjangoExtensionsCommand
 
 
-class EmailNotificationCommand(BaseCommand):
+class EmailNotificationCommand(_BaseDjangoExtensionsCommand):
     """
-    A BaseCommand subclass which adds sending email fuctionality.
+    A _BaseDjangoExtensionsCommand subclass which adds sending email fuctionality.
 
     Subclasses will have an extra command line option ``--email-notification``
     and will be able to send emails by calling ``send_email_notification()``

--- a/tests/management/commands/test_show_urls.py
+++ b/tests/management/commands/test_show_urls.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from io import StringIO
 
-from django.conf.urls import url
 from django.core.management import CommandError, call_command
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.views.generic.base import View
+from django.urls import re_path
 
 from unittest.mock import Mock, patch
 
@@ -20,9 +20,9 @@ class ClassView(View):
 
 
 urlpatterns = [
-    url(r'lambda/view', lambda request: HttpResponse('OK')),
-    url(r'function/based/', function_based_view, name='function-based-view'),
-    url(r'class/based/', ClassView.as_view(), name='class-based-view'),
+    re_path(r'lambda/view', lambda request: HttpResponse('OK')),
+    re_path(r'function/based/', function_based_view, name='function-based-view'),
+    re_path(r'class/based/', ClassView.as_view(), name='class-based-view'),
 ]
 
 

--- a/tests/test_admin_filter.py
+++ b/tests/test_admin_filter.py
@@ -35,7 +35,7 @@ class NullFieldListFilterTests(BaseFieldFilter):
 
         result = filter_spec.queryset(self.request, self.qs)
 
-        self.assertQuerysetEqual(self.qs, map(repr, result), ordered=False)
+        self.assertQuerysetEqual(self.qs, map(repr, result), ordered=False, transform=repr)
 
     def test_should_return_objects_with_empty_text_if_yes_lookup_selected(self):
         expected_result = Secret.objects.filter(text__isnull=True)
@@ -44,7 +44,7 @@ class NullFieldListFilterTests(BaseFieldFilter):
 
         result = filter_spec.queryset(self.request, self.qs)
 
-        self.assertQuerysetEqual(expected_result, map(repr, result), ordered=False)
+        self.assertQuerysetEqual(expected_result, map(repr, result), ordered=False, transform=repr)
 
     def test_should_return_objects_with_not_empty_text_value_if_no_lookup_selected(self):
         expected_result = Secret.objects.filter(text__isnull=False)
@@ -53,7 +53,7 @@ class NullFieldListFilterTests(BaseFieldFilter):
 
         result = filter_spec.queryset(self.request, self.qs)
 
-        self.assertQuerysetEqual(expected_result, map(repr, result), ordered=False)
+        self.assertQuerysetEqual(expected_result, map(repr, result), ordered=False, transform=repr)
 
     def test_choices(self):
         expected_result = [
@@ -79,4 +79,4 @@ class NotNullFieldListFilterTests(BaseFieldFilter):
 
         result = filter_spec.queryset(self.request, self.qs)
 
-        self.assertQuerysetEqual(self.qs, map(repr, result), ordered=False)
+        self.assertQuerysetEqual(self.qs, map(repr, result), ordered=False, transform=repr)

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -16,15 +16,15 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
+from django.urls import path
 
 login_view = auth_views.LoginView.as_view() if hasattr(auth_views, 'LoginView') else auth_views.login
 logout_view = auth_views.LogoutView.as_view() if hasattr(auth_views, 'LogoutView') else auth_views.logout
 
 urlpatterns = [
-    url(r'^login/$', login_view, {'template_name': 'login.html'}, name="login"),
-    url(r'^logout/$', logout_view, name="logout"),
-    url(r'^admin/', admin.site.urls),
+    path('login', login_view, {'template_name': 'login.html'}, name="login"),
+    path('logout', logout_view, name="logout"),
+    path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
- all commands of django_extensions now inherit from a base command `_BaseDjangoExtensionsCommand`.
- this helps in defining constant at a single place.(The `_` is prefixed intentionally to indicate the `class` as an internal API.)
- handle django41 deprecation warnings.
- update some test code to use upgraded version of django code.