### PR TITLE
runserver_plus autoreload on template change

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -16,7 +16,7 @@ from django.core.management.base import BaseCommand, CommandError, SystemCheckEr
 from django.core.management.color import color_style
 from django.core.servers.basehttp import get_internal_wsgi_application
 from django.dispatch import Signal
-from django.template.autoreload import get_template_directories
+from django.template.autoreload import get_template_directories, reset_loaders
 from django.utils.autoreload import file_changed, get_reloader
 from django.views import debug as django_views_debug
 
@@ -78,8 +78,7 @@ logger = logging.getLogger(__name__)
 _error_files = set()  # type: Set[str]
 
 
-def get_all_templates() -> Set[str]:
-
+def get_all_template_files() -> Set[str]:
     template_list = set()
 
     for template_dir in get_template_directories():
@@ -95,12 +94,27 @@ if HAS_WERKZEUG:
     for name, reloader_loop_klass in _reloader.reloader_loops.items():
         class WrappedReloaderLoop(reloader_loop_klass):  # type: ignore
             def __init__(self, *args, **kwargs):
+                self._template_files: Set[str] = get_all_template_files()
                 super().__init__(*args, **kwargs)
                 self._extra_files = self.extra_files
 
             @property
             def extra_files(self):
-                return self._extra_files.union(_error_files, get_all_templates())
+                template_files = get_all_template_files()
+
+                # reset loaders if there are new files detected
+                if len(self._template_files) != len(template_files):
+
+                    changed = template_files.difference(self._template_files)
+                    for filename in changed:
+                        _log("info", f" * New file {filename} added, reset template loaders")
+                        self.register_file_changed(filename)
+
+                    reset_loaders()
+
+                self._template_files = template_files
+
+                return self._extra_files.union(_error_files, template_files)
 
             @extra_files.setter
             def extra_files(self, extra_files):
@@ -111,6 +125,14 @@ if HAS_WERKZEUG:
                 results = file_changed.send(sender=self, file_path=path)
                 if not any(res[1] for res in results):
                     super().trigger_reload(filename)
+                else:
+                    _log("info", f" * Detected change in {filename!r}, reset template loaders")
+                    self.register_file_changed(filename)
+
+            def register_file_changed(self, filename):
+                if hasattr(self, "mtimes"):
+                    mtime = os.stat(filename).st_mtime
+                    self.mtimes[filename] = mtime
 
         _reloader.reloader_loops[name] = WrappedReloaderLoop
 


### PR DESCRIPTION
This pull-request is the second attempt (see #1775 for details) to get the correct behavior for reloading of the development server. 

The `watchdog` reloader did accept the *.html wildcard pattern but the `stat` reloader isn't. 

Therefore this pull-request adds an list of all files inside all template directories to `extra_files`. Even non .html files inside the template directories are triggering a reload since it can occur other extensions are used for templates like .css & .js. New files added to the template directory also trigger a reload since this is the same behavior as `runserver`. 

Thanks to @bmihelac for providing feedback to my first attempt. 