### PR TITLE
Drop use of mock and six

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ pytest-django
 pytest-cov
 factory-boy
 requests
-mock
 pygments
 vobject
 

--- a/tests/db/fields/test_uniq_field_mixin_compat.py
+++ b/tests/db/fields/test_uniq_field_mixin_compat.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
-import six
 from django.db import models
 from django.test import TestCase
 from tests.testapp.models import (
@@ -20,7 +16,7 @@ class UniqFieldMixinCompatTestCase(TestCase):
 
         class MockField(UniqueFieldMixin):
             def __init__(self, **kwargs):
-                for key, value in six.iteritems(kwargs):
+                for key, value in kwargs.items():
                     setattr(self, key, value)
 
         self.uniq_field = MockField(

--- a/tests/management/commands/test_clear_cache.py
+++ b/tests/management/commands/test_clear_cache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import os
 from io import StringIO
 

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-import mock
+from unittest import mock
 import logging
 import importlib
 

--- a/tests/test_sqldiff.py
+++ b/tests/test_sqldiff.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 from io import StringIO
 


### PR DESCRIPTION
Now that Python >= 3.5 is the minimal version supported, remove all
remaining traces of the external mock module, as well as one use of six
that is no longer required.