### PR TITLE
Fix truncated help text in delete_squashed_migrations.py

### DIFF
--- a/django_extensions/management/commands/delete_squashed_migrations.py
+++ b/django_extensions/management/commands/delete_squashed_migrations.py
@@ -16,9 +16,9 @@ def py_from_pyc(pyc_fn):
 
 
 class Command(BaseCommand):
-    help = "Deletes left over migrations that have been replaced by a "
-    "squashed migration and converts squashed migration into a normal "
-    "migration. Modifies your source tree! Use with care!"
+    help = ("Deletes left over migrations that have been replaced by a "
+        "squashed migration and converts squashed migration into a normal "
+        "migration. Modifies your source tree! Use with care!")
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
* The quoted strings after the first one weren't being concatenated, since they were being interpreted as separate statements.