### PR TITLE
Remove django 2.2 as a supported version

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,6 @@ jobs:
           - "3.10"
           - pypy3
         tox-django-version:
-          - "22"
           - "32"
           - "40"
           # GH Actions don't support something like allow-failure ?

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist =
     safety
     mypy
     {py37,py38,py39,py310}-flake8
-    {py36,py37,py38,py39,py310,pypy}-dj22
     {py36,py37,py38,py39,py310,pypy}-dj32
     {py38,py39,py310,pypy}-dj40
     {py38,py39,py310,pypy}-djmaster
@@ -39,7 +38,6 @@ setenv =
 deps =
     pip >= 21.1
     -rrequirements-dev.txt
-    dj22: Django==2.2
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     djmaster: https://github.com/django/django/archive/refs/heads/main.zip


### PR DESCRIPTION
Django 2.2 is not longer supported.