### PR TITLE
Add a py.typed file to export type annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ for dirpath, dirnames, filenames in os.walk(extensions_dir):
         path = os.path.join(*relative_path)
         package_files = package_data.setdefault('.'.join(parts), [])
         package_files.extend([os.path.join(path, f) for f in filenames])
+package_data['django_extensions'].append('py.typed')
 
 
 version = __import__('django_extensions').__version__


### PR DESCRIPTION
In order for any of the type annotations used within django-extensions to be available to downstream users, PEP-561 requires that an empty `py.typed` marker file be present as package data. For more details, see:
https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/

This allows downstream users to have type checking when directly using any Python APIs which happen to have type annotations.

More importantly, it allows Django and DRF mixin classes (like `ModelUserFieldPermissionMixin`) and subclasses (like `TimeStampedModel`) to inherit type information if type stub packages for Django or DRF are in use.