### PR TITLE
Add sqldiff specific database alias support and psqlextra support

### DIFF
--- a/docs/sqldiff.rst
+++ b/docs/sqldiff.rst
@@ -42,3 +42,8 @@ Example Usage
 
   # View SQL differences for all installed applications using text instead of SQL
   $ ./manage.py sqldiff -a -t
+
+::
+
+  # View SQL differences with specified database alias
+  $ ./manage.py sqldiff -D {database_alias}


### PR DESCRIPTION
I've used this amazing collection of extensions for many years, and I'm using multiple databases for my project currently.

Since the `sqldiff` command will always use `'default'` database for further operations, but I think if there is an option that we can choose which database should be used, it will be great.

Also I extend the `DATABASE_SQLDIFF_CLASSES` dictionary with `'psqlextra.backend'`, which should use `PostgresqlSQLDiff` as `sqldiff_instance`.