### PR TITLE
Allow list_model_info with to target multiple --models from the commandline

### DIFF
--- a/django_extensions/management/commands/list_model_info.py
+++ b/django_extensions/management/commands/list_model_info.py
@@ -27,11 +27,11 @@ class Command(BaseCommand):
             "--all-methods", action="store_true", default=None, help="list all methods, including private and default."
         )
         parser.add_argument(
-            "--model",
+            "--models",
             nargs="?",
             type=str,
             default=None,
-            help="list the details for a single model. Input should be in the form appname.Modelname",
+            help="list the details for specific models. Input should be in the form appname.Modelname, separated by a comma",
         )
 
     def list_model_info(self, options):
@@ -51,10 +51,10 @@ class Command(BaseCommand):
         ALL_METHODS = (
             True if options.get("all_methods", None) is not None else getattr(settings, "MODEL_INFO_ALL_METHODS", False)
         )
-        MODEL = (
-            options.get("model")
-            if options.get("model", None) is not None
-            else getattr(settings, "MODEL_INFO_MODEL", False)
+        MODELS = (
+            options.get("models")
+            if options.get("models", None) is not None
+            else getattr(settings, "MODEL_INFO_MODELS", False)
         )
 
         default_methods = [
@@ -76,8 +76,8 @@ class Command(BaseCommand):
             "validate_unique",
         ]
 
-        if MODEL:
-            model_list = [django_apps.get_model(MODEL)]
+        if MODELS:
+            model_list = [django_apps.get_model(x) for x in MODELS.split(",")]
         else:
             model_list = sorted(
                 django_apps.get_models(), key=lambda x: (x._meta.app_label, x._meta.object_name), reverse=False

--- a/docs/list_model_info.rst
+++ b/docs/list_model_info.rst
@@ -44,8 +44,8 @@ You can configure the output in a number of ways.
 
 ::
 
-  # Output only information for a single model, specifying the app and model using dot notation
-  $ ./manage.py list_model_info --model users.User
+  # Output only information for specific models, specifying the app and model using dot notation. Separate with a comma when targetting multiple models:
+  $ ./manage.py list_model_info --models users.User,appname.ModelName
 
 
 You can combine arguments. for instance, to list all methods and show the method signatures for the User model within the users app::


### PR DESCRIPTION
I wanted to output the `list_model_info` for some of our models (we have hundreds), but currently can a) either output **all of them** or b) call the command **once per** `--model`. I found that non-intuitive and would much prefer to be able to specify the desired models in a single command.

This PR changes `list_model_info --model app.Model` to `list_model_info --models app1.Model1,app2.Model2,app3.Model3`.

Since Django's management commands use [argparse with a forgiving CLI option config](https://docs.python.org/3/library/argparse.html#allow-abbrev), the old `--model` option will still work the exact same way as before (as it will match to the new --models), thus the change is backwards compatible.

Maybe it's worth thinking about something like this? The API could be different (e.g. support using `--model` more than once, or an extra option).