### PR TITLE
removed excess calls of "check" and "check_migrations" methods

### DIFF
--- a/django_extensions/management/commands/runscript.py
+++ b/django_extensions/management/commands/runscript.py
@@ -89,8 +89,6 @@ class Command(EmailNotificationCommand):
 
     @signalcommand
     def handle(self, *args, **options):
-        self.check()
-        self.check_migrations()
 
         NOTICE = self.style.SQL_TABLE
         NOTICE2 = self.style.SQL_FIELD


### PR DESCRIPTION
There are two significant reasons to remove this explicit check from _Command_ class:

1. First - this calls is excess, both of this methods already executed in django _BaseCommand_ class in method _execute_ https://github.com/django/django/blob/main/django/core/management/base.py#L391 (shown below)
2. Second - this calls doesn't respect the  nor _--skip_checks_ option, nor _requires_system_checks_ and _requires_migrations_checks_ variables

This PR reverts https://github.com/django-extensions/django-extensions/commit/6c78368e2f1d133c22778e5db6abb602307a4cbd

The full explanation
```
Python 3.6.8 (tags/v3.6.8:3c6b436a57, Dec 24 2018, 00:16:47) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.11.1 -- An enhanced Interactive Python. Type '?' for help.


In [15]: from django_extensions.management.commands import runscript

In [16]: from django_extensions.management.email_notifications import EmailNotificationCommand

In [19]: runscript.Command.execute??
Signature: runscript.Command.execute(self, *args, **options)
Source:
    def execute(self, *args, **options):
        """
        Overriden in order to send emails on unhandled exception.

        If an unhandled exception in ``def handle(self, *args, **options)``
        occurs and `--email-exception` is set or `self.email_exception` is
        set to True send an email to ADMINS with the traceback and then
        reraise the exception.
        """
        try:
            super().execute(*args, **options)
        except Exception:
            if options['email_exception'] or getattr(self, 'email_exception', False):
                self.send_email_notification(include_traceback=True)
            raise
File:      c:\users\empty\appdata\local\programs\python\python36\lib\site-packages\django_extensions\management\email_notifications.py
Type:      function


In [20]: runscript.Command.__mro__
Out[20]:
(django_extensions.management.commands.runscript.Command,
 django_extensions.management.email_notifications.EmailNotificationCommand,
 django.core.management.base.BaseCommand,
 object)

In [22]: f = super(EmailNotificationCommand, runscript.Command).execute

In [23]: f??
Signature: f(self, *args, **options)
Source:
    def execute(self, *args, **options):
        """
        Try to execute this command, performing system checks if needed (as
        controlled by the ``requires_system_checks`` attribute, except if
        force-skipped).
        """
        if options['force_color'] and options['no_color']:
            raise CommandError("The --no-color and --force-color options can't be used together.")
        if options['force_color']:
            self.style = color_style(force_color=True)
        elif options['no_color']:
            self.style = no_style()
            self.stderr.style_func = None
        if options.get('stdout'):
            self.stdout = OutputWrapper(options['stdout'])
        if options.get('stderr'):
            self.stderr = OutputWrapper(options['stderr'])

        if self.requires_system_checks and not options['skip_checks']:
            if self.requires_system_checks == ALL_CHECKS:
                self.check()
            else:
                self.check(tags=self.requires_system_checks)
        if self.requires_migrations_checks:
            self.check_migrations()
        output = self.handle(*args, **options)
        if output:
            if self.output_transaction:
                connection = connections[options.get('database', DEFAULT_DB_ALIAS)]
                output = '%s\n%s\n%s' % (
                    self.style.SQL_KEYWORD(connection.ops.start_transaction_sql()),
                    output,
                    self.style.SQL_KEYWORD(connection.ops.end_transaction_sql()),
                )
            self.stdout.write(output)
        return output
File:      c:\users\empty\appdata\local\programs\python\python36\lib\site-packages\django\core\management\base.py
Type:      function

In [24]:
```