### PR TITLE
Add small mention to --lab flag

### DIFF
--- a/docs/shell_plus.rst
+++ b/docs/shell_plus.rst
@@ -48,6 +48,10 @@ uses a web browser as its user interface, as an alternative shell::
 
     $ ./manage.py shell_plus --notebook
 
+Or with JupyterLab (a more feature-rich variant of Jupyter Notebook)::
+
+    $ ./manage.py shell_plus --lab
+
 In addition to being savable, IPython Notebooks can be updated (while running) to reflect changes in a Django application's code with the menu command `Kernel > Restart`.
 
 


### PR DESCRIPTION
# What

Mention an already existing `--lab` flag in the shell_plus docs

# Why

It's a useful feature and easy to miss if one is not actively looking for it
