### PR TITLE
Make sure key for removal exists

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -322,7 +322,7 @@ class Command(BaseCommand):
         class WSGIRequestHandler(_WSGIRequestHandler):
             def make_environ(self):
                 environ = super().make_environ()
-                if not options['keep_meta_shutdown_func']:
+                if environ.get('werkzeug.server.shutdown') and not options['keep_meta_shutdown_func']:
                     del environ['werkzeug.server.shutdown']
                 return environ
 


### PR DESCRIPTION
With Werkzeug 2.2 I run into an issue where `environ['werkzeug.server.shutdown']` does not exist and `del environ['werkzeug.server.shutdown']` fails. 