### PR TITLE
fix sqldiff: do not consider ('serial', 'integer') nor ('bigserial', 'bigint') as a `field-type-differ`

### DIFF
--- a/django_extensions/management/commands/sqldiff.py
+++ b/django_extensions/management/commands/sqldiff.py
@@ -571,7 +571,7 @@ class SQLDiff:
             if func:
                 model_type, db_type = func(field, description, model_type, db_type)
 
-            if not self.strip_parameters(db_type) == self.strip_parameters(model_type):
+            if not self.strip_parameters(db_type) == self.strip_parameters(model_type) and (db_type, model_type) not in {('serial', 'integer'), ('bigserial', 'bigint')}:
                 self.add_difference('field-type-differ', table_name, field.name, model_type, db_type)
 
     def find_field_parameter_differ(self, meta, table_description, table_name, func=None):


### PR DESCRIPTION
After upgrading from Django 3.x to Django 4.2.x  sqldiff complains about fictive differences when comparing AutoField to integer

```shell
$ python manage.py  sqldiff -a -t                  
+ Application: admin
|-+ Differences for model: LogEntry
|--+ field 'id' not of same type: db='serial', model='integer'
+ Application: auth
|-+ Differences for model: Permission
|--+ field 'id' not of same type: db='serial', model='integer'
|-+ Differences for model: Group_permissions
|--+ field 'id' not of same type: db='serial', model='integer'
|-+ Differences for model: Group
|--+ field 'id' not of same type: db='serial', model='integer'
```

for some reason `db_type=integer` is renamed to `serial` (and `db_type=bigint` is renamed to `bigserial`) [if it is a PrimaryKey and an AutoField](https://github.com/django-extensions/django-extensions/blob/main/django_extensions/management/commands/sqldiff.py#L1232-L1236), but the same do not apply to `model_type` which is leading to fictive diffs