### PR TITLE
Add REMOTE_USER to werkzeug environment

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -326,6 +326,9 @@ class Command(BaseCommand):
                 environ = super().make_environ()
                 if not options['keep_meta_shutdown_func'] and 'werkzeug.server.shutdown' in environ:
                     del environ['werkzeug.server.shutdown']
+                remote_user = os.getenv('REMOTE_USER')
+                if remote_user is not None:
+                    environ['REMOTE_USER'] = remote_user
                 return environ
 
         threaded = options['threaded']


### PR DESCRIPTION
Django RemoteUserMiddleware and RemoteUserBackend are able to authenticate users by looking at the REMOTE_USER request header.

In Werkzeug, this header isn't set unlike in Django's default WSGI server.

This patch add the variable to the Werkzeug environ if it's set.

Fixes #1708