### PR TITLE
Fix KeyError: 'werkzeug.server.shutdown' in runserver_plus

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -322,7 +322,7 @@ class Command(BaseCommand):
         class WSGIRequestHandler(_WSGIRequestHandler):
             def make_environ(self):
                 environ = super().make_environ()
-                if not options['keep_meta_shutdown_func']:
+                if not options['keep_meta_shutdown_func'] and 'werkzeug.server.shutdown' in environ:
                     del environ['werkzeug.server.shutdown']
                 return environ
 


### PR DESCRIPTION
Exception:

```
Exception happened during processing of request from ('172.20.0.5', 34456)
Traceback (most recent call last):
  File "/usr/lib/python3.7/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.7/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.7/socketserver.py", line 720, in __init__
    self.handle()
  File "/opt/cloudsmith/deps/venv/lib/python3.7/site-packages/werkzeug/serving.py", line 347, in handle
    super().handle()
  File "/usr/lib/python3.7/http/server.py", line 426, in handle
    self.handle_one_request()
  File "/usr/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/opt/cloudsmith/deps/venv/lib/python3.7/site-packages/werkzeug/serving.py", line 243, in run_wsgi
    self.environ = environ = self.make_environ()
  File "/opt/cloudsmith/deps/venv/lib/python3.7/site-packages/django_extensions/management/commands/runserver_plus.py", line 326, in make_environ
    del environ['werkzeug.server.shutdown']
KeyError: 'werkzeug.server.shutdown'
```

This change fixes the problem in my dev environment. Thanks to @cpontvieux-systra for the idea.

Fixes: #1715, https://github.com/pallets/werkzeug/issues/2387