### PR TITLE
Added more styles to the `sqldsn` management command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ htmlcov/
 django-sample-app*/
 *.swp
 *.swo
+*.sqlite3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,13 @@ $ source venv/bin/activate
 # install django-extensions in development mode
 (venv) $ pip install -e .
 # install dependencies
+# might need to replace DJango with 'Django<4' until issue #1695 is resolved.
 (venv) $ pip install Django -r requirements-dev.txt
 
 # for accessing the GUI portion of the test application
 (venv) $ export DJANGO_EXTENSIONS_DATABASE_NAME="db.sqlite3"    # you may change if you want to use any other database
+# run migrations
+(venv) $ python manage.py migrate
 # start the development server
 (venv) $ python manage.py runserver
 ```

--- a/docs/sqldsn.rst
+++ b/docs/sqldsn.rst
@@ -16,10 +16,33 @@ Currently the following databases are supported:
 
 Patches to support other databases are welcome! :-)
 
+
+Supported Styles
+----------------
+
+Currently the following databases are supported:
+
++----------+------------+-------+---------+---------------------------+
+| Style    | PostgreSQL | MySQL | Sqlite3 | Description               |
++==========+============+=======+=========+===========================+
+| args     |            |   Y   |         | command-line arguments    |
++----------+------------+-------+---------+---------------------------+
+| filename |            |       |    Y    | filename                  |
++----------+------------+-------+---------+---------------------------+
+| keyvalue |      Y     |   Y   |         | key-value pairs (legacy)  |
++----------+------------+-------+---------+---------------------------+
+| kwargs   |      Y     |       |         | Python keyword arguments  |
++----------+------------+-------+---------+---------------------------+
+| pgpass   |      Y     |       |         | ``.pgpass`` format        |
++----------+------------+-------+---------+---------------------------+
+| uri      |      Y     |   Y   |    Y    | (See ``dj-database-url``) |
++----------+------------+-------+---------+---------------------------+
+
+
 Exit Codes
 ----------
 
-Exit status is 0
+Exit status is 0 unless invalid options were given.
 
 
 Example Usage
@@ -44,6 +67,11 @@ Example Usage
 
   # Print all DSN styles available for the default database
   $ ./manage.py sqldsn --style=all
+
+::
+
+  # Print the URI for the default database
+  $ ./manage.py sqldsn -q --style=uri
 
 ::
 

--- a/tests/management/commands/test_sqldsn.py
+++ b/tests/management/commands/test_sqldsn.py
@@ -81,12 +81,40 @@ db.sqlite3
 
         self.assertEqual(expected_result, m_stdout.getvalue())
 
+    @override_settings(DATABASES={'default': SQLITE3_DATABASE_SETTINGS})
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_should_print_uri_for_default_sqlite3_database(self, m_stdout):
+        expected_result = """DSN for database 'default' with engine 'django.db.backends.sqlite3':
+sqlite:///db.sqlite3
+"""
+        call_command('sqldsn', '--style=uri')
+
+        self.assertEqual(expected_result, m_stdout.getvalue())
+
     @override_settings(DATABASES={'default': MYSQL_DATABASE_SETTINGS})
     @patch('sys.stdout', new_callable=StringIO)
     def test_should_print_quiet_info_for_mysql_database(self, m_stdout):
         expected_result = """host="127.0.0.1", db="dbatabase", user="foo", passwd="bar", port="3306"
 """
         call_command('sqldsn', '-q')
+
+        self.assertEqual(expected_result, m_stdout.getvalue())
+
+    @override_settings(DATABASES={'default': MYSQL_DATABASE_SETTINGS})
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_should_print_quiet_uri_for_mysql_database(self, m_stdout):
+        expected_result = """mysql://foo:bar@127.0.0.1:3306/dbatabase
+"""
+        call_command('sqldsn', '-q', '--style=uri')
+
+        self.assertEqual(expected_result, m_stdout.getvalue())
+
+    @override_settings(DATABASES={'default': MYSQL_DATABASE_SETTINGS})
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_should_print_quiet_args_for_mysql_database(self, m_stdout):
+        expected_result = """-h "127.0.0.1" -D "dbatabase" -u "foo" -p "bar" -P 3306
+"""
+        call_command('sqldsn', '-q', '--style=args')
 
         self.assertEqual(expected_result, m_stdout.getvalue())
 
@@ -160,7 +188,7 @@ host="127.0.0.1", db="dbatabase", user="foo", passwd="bar", port="3306"'''
         test_sqlite3 = """DSN for database 'test' with engine 'django.db.backends.sqlite3':
 db.sqlite3"""
         unknown = """DSN for database 'unknown' with engine 'django.db.backends.unknown':
-Unknown database, cant generate DSN"""
+Unknown database, can't generate DSN"""
 
         call_command('sqldsn', '--all')
 
@@ -189,7 +217,7 @@ host="127.0.0.1", db="dbatabase", user="foo", passwd="bar", port="3306"'''
         test_sqlite3 = """DSN for database 'test' with engine 'django.db.backends.sqlite3':
 db.sqlite3"""
         unknown = """DSN for database 'unknown' with engine 'django.db.backends.unknown':
-Unknown database, cant generate DSN"""
+Unknown database, can't generate DSN"""
 
         call_command('sqldsn', '--all', '--style=all')
 


### PR DESCRIPTION
Expands the `sqldsn` command:
* Adds `uri` styles for the two supported database types that didn't have it already.
* Adds `args` style for MySQL, generating command-line flags that can be passed to `mysql`, `mysqldump`, etc.
* Refactors engine/style code to ease expansion and take advantage of f-strings available in Python 3.6 and up.
* Fixes a typo in an error message and `--style=kwargs` quoting while we're at it.
* Adds test cases for above.
* Adds rst documentation for above.