### PR TITLE
Add webp support for graph_models

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -336,9 +336,9 @@ class Command(BaseCommand):
         formats = [
             'bmp', 'canon', 'cmap', 'cmapx', 'cmapx_np', 'dot', 'dia', 'emf',
             'em', 'fplus', 'eps', 'fig', 'gd', 'gd2', 'gif', 'gv', 'imap',
-            'imap_np', 'ismap', 'jpe', 'jpeg', 'jpg', 'metafile', 'pdf',
-            'pic', 'plain', 'plain-ext', 'png', 'pov', 'ps', 'ps2', 'svg',
-            'svgz', 'tif', 'tiff', 'tk', 'vml', 'vmlz', 'vrml', 'wbmp', 'xdot',
+            'imap_np', 'ismap', 'jpe', 'jpeg', 'jpg', 'metafile', 'pdf', 'pic',
+            'plain', 'plain-ext', 'png', 'pov', 'ps', 'ps2', 'svg', 'svgz',
+            'tif', 'tiff', 'tk', 'vml', 'vmlz', 'vrml', 'wbmp', 'webp', 'xdot',
         ]
         ext = output_file[output_file.rfind('.') + 1:]
         format_ = ext if ext in formats else 'raw'


### PR DESCRIPTION
Adds `webp` support, graphviz already seem to support it https://graphviz.org/docs/outputs/webp/.

Example images generated: https://szi.app/shared/erd.png vs https://szi.app/shared/erd.webp

```
     12K jan   16 22.38 erd.png
    7,1K jan   16 22.40 erd.webp
```
