### PR TITLE
sort the listdir of jobs, so that jobs will run in a predictable order

### DIFF
--- a/django_extensions/management/jobs.py
+++ b/django_extensions/management/jobs.py
@@ -67,7 +67,7 @@ def my_import(name):
 
 def find_jobs(jobs_dir):
     try:
-        return [f[:-3] for f in os.listdir(jobs_dir) if not f.startswith('_') and f.endswith(".py")]
+        return sorted([f[:-3] for f in os.listdir(jobs_dir) if not f.startswith('_') and f.endswith(".py")])
     except OSError:
         return []
 


### PR DESCRIPTION
This makes it so that jobs will be run in alphabetic order per directory, starting with the jobs dir, then in order of time period from smallest (minutely) to largest (yearly), still contingent on the specification of time period as before. This allows the user to set the order of their jobs in a way similar to init; e.g. name the files with `00_<jobname>` for it to go before `10_<jobname>`

This is the simple fix for #1721 