### PR TITLE
Support for Python 3.12

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,6 +45,9 @@ jobs:
             tox-django-version: "42"
           - python-version: "pypy3.9"
             tox-django-version: "42"
+        include:
+          - tox-django-version: "42"
+            python-version: "3.12"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,5 @@ types-pyOpenSSL
 types-PyYAML
 types-boto
 types-requests
+
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
     cmdclass=cmdclasses,
     package_data=package_data,
     python_requires=">=3.6",
+    setup_requires=["setuptools"],
     install_requires=["Django>=3.2"],
     extras_require={},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',

--- a/tests/management/commands/shell_plus_tests/test_collision_resolver.py
+++ b/tests/management/commands/shell_plus_tests/test_collision_resolver.py
@@ -188,7 +188,10 @@ class CRTestCase(AutomaticShellPlusImportsTestCase):
     )
     def test_installed_apps_no_resolve_conflicts_function(self):
         exception_msg = "Can't instantiate abstract class CRNoFunction with abstract methods resolve_collisions"
-        if sys.version_info[:2] >= (3, 9):
+
+        if sys.version_info[:2] >= (3, 12):
+            exception_msg = "Can't instantiate abstract class CRNoFunction without an implementation for abstract method 'resolve_collisions'"
+        elif sys.version_info[:2] >= (3, 9):
             exception_msg = exception_msg.replace('methods', 'method')
         with self.assertRaisesRegex(TypeError, exception_msg):
             self._assert_models_present_under_names(

--- a/tests/management/commands/test_pipchecker.py
+++ b/tests/management/commands/test_pipchecker.py
@@ -6,6 +6,7 @@ import sys
 
 import pip
 import pkg_resources
+import pytest
 from django.core.management import call_command
 from django.test import TestCase
 from io import StringIO
@@ -92,6 +93,7 @@ class PipCheckerTests(TestCase):
 
         self.assertTrue(value.endswith('repo is not frozen\n'), value)
 
+    @pytest.mark.skipif(sys.version_info >= (3, 12), reason="pip 20.1 is not compatible with Python 3.12+")
     def test_pipchecker_with_outdated_requirement_on_pip20_1(self):
         subprocess.call([sys.executable, '-m', 'pip', 'install', '-U', 'pip==20.1'])
         importlib.reload(pip)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
     {py36,py37,py38,py39,py310,pypy}-dj32
     {py38,py39,py310,pypy}-dj40
     {py38,py39,py310,py311,pypy}-dj41
-    {py38,py39,py310,py311,pypy}-dj42
+    {py38,py39,py310,py311,py312,pypy}-dj42
     {py38,py39,py310,pypy}-djmaster
     py310-dj32-postgres
     py310-dj40-postgres


### PR DESCRIPTION
The heavy lifting is already done in https://github.com/django-extensions/django-extensions/pull/1841 by @weslord and this PR depends on #1841 

This PR skips a test, adds `setuptools` as hard dependency and modifies a exception message to achieve compatibility with Python 3.12. 