### PR TITLE
fix: test_should_highlight_bash_syntax_without_name to include whites…

### DIFF
--- a/tests/templatetags/test_highlighting.py
+++ b/tests/templatetags/test_highlighting.py
@@ -44,7 +44,7 @@ def need_food(self):
 {% highlight 'bash' %}
 echo "Hello $1"
 {% endhighlight %}"""
-        expected_result = '''<div class="highlight"><pre><span></span><span class="nb">echo</span> <span class="s2">&quot;Hello </span><span class="nv">$1</span><span class="s2">&quot;</span>
+        expected_result = '''<div class="highlight"><pre><span></span><span class="nb">echo</span><span class="w"> </span><span class="s2">&quot;Hello </span><span class="nv">$1</span><span class="s2">&quot;</span>
 </pre></div>'''
 
         result = Template(content).render(self.ctx)


### PR DESCRIPTION
Pygments 2.14 has some impact on the output of the highlight method (https://github.com/pygments/pygments/pull/2304). This pull requests updates the tests according to the new output. 

Fixes #1795. 