### PR TITLE
Add setting to fix `runserver_plus` debugger on custom host names

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -454,6 +454,11 @@ class Command(BaseCommand):
             if self.nopin:
                 os.environ['WERKZEUG_DEBUG_PIN'] = 'off'
             handler = DebuggedApplication(handler, True)
+            # Set trusted_hosts (for Werkzeug 3.0.3+)
+            try:
+                handler.trusted_hosts = settings.RUNSERVERPLUS_TRUSTED_HOSTS
+            except AttributeError:
+                pass
 
         runserver_plus_started.send(sender=self)
         run_simple(

--- a/docs/runserver_plus.rst
+++ b/docs/runserver_plus.rst
@@ -85,10 +85,18 @@ An ajax based console appears in the pane and you can start debugging.
 Notice in the screenshot above I did a `print environ` to see what was in the
 environment parameter coming into the function.
 
-*WARNING*: This should *never* be used in any kind of production environment.
-Not even for a quick problem check.  I cannot emphasize this enough. The
-interactive debugger allows you to evaluate python code right against the
-server.  You've been warned.
+.. warning::
+
+    This should *never* be used in any kind of production environment.
+    Not even for a quick problem check.  I cannot emphasize this enough. The
+    interactive debugger allows you to evaluate python code right against the
+    server.  You've been warned.
+
+..  note::
+
+    If you're using Werkzeug 3.0.3 or later, by default, the debugger will only
+    be enabled if the hostname is one of ``[localhost, .localhost, 127.0.0.1]``.
+    You may allow more host names by setting the ``RUNSERVERPLUS_TRUSTED_HOSTS``.
 
 .. _`Werkzeug WSGI utilities`: https://werkzeug.palletsprojects.com/
 
@@ -208,6 +216,9 @@ Other configuration options and their defaults include:
 
   # Do not watch files matching any of these patterns
   RUNSERVER_PLUS_EXCLUDE_PATTERNS = []
+
+  # List of domains to allow requests to the debugger from
+  RUNSERVERPLUS_TRUSTED_HOSTS = [".localhost", "127.0.0.1"]
 
 
 IO Calls and CPU Usage


### PR DESCRIPTION
Add `RUNSERVERPLUS_TRUSTED_HOSTS` setting to work with Werkzeug 3.0.3+ debugger.

[Werkzeug version 3.0.3](https://werkzeug.palletsprojects.com/en/3.0.x/changes/#version-3-0-3) introduced a fix for a security vulnerability:

> Only allow `localhost`, `.localhost`, `127.0.0.1`, or the specified hostname when running the dev server, to make debugger requests. Additional hosts can be added by using the debugger middleware directly. The debugger UI makes requests using the full URL rather than only the path. [GHSA-2g68-c3qc-8985](https://github.com/advisories/2g68-c3qc-8985)

I'm running `runserver_plus` with Werkzeug 3.0.3 on a machine with a custom dev host (e.g. `dev.mydomain.com`) which means that the Werkzeug debugger no longer works.

As far as I could tell, there was no way to tell Werkzeug to trust my dev host, so adding this option to do so.

## Questions

1. Should this default to `settings.ALLOWED_HOSTS`? It might be a good enough default on a Django project...
2. Updated the docs, let me know if I missed anything?