### PR TITLE
docs: Fix a few typos

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -642,7 +642,7 @@ class SQLDiff:
                 transaction.rollback()  # reset transaction
                 continue
 
-            # map table_contraints into table_indexes
+            # map table_constraints into table_indexes
             table_indexes = {}
             for contraint_name, dct in table_constraints.items():
 
@@ -1192,7 +1192,7 @@ class PostgresqlSQLDiff(SQLDiff):
                 #       constraints for the type in `get_data_type_arrayfield` which instantiates
                 #       the array base_field or maybe even better restructure sqldiff entirely
                 #       to be based around the concrete type yielded by the code below. That gives
-                #       the complete type the database uses, why not use thie much earlier in the
+                #       the complete type the database uses, why not use this much earlier in the
                 #       process to compare to whatever django spits out as the desired database type ?
                 attname = field.db_column or field.attname
                 introspect_db_type = self.sql_to_dict(

--- a/django_extensions/mongodb/fields/__init__.py
+++ b/django_extensions/mongodb/fields/__init__.py
@@ -125,7 +125,7 @@ class AutoSlugField(SlugField):
         if model_instance.pk:
             queryset = queryset.exclude(pk=model_instance.pk)
 
-        # form a kwarg dict used to impliment any unique_together contraints
+        # form a kwarg dict used to impliment any unique_together constraints
         kwargs = {}
         for params in model_instance._meta.unique_together:
             if self.attname in params:

--- a/django_extensions/templatetags/syntax_color.py
+++ b/django_extensions/templatetags/syntax_color.py
@@ -21,7 +21,7 @@ less efficient compared to specifying the lexer to use.
 
     {{ code_string|colorize }}
 
-You may also render the syntax highlighed text with line numbers.
+You may also render the syntax highlighted text with line numbers.
 
     {% load syntax_color %}
     {{ some_code|colorize_table:"html+django" }}


### PR DESCRIPTION
There are small typos in:
- django_extensions/management/commands/sqldiff.py
- django_extensions/mongodb/fields/__init__.py
- django_extensions/templatetags/syntax_color.py

Fixes:
- Should read `constraints` rather than `contraints`.
- Should read `this` rather than `thie`.
- Should read `highlighted` rather than `highlighed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md