### PR TITLE
fix(dumpscript): handle formatting of tuples

### DIFF
--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -73,7 +73,7 @@ def orm_item_locator(orm_obj):
                 v = timezone.make_aware(v)
                 clean_dict[key] = StrToCodeChanger('dateutil.parser.parse("%s")' % v.isoformat())
             elif not isinstance(v, (str, int, float)):
-                clean_dict[key] = str("%s" % v)
+                clean_dict[key] = str(v)
 
     output = """ importer.locate_object(%s, "%s", %s, "%s", %s, %s ) """ % (
         original_class, original_pk_name,


### PR DESCRIPTION
With tuples it would fail to format it:

```
  File "…/django_extensions/management/commands/dumpscript.py", line 360, in get_waiting_list
    value = get_attribute_value(self.instance, field, self.context, force=force, skip_autofield=skip_autofield)
  File "…/django_extensions/management/commands/dumpscript.py", line 697, in get_attribute_value
    item_locator = orm_item_locator(value)
  File "…/django_extensions/management/commands/dumpscript.py", line 77, in orm_item_locator
    clean_dict[key] = str("%s" % v)
TypeError: not all arguments converted during string formatting
```