### PR TITLE
Remove myself from contributors in modelviz.py

### DIFF
--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -45,7 +45,6 @@ __contributors__ = [
     "Mikkel Munch Mortensen <https://www.detfalskested.dk/>",
     "Andrzej Bistram <andrzej.bistram@gmail.com>",
     "Daniel Lipsitt <danlipsitt@gmail.com>",
-    "Tobias Mitterdorfer <tobias.mitterdorfer97@gmail.com>"
 ]
 
 


### PR DESCRIPTION
Hello,

So this is kind of awkward. I contributed a small PR 2 years ago: https://github.com/django-extensions/django-extensions/pull/1665 where I've added my full name and email to the list of contributors in [modelviz.py](https://github.com/django-extensions/django-extensions/blob/main/django_extensions/management/modelviz.py). Looking back, I’ve become more mindful about sharing my personal information online and would prefer to keep it private. I understand this is a minor change and that it is annoying to have a commit and PR just for this, but I would really appreciate it if we could update the contributors list to remove that specific entry.

Edit: Maybe someone can include this change into another PR that will be shipped anyway, then there is no need for a special commit just for this tiny change