### PR TITLE
Handle non-package modules when looking for job definitions

### DIFF
--- a/django_extensions/management/jobs.py
+++ b/django_extensions/management/jobs.py
@@ -80,6 +80,11 @@ def find_job_module(app_name: str, when: Optional[str] = None) -> str:
         parts.append(when)
     module_name = ".".join(parts)
     module = importlib.import_module(module_name)
+
+    if not hasattr(module, "__path__"):
+        # module here is a non-package module, eg jobs.py
+        raise ImportError
+
     return module.__path__[0]
 
 


### PR DESCRIPTION
This fixes an error with runjobs when a jobs.py exists in the environment.  Modules have no `__path__` member defined unless it's a package, so we should be able to rely on that here.

Fix: #1836 