### PR TITLE
Fix error with lack of PosixPath support

### DIFF
--- a/django_extensions/import_subclasses.py
+++ b/django_extensions/import_subclasses.py
@@ -39,7 +39,7 @@ class SubclassesFinder:
         but in future functionality of aliasing subclasses can be added.
         """
         result = {}  # type: Dict[str, List[Tuple[str, str]]]
-        for loader, module_name, is_pkg in walk_packages(path=[settings.BASE_DIR]):
+        for loader, module_name, is_pkg in walk_packages(path=[str(settings.BASE_DIR)]):
             subclasses_from_module = self._collect_classes_from_module(module_name)
             if subclasses_from_module:
                 result[module_name] = subclasses_from_module


### PR DESCRIPTION
Current Django sets `settings.BASE_DIR` to a `PosixPath` object by default.

Python stdlib `pkgutil` and `importlib` do not yet support using `PosixPath` values, at least as of `3.10.9`.

If the `SHELL_PLUS_SUBCLASSES_IMPORT` value is set under these conditions, attempting to launch `shell_plus` will result in an error:
```
AttributeError: 'PosixPath' object has no attribute 'startswith'
```