### PR TITLE
FIX SETTINGS.PY  

### DIFF
--- a/django_extensions/settings.py
+++ b/django_extensions/settings.py
@@ -3,7 +3,13 @@ import os
 
 from django.conf import settings
 
-BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+TEMPLATES = [
+    {
+        # ...
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        # ...
+    },
+]
 REPLACEMENTS = getattr(settings, 'EXTENSIONS_REPLACEMENTS', {})
 
 DEFAULT_SQLITE_ENGINES = (

--- a/django_extensions/settings.py
+++ b/django_extensions/settings.py
@@ -5,9 +5,8 @@ from django.conf import settings
 
 TEMPLATES = [
     {
-        # ...
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
-        # ...
+        
     },
 ]
 REPLACEMENTS = getattr(settings, 'EXTENSIONS_REPLACEMENTS', {})


### PR DESCRIPTION
#1635 

To resolve the TemplateDoesNotExist error when using manage.py validate_templates in Django:

Place project-level templates in a 'templates' directory at the project root, and not within any specific app's directory.

Configure the 'DIRS' option in the TEMPLATES setting in your settings.py to include the absolute path to the project-level 'templates' directory using os.path.join(BASE_DIR, 'templates').