### PR TITLE
Add option to display field choices in graph_models

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -80,6 +80,12 @@ class Command(BaseCommand):
                 'dest': 'disable_abstract_fields',
                 'help': 'Do not show the class member fields that were inherited',
             },
+            '--display-field-choices': {
+                'action': 'store_true',
+                'default': False,
+                'dest': 'display_field_choices',
+                'help': 'Display choices instead of field type',
+            },
             '--group-models -g': {
                 'action': 'store_true',
                 'default': False,

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -102,6 +102,7 @@ class ModelGraph:
         else:
             self.app_labels = app_labels
         self.rankdir = kwargs.get("rankdir")
+        self.display_field_choices = kwargs.get("display_field_choices", False)
 
     def generate_graph_data(self):
         self.process_apps()
@@ -124,6 +125,7 @@ class ModelGraph:
             'cli_options': self.cli_options,
             'disable_fields': self.disable_fields,
             'disable_abstract_fields': self.disable_abstract_fields,
+            'display_field_choices': self.display_field_choices,
             'use_subgraph': self.use_subgraph,
             'rankdir': self.rankdir,
         }
@@ -153,6 +155,9 @@ class ModelGraph:
         t = type(field).__name__
         if isinstance(field, (OneToOneField, ForeignKey)):
             t += " ({0})".format(field.remote_field.field_name)
+        if self.display_field_choices and field.choices is not None:
+            choices = {c for c, _ in field.choices}
+            t = str(choices)
         # TODO: ManyToManyField, GenericRelation
 
         return {


### PR DESCRIPTION
Use `./manage.py graph_models --display-field-choices` to display the set of
valid choices for a field. This option is not enabled by default, because
choices with a "large" cardinality would mess up the layout, but this can be
very useful for fields with a small number of choices.

Signed-off-by: Titouan Christophe <moiandme@gmail.com>
