### PR TITLE
Remove default_app_config with change to only support Django 3.2+

### DIFF
--- a/django_extensions/__init__.py
+++ b/django_extensions/__init__.py
@@ -18,9 +18,3 @@ def get_version(version):
 
 
 __version__ = get_version(VERSION)
-
-try:
-    default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'
-except ModuleNotFoundError:
-    # this part is useful for allow setup.py to be used for version checks
-    pass

--- a/tests/testapp/__init__.py
+++ b/tests/testapp/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-default_app_config = 'tests.testapp.apps.TestAppConfig'

--- a/tests/testapp_with_appconfig/__init__.py
+++ b/tests/testapp_with_appconfig/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-default_app_config = 'tests.testapp.apps.TestappWithAppConfigConfig'


### PR DESCRIPTION
This is the correct fix from the change at https://github.com/django-extensions/django-extensions/commit/7b2e0d7e0dedfeccb0e20586a411c10b6999ad90#r78148010. Related to Django 3.2 minimum requirements added at #1730.

Also fixes deprecation warnings like:

```
[2022-07-11T23:05:36.932Z] Traceback (most recent call last):
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/bin/pytest", line 8, in <module>
[2022-07-11T23:05:36.932Z]     sys.exit(console_main())
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 187, in console_main
[2022-07-11T23:05:36.932Z]     code = main()
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 145, in main
[2022-07-11T23:05:36.932Z]     config = _prepareconfig(args, plugins)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 324, in _prepareconfig
[2022-07-11T23:05:36.932Z]     config = pluginmanager.hook.pytest_cmdline_parse(
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_hooks.py", line 265, in __call__
[2022-07-11T23:05:36.932Z]     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_manager.py", line 80, in _hookexec
[2022-07-11T23:05:36.932Z]     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_callers.py", line 55, in _multicall
[2022-07-11T23:05:36.932Z]     gen.send(outcome)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/_pytest/helpconfig.py", line 102, in pytest_cmdline_parse
[2022-07-11T23:05:36.932Z]     config: Config = outcome.get_result()
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_result.py", line 60, in get_result
[2022-07-11T23:05:36.932Z]     raise ex[1].with_traceback(ex[2])
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_callers.py", line 39, in _multicall
[2022-07-11T23:05:36.932Z]     res = hook_impl.function(*args)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1016, in pytest_cmdline_parse
[2022-07-11T23:05:36.932Z]     self.parse(args)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1304, in parse
[2022-07-11T23:05:36.932Z]     self._preparse(args, addopts=addopts)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1206, in _preparse
[2022-07-11T23:05:36.932Z]     self.hook.pytest_load_initial_conftests(
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_hooks.py", line 265, in __call__
[2022-07-11T23:05:36.932Z]     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_manager.py", line 80, in _hookexec
[2022-07-11T23:05:36.932Z]     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_callers.py", line 60, in _multicall
[2022-07-11T23:05:36.932Z]     return outcome.get_result()
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_result.py", line 60, in get_result
[2022-07-11T23:05:36.932Z]     raise ex[1].with_traceback(ex[2])
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pluggy/_callers.py", line 39, in _multicall
[2022-07-11T23:05:36.932Z]     res = hook_impl.function(*args)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pytest_django/plugin.py", line 353, in pytest_load_initial_conftests
[2022-07-11T23:05:36.932Z]     _setup_django()
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/pytest_django/plugin.py", line 236, in _setup_django
[2022-07-11T23:05:36.932Z]     django.setup()
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/django/__init__.py", line 24, in setup
[2022-07-11T23:05:36.932Z]     apps.populate(settings.INSTALLED_APPS)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/django/apps/registry.py", line 91, in populate
[2022-07-11T23:05:36.932Z]     app_config = AppConfig.create(entry)
[2022-07-11T23:05:36.932Z]   File "/opt/pysetup/.venv/lib/python3.10/site-packages/django/apps/config.py", line 189, in create
[2022-07-11T23:05:36.932Z]     warnings.warn(message, RemovedInDjango41Warning, stacklevel=2)
[2022-07-11T23:05:36.932Z] django.utils.deprecation.RemovedInDjango41Warning: 'django_extensions' defines default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'. Django now detects this configuration automatically. You can remove default_app_config.

```