### PR TITLE
Import pkg_resources directly 

### DIFF
--- a/django_extensions/management/commands/pipchecker.py
+++ b/django_extensions/management/commands/pipchecker.py
@@ -39,20 +39,16 @@ try:
             """Return a list of installed Distribution objects.
             Left for compatibility until direct pkg_resources uses are refactored out.
             """
-            from pip._internal.metadata import get_default_environment, get_environment
-            from pip._internal.metadata.pkg_resources import Distribution as _Dist
 
-            if paths is None:
-                env = get_default_environment()
-            else:
-                env = get_environment(paths)
-            dists = env.iter_installed_distributions(
+            from pip._internal.metadata import pkg_resources
+
+            dists = pkg_resources.Environment.from_paths(paths).iter_installed_distributions(
                 local_only=local_only,
                 include_editables=include_editables,
                 editables_only=editables_only,
                 user_only=user_only,
             )
-            return [cast(_Dist, dist)._dist for dist in dists]
+            return [cast(pkg_resources.Distribution, dist)._dist for dist in dists]
 except ImportError:
     # pip < 10
     try:


### PR DESCRIPTION
pipdeptree encountered the same issue as pipchecker #1778 / https://github.com/tox-dev/pipdeptree/issues/164 

They solved the issue in https://github.com/tox-dev/pipdeptree/pull/173 

For `pipchecker` and python 3.11 this solution is also sufficient.  

`pip._internal.metadata.select_backend` decides if it should use `importlib` or pips internal `pkg_resources`. By importing `pkg_resources` directly `importlib` is of the table and the attribute `project_name` is always available. 