### PR TITLE
setup.py: Add project URLs for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,4 +132,10 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',
     ],
+    project_urls={
+        "Documentation": "https://django-extensions.readthedocs.io/",
+        "Changelog": "https://github.com/django-extensions/django-extensions/blob/main/CHANGELOG.md",
+        "Source": "https://github.com/django-extensions/django-extensions",
+        "Tracker": "https://github.com/django-extensions/django-extensions/issues",
+    },
 )


### PR DESCRIPTION
Per python packaging's [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)

![image](https://user-images.githubusercontent.com/26336/146016771-e02a4dfc-2a27-4418-9b62-de72abcd142b.png)
