### PR TITLE
Fix one code format in documentation

### DIFF
--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -28,7 +28,7 @@ Python::
 
   $ ./manage.py shell_plus --plain
 
-It is possible to directly add command line arguments to the underlying Python shell using `--`::
+It is possible to directly add command line arguments to the underlying Python shell using ``--``::
 
   $ ./manage.py shell_plus --ipython -- --profile=foo
 


### PR DESCRIPTION
Currently, the `--` renders as – in the docs, which had me confused until I read the example more carefully.