### PR TITLE
Add support for Django 5.0

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,6 +26,7 @@ jobs:
           - "40"
           - "41"
           - "42"
+          - "50"
           # GH Actions don't support something like allow-failure ?
           # - "master"
         exclude:
@@ -45,6 +46,12 @@ jobs:
             tox-django-version: "42"
           - python-version: "pypy3.9"
             tox-django-version: "42"
+          - python-version: "3.6"
+            tox-django-version: "50"
+          - python-version: "3.7"
+            tox-django-version: "50"
+          - python-version: "pypy3.9"
+            tox-django-version: "50"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog
 
 See https://github.com/django-extensions/django-extensions/releases
 
+
+Pending
+-------
+
+- Improvement: Add support for Django 5.0
+
+
 3.2.2
 -----
 

--- a/django_extensions/management/commands/list_signals.py
+++ b/django_extensions/management/commands/list_signals.py
@@ -44,7 +44,8 @@ class Command(BaseCommand):
         for signal in signals:
             signal_name = SIGNAL_NAMES.get(signal, 'unknown')
             for receiver in signal.receivers:
-                lookup, receiver = receiver
+                # TODO: Determine what to do with is_async for Django 5.0
+                lookup, receiver, is_async = receiver
                 if isinstance(receiver, weakref.ReferenceType):
                     receiver = receiver()
                 if receiver is None:

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests/management/commands/test_update_permissions.py
+++ b/tests/management/commands/test_update_permissions.py
@@ -36,8 +36,8 @@ class UpdatePermissionsTests(TestCase):
                      stdout=out, verbosity=3)
 
         sys.stdout = original_stdout
-        self.assertNotIn('django_extensions | perm model | Can add perm model', out.getvalue())
-        self.assertIn('testapp | test model | Can add test model', out.getvalue())
+        self.assertNotIn('Django Extensions | perm model | Can add perm model', out.getvalue())
+        self.assertIn('Testapp | test model | Can add test model', out.getvalue())
 
     def test_should_reload_permission_only_for_all_apps(self):
         original_stdout = sys.stdout
@@ -46,15 +46,15 @@ class UpdatePermissionsTests(TestCase):
         call_command('update_permissions', verbosity=3)
 
         sys.stdout = original_stdout
-        self.assertIn('django_extensions | perm model | Can add perm model', out.getvalue())
-        self.assertIn('testapp | test model | Can add test model', out.getvalue())
+        self.assertIn('Django Extensions | perm model | Can add perm model', out.getvalue())
+        self.assertIn('Testapp | test model | Can add test model', out.getvalue())
 
     def test_should_update_permission_if_name_changed(self):
         original_stdout = sys.stdout
         out = sys.stdout = StringIO()
 
         call_command('update_permissions', verbosity=3, create_only=True)
-        self.assertIn('testapp | test model | testapp_permission', out.getvalue())
+        self.assertIn('Testapp | test model | testapp_permission', out.getvalue())
 
         testapp_permission = Permission.objects.get(name="testapp_permission")
         testapp_permission.name = "testapp_permission_wrong"
@@ -63,4 +63,4 @@ class UpdatePermissionsTests(TestCase):
         call_command('update_permissions', verbosity=3, update_only=True)
 
         sys.stdout = original_stdout
-        self.assertIn("'testapp | test model | testapp_permission_wrong' to 'testapp | test model | testapp_permission'", out.getvalue())
+        self.assertIn("'Testapp | test model | testapp_permission_wrong' to 'Testapp | test model | testapp_permission'", out.getvalue())

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     {py38,py39,py310,pypy}-dj40
     {py38,py39,py310,py311,pypy}-dj41
     {py38,py39,py310,py311,pypy}-dj42
+    {py310,py311,pypy}-dj50
     {py38,py39,py310,pypy}-djmaster
     py310-dj32-postgres
     py310-dj40-postgres
@@ -52,6 +53,7 @@ deps =
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<5.0
+    dj50: Django==5.0a1,<5.1
     djmaster: https://github.com/django/django/archive/refs/heads/main.zip
     postgres: psycopg2-binary
     postgres3: psycopg[binary,pool]


### PR DESCRIPTION
This allows the test suite to pass. However this can't be merged as is. The command `list_signals` should probably be updated to include the `is_async` descriptor in its output somewhere. You can see how the `Signal.receivers` list of tuples was modified to include `is_async` here: https://github.com/django/django/blob/stable/5.0.x/django/dispatch/dispatcher.py#L116

If you want to make the change for `list_signals` on your own, I won't be offended. If you'd like me to make the change, I will try to make more time for it in the future.