### PR TITLE
Fix warning

### DIFF
--- a/django_extensions/__init__.py
+++ b/django_extensions/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import django
+
 VERSION = (3, 2, 1, 'DEV')
 
 
@@ -19,8 +21,5 @@ def get_version(version):
 
 __version__ = get_version(VERSION)
 
-try:
-    default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'
-except ModuleNotFoundError:
-    # this part is useful for allow setup.py to be used for version checks
-    pass
+if django.VERSION < (3, 2):  # pragma: no cover
+    default_app_config = "django_extensions.apps.DjangoExtensionsConfig"


### PR DESCRIPTION
```
./home/varys/.pyenv/versions/3.8.12/envs/varys/lib/python3.8/site-packages/django/apps/registry.py:91
  /home/varys/.pyenv/versions/3.8.12/envs/varys/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'django_extensions' defines default_app_config = 'django_extensions.apps.DjangoExtensionsConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)
```