### PR TITLE
Use python_history for shell_plus command

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -334,6 +334,26 @@ class Command(BaseCommand):
         # Using normal Python shell
         import code
         imported_objects = self.get_imported_objects(options)
+
+        # By default, this will set up readline to do tab completion and to read and
+        # write history to the .python_history file, but this can be overridden by
+        # $PYTHONSTARTUP or ~/.pythonrc.py.
+        try:
+            hook = sys.__interactivehook__
+        except AttributeError:
+            # Match the behavior of the cpython shell where a missing
+            # sys.__interactivehook__ is ignored.
+            pass
+        else:
+            try:
+                hook()
+            except Exception:
+                # Match the behavior of the cpython shell where an error in
+                # sys.__interactivehook__ prints a warning and the exception
+                # and continues.
+                print("Failed calling sys.__interactivehook__")
+                traceback.print_exc()
+        
         try:
             # Try activating rlcompleter, because it's handy.
             import readline


### PR DESCRIPTION
This feature [was added to Django](https://github.com/django/django/commit/3921b1c6d24c9d5a60e5f5f83c9a394104089c21) a few years ago. It allows you to restore the command history when you re-enter the `shell` (in our case, `shell_plus`),

What it means:
If the user has executed some commands, they are written to `~/.python_history` by default.
Then, when exiting and re-entering, the entire history can be restored in a shell using the up arrow.

I just copied this code from the Django command, but if you want to do the same in other way - np with that.