### PR TITLE
Update mail_debug command to use aiosmtpd

### DIFF
--- a/django_extensions/management/commands/mail_debug.py
+++ b/django_extensions/management/commands/mail_debug.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import asyncore
+import asyncio
 import sys
+from aiosmtpd.controller import Controller
 from logging import getLogger
-from smtpd import SMTPServer
 from typing import List
 
 from django.core.management.base import BaseCommand, CommandError
@@ -12,14 +12,12 @@ from django_extensions.management.utils import setup_logger, signalcommand
 logger = getLogger(__name__)
 
 
-class ExtensionDebuggingServer(SMTPServer):
-    """Duplication of smtpd.DebuggingServer, but using logging instead of print."""
-
-    # Do something with the gathered message
-    def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
+class CustomHandler:
+    async def handle_DATA(self, server, session, envelope):
         """Output will be sent to the module logger at INFO level."""
+        peer = session.peer
         inheaders = 1
-        lines = data.split('\n')
+        lines = envelope.content.decode('utf8', errors='replace').splitlines()
         logger.info('---------- MESSAGE FOLLOWS ----------')
         for line in lines:
             # headers first
@@ -28,6 +26,7 @@ class ExtensionDebuggingServer(SMTPServer):
                 inheaders = 0
             logger.info(line)
         logger.info('------------ END MESSAGE ------------')
+        return '250 OK'
 
 
 class Command(BaseCommand):
@@ -78,8 +77,11 @@ class Command(BaseCommand):
         def inner_run():
             quit_command = (sys.platform == 'win32') and 'CTRL-BREAK' or 'CONTROL-C'
             print("Now accepting mail at %s:%s -- use %s to quit" % (addr, port, quit_command))
-            ExtensionDebuggingServer((addr, port), None, decode_data=True)
-            asyncore.loop()
+            handler = CustomHandler()
+            controller = Controller(handler, hostname=addr, port=port)
+            controller.start()
+            loop = asyncio.get_event_loop()
+            loop.run_forever()
 
         try:
             inner_run()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ factory-boy
 requests
 pygments
 vobject
+aiosmtpd
 
 types-pyOpenSSL
 types-PyYAML

--- a/tests/management/commands/test_mail_debug.py
+++ b/tests/management/commands/test_mail_debug.py
@@ -4,6 +4,6 @@ from unittest import mock
 
 
 def test_initialize_mail_server():
-    with mock.patch('django_extensions.management.commands.mail_debug.asyncore.loop') as loop:
+    with mock.patch('django_extensions.management.commands.mail_debug.asyncio') as asyncio:
         call_command('mail_debug', '2525')
-        assert loop.called, 'asyncore.loop was not called'
+        assert asyncio.get_event_loop.called, 'asyncio.get_event_loop was not called'


### PR DESCRIPTION
Issue #1831

Python 3.12 dropped `asyncore` and `smtpd`

This adds a new dependency `aiosmtpd` from pypi. Should we add some kind of check and instructional message if the library is not found?