### PR TITLE
Fixed drop test database command with psycopg 3

### DIFF
--- a/django_extensions/management/commands/drop_test_database.py
+++ b/django_extensions/management/commands/drop_test_database.py
@@ -174,7 +174,7 @@ Type 'yes' to continue, or 'no' to cancel: """.format(db_name=database_name))
             else:
                 import psycopg2 as Database  # NOQA
 
-            conn_params = {'database': 'template1'}
+            conn_params = {'dbname': 'template1'}
             if user:
                 conn_params['user'] = user
             if password:
@@ -185,7 +185,10 @@ Type 'yes' to continue, or 'no' to cancel: """.format(db_name=database_name))
                 conn_params['port'] = database_port
 
             connection = Database.connect(**conn_params)
-            connection.set_isolation_level(0)  # autocommit false
+            if has_psycopg3:
+                connection.autocommit = True
+            else:
+                connection.set_isolation_level(0)  # autocommit false
             cursor = connection.cursor()
 
             for db_name in get_database_names('{}_{}'.format):


### PR DESCRIPTION
With the current main branch, when executing drop_test_databaes with only psycopg v3 installed, there is a trace, see below.
This PR fixes the command when psycopg v3 is installed. It is backwards compatible with psycopg2.

Traceback (most recent call last):
  File "/home/jannh/git/siam/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/django_extensions/management/utils.py", line 62, in inner
    ret = func(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/django_extensions/management/commands/drop_test_database.py", line 187, in handle
    connection = Database.connect(**conn_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/psycopg/connection.py", line 720, in connect
    conninfo = make_conninfo(**params)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/psycopg/conninfo.py", line 59, in make_conninfo
    _parse_conninfo(conninfo)
  File "/home/jannh/.virtualenvs/siam/lib/python3.11/site-packages/psycopg/conninfo.py", line 98, in _parse_conninfo
    raise e.ProgrammingError(str(ex))
psycopg.ProgrammingError: invalid connection option "database"