### PR TITLE
Improve error message for missing shell_plus import

### DIFF
--- a/django_extensions/management/shells.py
+++ b/django_extensions/management/shells.py
@@ -112,7 +112,7 @@ def import_items(import_directives, style, quiet_load=False):
                                 else:
                                     imported_objects[asname] = getattr(imported_object, name.name)
                             except AttributeError as exc:
-                                print(dir(imported_object))
+                                print(f"Couldn't find {name.name} in {body.module}. Only found: {dir(imported_object)}")
                                 # raise
                                 raise ImportError(exc)
             else:


### PR DESCRIPTION
Today, if you misspell something in SHELL_PLUS_IMPORTS, you just get a line printed when opening the shell, with a list of names in scope from the module you have an incorrect import from. This can be a bit confusing to debug.

This commit adds some more context to this print, both to explain what's happening, and tell you which module import is at fault.