### PR TITLE
Remove use of deprecated imp module in job system.

### DIFF
--- a/django_extensions/management/jobs.py
+++ b/django_extensions/management/jobs.py
@@ -80,7 +80,7 @@ def find_job_module(app_name: str, when: Optional[str] = None) -> str:
         parts.append(when)
     module_name = ".".join(parts)
     module = importlib.import_module(module_name)
-    return os.path.dirname(module.__file__)
+    return module.__path__[0]
 
 
 def import_job(app_name, name, when=None):

--- a/django_extensions/management/jobs.py
+++ b/django_extensions/management/jobs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-from imp import find_module
+import importlib
 from typing import Optional  # NOQA
 from django.apps import apps
 
@@ -72,17 +72,15 @@ def find_jobs(jobs_dir):
         return []
 
 
-def find_job_module(app_name, when=None):
+def find_job_module(app_name: str, when: Optional[str] = None) -> str:
+    """Find the directory path to a job module."""
     parts = app_name.split('.')
     parts.append('jobs')
     if when:
         parts.append(when)
-    parts.reverse()
-    path = None
-    while parts:
-        part = parts.pop()
-        f, path, descr = find_module(part, path and [path] or None)
-    return path
+    module_name = ".".join(parts)
+    module = importlib.import_module(module_name)
+    return os.path.dirname(module.__file__)
 
 
 def import_job(app_name, name, when=None):


### PR DESCRIPTION
Hello, django-extensions devs! Thanks for a great package. I use django-extensions all the time.

This PR removes the following Python deprecation:

```
venv/lib/python3.9/site-packages/django_extensions/management/jobs.py:4
  /Users/matt/projects/homeschool/venv/lib/python3.9/site-packages/django_extensions/management/jobs.py:4: 
  DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation
  for alternative uses
    from imp import find_module
```

Since Python 3.3, `import_module` imports the parent modules. I believe this mimics the behavior of the existing code that is using `find_module`. https://docs.python.org/3/library/importlib.html#importlib.import_module

`import_module` will also raise an `ImportError` if the module name is not found. This matches the expected error interface of `find_job_module`.

I took the liberty of adding a type annotation and docstring while I was at it.

I did not write any additional tests because this portion of the code has decent test coverage, and I saw that the existing tests cover `find_job_module`.