### PR TITLE
fix(dumpscript): `make_aware` should not be called if aware already

### DIFF
--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -70,7 +70,8 @@ def orm_item_locator(orm_obj):
         v = clean_dict[key]
         if v is not None:
             if isinstance(v, datetime.datetime):
-                v = timezone.make_aware(v)
+                if not timezone.is_aware(v):
+                    v = timezone.make_aware(v)
                 clean_dict[key] = StrToCodeChanger('dateutil.parser.parse("%s")' % v.isoformat())
             elif not isinstance(v, (str, int, float)):
                 clean_dict[key] = str("%s" % v)


### PR DESCRIPTION
Otherwise it raises a ValueError:

```
  File "…/django_extensions/management/commands/dumpscript.py", line 696, in get_attribute_value
    item_locator = orm_item_locator(value)
  File "…/django_extensions/management/commands/dumpscript.py", line 73, in orm_item_locator
    v = timezone.make_aware(v)
  File "…/django/utils/timezone.py", line 279, in make_aware
    raise ValueError("make_aware expects a naive datetime, got %s" % value)
ValueError: make_aware expects a naive datetime, got 2022-05-19 06:53:06.476209+00:00
```

`value` being a user's `last_login` field.

The project uses `USE_TZ = True`.

The check is there since Django 1.8 already:
https://github.com/django/django/commit/fa89acf1d0a4adbf0802c1275494f5159a912c9e