### PR TITLE
Handle exessively long help text for jobs.

### DIFF
--- a/django_extensions/management/commands/runjob.py
+++ b/django_extensions/management/commands/runjob.py
@@ -53,6 +53,6 @@ class Command(BaseCommand):
         setup_logger(logger, self.stdout)
 
         if options['list_jobs']:
-            print_jobs(only_scheduled=False, show_when=True, show_appname=True)
+            print_jobs(only_scheduled=False, show_when=True, show_appname=True, verbose=options['verbosity'] >= 2)
         else:
             self.runjob(app_name, job_name, options)

--- a/django_extensions/management/jobs.py
+++ b/django_extensions/management/jobs.py
@@ -152,10 +152,10 @@ def get_job(app_name, job_name):
 
 def format_help_text(txt: str, digest: bool=False, maxwidth: int=80) -> str:
     """Return the help text properly formatted."""
-    if digest:
-        return textwrap.shorten(txt, maxwidth)
     paragraphs = txt.split('\n\n')
-    return '\n\n'.join(textwrap.fill(textwrap.dedent(p), width=maxwidth) for p in paragraphs)
+    if digest:
+        return textwrap.shorten(paragraphs[0], maxwidth)
+    return '\n\n'.join(textwrap.dedent(p).replace('\n', ' ') for p in paragraphs)
 
 
 def print_jobs(when=None, only_scheduled=False, show_when=True, show_appname=False, show_header=True, verbose=False):

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,10 @@ setup(
     cmdclass=cmdclasses,
     package_data=package_data,
     python_requires=">=3.6",
-    install_requires=["Django>=3.2"],
+    install_requires=[
+        "Django>=3.2",
+        "rich"
+    ],
     extras_require={},
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/management/commands/test_runjob.py
+++ b/tests/management/commands/test_runjob.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import sys
+stdout = sys.stdout
 from io import StringIO
 
 from django.core.management import call_command
@@ -32,7 +33,7 @@ class RunJobTests(TestCase):
 
     def test_list_jobs(self):
         call_command('runjob', '-l', verbosity=2)
-        self.assertRegex(sys.stdout.getvalue(), "tests.testapp +- sample_job +- +- My sample job.\n")
+        self.assertRegex(sys.stdout.getvalue(), r"tests.testapp[^\w]+sample_job[^\w]+My sample job.")
 
     def test_list_jobs_appconfig(self):
         with self.modify_settings(INSTALLED_APPS={
@@ -40,7 +41,7 @@ class RunJobTests(TestCase):
             'remove': 'tests.testapp',
         }):
             call_command('runjob', '-l', verbosity=2)
-            self.assertRegex(sys.stdout.getvalue(), "tests.testapp +- sample_job +- +- My sample job.\n")
+            self.assertRegex(sys.stdout.getvalue(), r"tests.testapp[^\w]+sample_job[^\w]+My sample job.")
 
     def test_runs_appconfig(self):
         with self.modify_settings(INSTALLED_APPS={

--- a/tests/management/commands/test_runjob.py
+++ b/tests/management/commands/test_runjob.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import sys
-stdout = sys.stdout
 from io import StringIO
 
 from django.core.management import call_command


### PR DESCRIPTION
Currently, long (especially multi-line) text in the `help = ` property of `Job` classes mess up the job listings (`manage.py runjob -l`):
```
 bizautuser        - bizautuser_process_transfer_request     - daily          - Remind BAs to process pending transfer requests after 3 days,
                or notify finaut after 5 days. Also processes queued requests.
 finlib            - run_rules_action_pnr                    - quarter_hourly - Process results that are awaiting in QM-db
 gos               - sample                                  -                - My sample job.
```
this PR, by default, extracts an 80 character digest and uses the `rich` library to output the listing as a table:
```
Job List: 47 jobs
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ appname           ┃ jobname                                 ┃ when           ┃ help                                                        ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ bizautuser        │ bizautuser_process_transfer_request     │ daily          │ Remind BAs to process pending transfer requests after 3     │
│                   │                                         │                │ days, or notify [...]                                       │
│ finlib            │ run_rules_action_pnr                    │ quarter_hourly │ Process results that are awaiting in QM-db                  │
│ gos               │ sample                                  │                │ My sample job.                                              │
└───────────────────┴─────────────────────────────────────────┴────────────────┴─────────────────────────────────────────────────────────────┘
```
or, if verbosity is set to 2 or higher (`manage.py runjob -l -v2`) outputs the entire help text, but formatted a little better:
```
Job List: 47 jobs
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ appname           ┃ jobname                                 ┃ when           ┃ help                                                              ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ bizautrules       │ advisors_missing_updates                │ daily          │ Find all users who is missing goals according to their            │
│                   │                                         │                │ competencyplan where the deadline has passed for at least one of  │
│                   │                                         │                │ the goals. Add these users to a list that the BA's has access to  │
│                   │                                         │                │ where the BA can select them all to set them to 'hvilende' in the │
│                   │                                         │                │ authorization scheme where the goal is missing.                   │
│                   │                                         │                │                                                                   │
│                   │                                         │                │ For users who are not authorized, but has taken an exam but has   │
│                   │                                         │                │ not updated the competency of that exam, the rules needs to be    │
│                   │                                         │                │ rerun. The reason for this is that the rules will have to say     │
│                   │                                         │                │ that a module is not ok if the competency is not updated.         │
│ bizautrules       │ rerunrules                              │ daily          │ Re-run the rules in table ReRunRules that are due to run today.   │
└───────────────────┴─────────────────────────────────────────┴────────────────┴───────────────────────────────────────────────────────────────────┘
```
As an added feature, `rich` will render any console markup (https://rich.readthedocs.io/en/latest/markup.html) present in the help text.
