### PR TITLE
Updates graph models command with output extension type formats

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -101,7 +101,7 @@ class Command(BaseCommand):
             '--output -o': {
                 'action': 'store',
                 'dest': 'outputfile',
-                'help': 'Render output file. Type of output dependend on file extensions. Use png or jpg to render graph to image.',
+                'help': 'Render output file. Type of output dependend on file extensions. Use png, jpg, or svg to render graph to image.',
             },
             '--layout -l': {
                 'action': 'store',


### PR DESCRIPTION
Recently looking for a way to export our models to an ERD and discovered this project. However wasn't sure from the help text if SVG was available. Hoping that this PR will allow / inform anyone using the graph_models command that SVG is a format available 