### PR TITLE
Run tests againts Django 4.2 and add trove classifier

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,6 +24,7 @@ jobs:
           - "32"
           - "40"
           - "41"
+          - "42"
           # GH Actions don't support something like allow-failure ?
           # - "master"
         exclude:
@@ -37,6 +38,12 @@ jobs:
             tox-django-version: "41"
           - python-version: "pypy3.9"
             tox-django-version: "41"
+          - python-version: "3.6"
+            tox-django-version: "42"
+          - python-version: "3.7"
+            tox-django-version: "42"
+          - python-version: "pypy3.9"
+            tox-django-version: "42"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests/templatetags/test_highlighting.py
+++ b/tests/templatetags/test_highlighting.py
@@ -44,7 +44,7 @@ def need_food(self):
 {% highlight 'bash' %}
 echo "Hello $1"
 {% endhighlight %}"""
-        expected_result = '''<div class="highlight"><pre><span></span><span class="nb">echo</span> <span class="s2">&quot;Hello </span><span class="nv">$1</span><span class="s2">&quot;</span>
+        expected_result = '''<div class="highlight"><pre><span></span><span class="nb">echo</span><span class="w"> </span><span class="s2">&quot;Hello </span><span class="nv">$1</span><span class="s2">&quot;</span>
 </pre></div>'''
 
         result = Template(content).render(self.ctx)

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,16 @@ envlist =
     {py36,py37,py38,py39,py310,pypy}-dj32
     {py38,py39,py310,pypy}-dj40
     {py38,py39,py310,py311,pypy}-dj41
+    {py38,py39,py310,py311,pypy}-dj42
     {py38,py39,py310,pypy}-djmaster
     py310-dj32-postgres
     py310-dj40-postgres
     py310-dj41-postgres
+    py310-dj42-postgres
     py310-dj32-mysql
     py310-dj40-mysql
     py310-dj41-mysql
+    py310-dj42-mysql
     py310-djmaster-postgres
 
 [testenv]
@@ -44,6 +47,7 @@ deps =
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<5.0
     djmaster: https://github.com/django/django/archive/refs/heads/main.zip
     postgres: psycopg2-binary
     mysql: mysqlclient


### PR DESCRIPTION
Had to include the commit from django-extensions/django-extensions#1797 (update tests for Pygments 2.14 compatibility) for the tests to pass