### PR TITLE
Replace requires_system_checks False values with []

### DIFF
--- a/django_extensions/management/commands/clean_pyc.py
+++ b/django_extensions/management/commands/clean_pyc.py
@@ -12,7 +12,7 @@ from django_extensions.management.utils import signalcommand
 class Command(BaseCommand):
     help = "Removes all python bytecode compiled files from the project."
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django_extensions/management/commands/compile_pyc.py
+++ b/django_extensions/management/commands/compile_pyc.py
@@ -12,7 +12,7 @@ from django_extensions.management.utils import signalcommand
 
 class Command(BaseCommand):
     help = "Compile python bytecode files for the project."
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         parser.add_argument('--path', '-p', action='store', dest='path',

--- a/django_extensions/management/commands/create_command.py
+++ b/django_extensions/management/commands/create_command.py
@@ -12,7 +12,7 @@ from django_extensions.management.utils import _make_writeable, signalcommand
 class Command(AppCommand):
     help = "Creates a Django management command directory structure for the given app name in the app's directory."
 
-    requires_system_checks = False
+    requires_system_checks = []
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/create_jobs.py
+++ b/django_extensions/management/commands/create_jobs.py
@@ -12,7 +12,7 @@ from django_extensions.management.utils import _make_writeable, signalcommand
 class Command(AppCommand):
     help = "Creates a Django jobs command directory structure for the given app name in the current directory."
 
-    requires_system_checks = False
+    requires_system_checks = []
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/create_template_tags.py
+++ b/django_extensions/management/commands/create_template_tags.py
@@ -21,7 +21,7 @@ class Command(AppCommand):
             help='The name to use for the template tag base name. Defaults to `appname`_tags.'
         )
 
-    requires_system_checks = False
+    requires_system_checks = []
     # Can't import settings during this command, because they haven't
     # necessarily been created.
     can_import_settings = True

--- a/django_extensions/management/commands/generate_password.py
+++ b/django_extensions/management/commands/generate_password.py
@@ -10,7 +10,7 @@ from django_extensions.management.utils import signalcommand
 class Command(BaseCommand):
     help = "Generates a new password that can be used for a user password. This uses Django core's default password generator `BaseUserManager.make_random_password()`."
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django_extensions/management/commands/generate_secret_key.py
+++ b/django_extensions/management/commands/generate_secret_key.py
@@ -8,7 +8,7 @@ from django_extensions.management.utils import signalcommand
 class Command(BaseCommand):
     help = "Generates a new SECRET_KEY that can be used in a project settings file."
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     @signalcommand
     def handle(self, *args, **options):

--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
     help = "Starts a test mail server for development."
     args = '[optional port number or ippaddr:port]'
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -128,7 +128,7 @@ class Command(BaseCommand):
     help = "Starts a lightweight Web server for development."
 
     # Validation is called explicitly each time the server is reloaded.
-    requires_system_checks = False
+    requires_system_checks = []
     DEFAULT_CRT_EXTENSION = ".crt"
     DEFAULT_KEY_EXTENSION = ".key"
 

--- a/django_extensions/management/commands/set_fake_emails.py
+++ b/django_extensions/management/commands/set_fake_emails.py
@@ -19,7 +19,7 @@ DEFAULT_FAKE_EMAIL = '%(username)s@example.com'
 
 class Command(BaseCommand):
     help = '''DEBUG only: give all users a new email based on their account data ("%s" by default). Possible parameters are: username, first_name, last_name''' % (DEFAULT_FAKE_EMAIL, )
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/django_extensions/management/commands/set_fake_passwords.py
+++ b/django_extensions/management/commands/set_fake_passwords.py
@@ -18,7 +18,7 @@ DEFAULT_FAKE_PASSWORD = 'password'
 
 class Command(BaseCommand):
     help = 'DEBUG only: sets all user passwords to a common value ("%s" by default)' % (DEFAULT_FAKE_PASSWORD, )
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -19,7 +19,7 @@ The envisioned use case is something like this:
     ./manage.py sqlcreate [--database=<databasename>] | mysql -u <db_administrator> -p
     ./manage.py sqlcreate [--database=<databasname>] | psql -U <db_administrator> -W"""
 
-    requires_system_checks = False
+    requires_system_checks = []
     can_import_settings = True
 
     def add_arguments(self, parser):

--- a/django_extensions/management/commands/sqldsn.py
+++ b/django_extensions/management/commands/sqldsn.py
@@ -84,7 +84,7 @@ _FORMATTERS = [
 
 class Command(BaseCommand):
     help = "Prints DSN on stdout, as specified in settings.py"
-    requires_system_checks = False
+    requires_system_checks = []
     can_import_settings = True
 
     def add_arguments(self, parser):


### PR DESCRIPTION
Support for boolean values for `requires_system_checks` was [removed in Django 4.1](https://docs.djangoproject.com/en/4.1/releases/4.1/#features-removed-in-4-1) (and deprecated since 3.2 so safe to replace).

The replacement for `False` is `[]`: https://github.com/django/django/commit/c60524c658f197f645b638f9bcc553103bfe2630