### PR TITLE
docs: fix mismatched v3.2.3 CHANGELOG heading and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 See https://github.com/django-extensions/django-extensions/releases
 
-3.2.2
+3.2.3
 -----
 
 Changes:


### PR DESCRIPTION
fixes:
```
$ pip install django-extensions==3.2.2
ERROR: No matching distribution found for django-extensions==3.2.2
```