### PR TITLE
ModelUserFieldPermissionMixin: fix error in checking for the right user of an edited model instance

### DIFF
--- a/django_extensions/auth/mixins.py
+++ b/django_extensions/auth/mixins.py
@@ -12,4 +12,4 @@ class ModelUserFieldPermissionMixin(UserPassesTestMixin):
         model_attr = self.get_model_permission_user_field()
         current_user = self.request.user
 
-        return current_user == getattr(self.get_queryset().first(), model_attr)
+        return current_user == getattr(self.get_object(), model_attr)

--- a/tests/auth/test_mixins.py
+++ b/tests/auth/test_mixins.py
@@ -29,19 +29,30 @@ class ModelUserFieldPermissionMixinTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = cls.User.objects.create(username="Joe", password="pass")
+        cls.second_user = cls.User.objects.create(username="Jen",
+                                                  password="pass")
         cls.ownerModel = HasOwnerModel.objects.create(owner=cls.user)
+        cls.second_ownerModel = HasOwnerModel.objects.create(
+            owner=cls.second_user)
 
     # Test if owner model has access
     def test_permission_pass(self):
-        request = self.factory.get('/permission-required/' + str(self.ownerModel.id))
+        request = self.factory.get('/permission-required/')
         request.user = self.user
-        resp = OwnerView.as_view()(request)
+        resp = OwnerView.as_view()(request, pk=self.ownerModel.id)
         self.assertEqual(resp.status_code, 200)
 
-    # # Test if non owner model is redirected
-    def test_permission_denied_and_redirect(self):
-        request = self.factory.get('/permission-required/' + str(self.ownerModel.id))
+    # # Test if anonymous user is redirected to login page
+    def test_anonymous_redirect_to_login(self):
+        request = self.factory.get('/permission-required/')
         request.user = AnonymousUser()
-        resp = OwnerView.as_view()(request)
-        self.assertRaises(PermissionDenied)
+        resp = OwnerView.as_view()(request, pk=self.ownerModel.id)
         self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url,
+                         "/accounts/login/?next=/permission-required/")
+
+    def test_permission_denied(self):
+        request = self.factory.get('/permission-required/', follow=True)
+        request.user = self.user
+        with self.assertRaises(PermissionDenied):
+            OwnerView.as_view()(request, pk=self.second_ownerModel.id)


### PR DESCRIPTION
The mixin so far test for the right user against the first entry of Model.objects.all(). This entry has, most of the time, nothing to do with the actual entry (to edit/update/delete). Now the mixin tests the actual user against the user of the actual model instance given by pk or slug.
Fix tests accordingly. Until now, the tests for the mixin confirm the produced results (anonymous user) and test not the real expectation (second user can't get data of the first user).