### PR TITLE
Accept both --no-input and --noinput

### DIFF
--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
-            '--noinput', action='store_false', dest='interactive',
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             default=True, help='Tells Django to NOT prompt the user for input of any kind.'
         )
         parser.add_argument(

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
-            '--noinput', action='store_false',
+            '--noinput', '--no-input', action='store_false',
             dest='interactive', default=True,
             help='Tells Django to NOT prompt the user for input of any kind.'
         )

--- a/django_extensions/management/commands/reset_schema.py
+++ b/django_extensions/management/commands/reset_schema.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
-            '--noinput', action='store_false',
+            '--noinput', '--no-input', action='store_false',
             dest='interactive', default=True,
             help='Tells Django to NOT prompt the user for input of any kind.'
         )


### PR DESCRIPTION
This makes it easier for users who may be used to one spelling or the other and brings these commands compatibility with Django built-in commands (which all accept either spelling).