### PR TITLE
Add support for psycopg3

### DIFF
--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import importlib.util
 from itertools import count
 import os
 import logging
@@ -167,7 +168,11 @@ Type 'yes' to continue, or 'no' to cancel: """.format(db_name=database_name))
                 cursor.execute(drop_query)
 
         elif engine in POSTGRESQL_ENGINES:
-            import psycopg2 as Database  # NOQA
+            has_psycopg3 = importlib.util.find_spec("psycopg")
+            if has_psycopg3:
+                import psycopg as Database  # NOQA
+            else:
+                import psycopg2 as Database  # NOQA
 
             conn_params = {'database': 'template1'}
             if user:

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -4,6 +4,7 @@ reset_db command
 
 originally from http://www.djangosnippets.org/snippets/828/ by dnordberg
 """
+import importlib.util
 import os
 import logging
 import warnings
@@ -141,7 +142,11 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             logging.info('Executing... "%s"', create_query)
             connection.query(create_query.strip())
         elif engine in POSTGRESQL_ENGINES:
-            import psycopg2 as Database  # NOQA
+            has_psycopg3 = importlib.util.find_spec("psycopg")
+            if has_psycopg3:
+                import psycopg as Database  # NOQA
+            else:
+                import psycopg2 as Database  # NOQA
 
             conn_params = {'database': 'template1'}
             if user:

--- a/docs/sqldsn.rst
+++ b/docs/sqldsn.rst
@@ -10,7 +10,7 @@ Supported Databases
 
 Currently the following databases are supported:
 
-* PostgreSQL (psycopg2 or postgis)
+* PostgreSQL (psycopg2, psycopg3, or postgis)
 * Sqlite3
 * MySQL
 

--- a/tests/management/commands/test_drop_test_database.py
+++ b/tests/management/commands/test_drop_test_database.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import importlib.util
 from io import StringIO
 from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 
@@ -251,7 +252,11 @@ class DropTestDatabaseTests(TestCase):
         # Indicate that no clone databases exist
         type(m_cursor).rowcount = PropertyMock(side_effect=(1, 0))
 
-        with patch.dict("sys.modules", psycopg2=m_database):
+        mock_kwargs = {"psycopg2": m_database}
+        has_psycopg3 = importlib.util.find_spec("psycopg") is not None
+        if has_psycopg3:
+            mock_kwargs = {"psycopg": m_database}
+        with patch.dict("sys.modules", **mock_kwargs):
             call_command('drop_test_database', '--noinput', verbosity=2)
 
         with self.subTest('Should check for and remove test database names until failure'):
@@ -277,7 +282,11 @@ class DropTestDatabaseTests(TestCase):
         # Indicate that clone databases exist up to test_test_2
         type(m_cursor).rowcount = PropertyMock(side_effect=(1, 1, 1, 0))
 
-        with patch.dict("sys.modules", psycopg2=m_database):
+        mock_kwargs = {"psycopg2": m_database}
+        has_psycopg3 = importlib.util.find_spec("psycopg") is not None
+        if has_psycopg3:
+            mock_kwargs = {"psycopg": m_database}
+        with patch.dict("sys.modules", **mock_kwargs):
             call_command('drop_test_database', '--noinput')
 
         exists_query = "SELECT datname FROM pg_catalog.pg_database WHERE datname="
@@ -303,7 +312,11 @@ class DropTestDatabaseTests(TestCase):
         m_cursor.execute.side_effect = m_database.ProgrammingError
         m_database.connect.return_value.cursor.return_value = m_cursor
 
-        with patch.dict("sys.modules", psycopg2=m_database):
+        mock_kwargs = {"psycopg2": m_database}
+        has_psycopg3 = importlib.util.find_spec("psycopg") is not None
+        if has_psycopg3:
+            mock_kwargs = {"psycopg": m_database}
+        with patch.dict("sys.modules", **mock_kwargs):
             call_command('drop_test_database', '--noinput', verbosity=2)
 
         self.assertNotIn("Reset successful.", m_stdout.getvalue())

--- a/tests/management/commands/test_pipchecker.py
+++ b/tests/management/commands/test_pipchecker.py
@@ -140,6 +140,7 @@ class PipCheckerTests(TestCase):
         f.write('Pillow')
         f.write('pluggy')
         f.write('psycopg2-binary')
+        f.write('psycopg[binary,pool]')
         f.write('py')
         f.write('pyparsing')
         f.write('pytest')

--- a/tests/management/commands/test_reset_db.py
+++ b/tests/management/commands/test_reset_db.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import importlib.util
 import os
 from io import StringIO
 
@@ -166,7 +167,11 @@ class ResetDbPostgresqlTests(TestCase):
             mock.call('CREATE DATABASE "test_db" WITH OWNER = "foo"  ENCODING = \'UTF8\';'),
         ]
 
-        with mock.patch.dict("sys.modules", psycopg2=m_database):
+        mock_kwargs = {"psycopg2": m_database}
+        has_psycopg3 = importlib.util.find_spec("psycopg") is not None
+        if has_psycopg3:
+            mock_kwargs = {"psycopg": m_database}
+        with mock.patch.dict("sys.modules", **mock_kwargs):
             call_command('reset_db', '--noinput', verbosity=2)
 
         m_database.connect.assert_called_once_with(database='template1', host='127.0.0.1', password='bar', port='5432', user='foo')
@@ -186,7 +191,11 @@ class ResetDbPostgresqlTests(TestCase):
             mock.call('CREATE DATABASE "test_db" WITH OWNER = "foo"  ENCODING = \'UTF8\' TABLESPACE = TEST_TABLESPACE;'),
         ]
 
-        with mock.patch.dict("sys.modules", psycopg2=m_database):
+        mock_kwargs = {"psycopg2": m_database}
+        has_psycopg3 = importlib.util.find_spec("psycopg") is not None
+        if has_psycopg3:
+            mock_kwargs = {"psycopg": m_database}
+        with mock.patch.dict("sys.modules", **mock_kwargs):
             call_command('reset_db', '--noinput', '--close-sessions', verbosity=2)
 
         m_database.connect.assert_called_once_with(database='template1', host='127.0.0.1', password='bar', port='5432', user='foo')

--- a/tox.ini
+++ b/tox.ini
@@ -18,11 +18,13 @@ envlist =
     py310-dj40-postgres
     py310-dj41-postgres
     py310-dj42-postgres
+    py310-dj42-postgres3
     py310-dj32-mysql
     py310-dj40-mysql
     py310-dj41-mysql
     py310-dj42-mysql
     py310-djmaster-postgres
+    py310-djmaster-postgres3
 
 [testenv]
 commands = make test
@@ -38,6 +40,8 @@ passenv =
 setenv =
     postgres: DJANGO_EXTENSIONS_DATABASE_ENGINE = {env:DJANGO_EXTENSIONS_DATABASE_ENGINE:django.db.backends.postgresql}
     postgres: DJANGO_EXTENSIONS_DATABASE_NAME = {env:DJANGO_EXTENSIONS_DATABASE_NAME:django_extensions_test}
+    postgres3: DJANGO_EXTENSIONS_DATABASE_ENGINE = {env:DJANGO_EXTENSIONS_DATABASE_ENGINE:django.db.backends.postgresql}
+    postgres3: DJANGO_EXTENSIONS_DATABASE_NAME = {env:DJANGO_EXTENSIONS_DATABASE_NAME:django_extensions_test}
     mysql: DJANGO_EXTENSIONS_DATABASE_ENGINE = {env:DJANGO_EXTENSIONS_DATABASE_ENGINE:django.db.backends.mysql}
     mysql: DJANGO_EXTENSIONS_DATABASE_NAME = {env:DJANGO_EXTENSIONS_DATABASE_NAME:django_extensions_test}
 
@@ -50,6 +54,7 @@ deps =
     dj42: Django>=4.2,<5.0
     djmaster: https://github.com/django/django/archive/refs/heads/main.zip
     postgres: psycopg2-binary
+    postgres3: psycopg[binary,pool]
     mysql: mysqlclient
 
 [testenv:precommit]


### PR DESCRIPTION
Django now supports psycopg3. The reset_db and drop_test_database management commands both make calls directly to psycopg2. This means they will not work in a Django project based on psycopg3.

I've never worked on the django-extensions codebase before, so I imagine there is a lot that is wrong with this very simple and straightforward patch attempt. Nonetheless, something is better than nothing. My hope is that even a rejected PR will help this issue get resolved more quickly.

closes #1811