### PR TITLE
Fix django app default warning

### DIFF
--- a/django_extensions/__init__.py
+++ b/django_extensions/__init__.py
@@ -22,7 +22,10 @@ __version__ = get_version(VERSION)
 try:
     import django
 
-    if django.VERSION < (3, 2):
+    if django.VERSION >= (3, 2):
+        # The declaration is only needed for older Django versions
+        pass
+    else:
         default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'
 except ModuleNotFoundError:
     # this part is useful for allow setup.py to be used for version checks


### PR DESCRIPTION
What does this PR do ?

It solves the fix warnings default_app_config.
Full error details :
`
RemovedInDjango41Warning: 'django_extensions' defines default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'. Django now detects this configuration automatically. You can remove default_app_config.`
