### PR TITLE
Support for ordering edges on pydot/dot/graphviz.

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -197,6 +197,13 @@ class Command(BaseCommand):
                 'choices': ['TB', 'BT', 'LR', 'RL'],
                 'help': 'Set direction of graph layout. Supported directions: "TB", "LR", "BT", "RL", corresponding to directed graphs drawn from top to bottom, from left to right, from bottom to top, and from right to left, respectively. Default is TB.'
             },
+            '--ordering': {
+                'action': 'store',
+                'default': None,
+                'dest': 'ordering',
+                'choices': ['in', 'out'],
+                'help': 'Controls how the edges are arranged. Supported orderings: "in" (incoming relations first), "out" (outgoing relations first). Default is None.'
+            },
         }
 
         defaults = getattr(settings, 'GRAPH_MODELS', None)

--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -264,6 +264,9 @@ class Command(BaseCommand):
 
         if options.get('rankdir') != 'TB' and output not in ["pydot", "pygraphviz", "dot"]:
             raise CommandError("--rankdir is not supported for the chosen output format")
+        
+        if options.get('ordering') and output not in ["pydot", "pygraphviz", "dot"]:
+            raise CommandError("--ordering is not supported for the chosen output format")
 
         # Consistency check: Abort if --pygraphviz or --pydot options are set
         # but no outputfile is specified. Before 2.1.4 this silently fell back

--- a/django_extensions/management/modelviz.py
+++ b/django_extensions/management/modelviz.py
@@ -45,6 +45,7 @@ __contributors__ = [
     "Mikkel Munch Mortensen <https://www.detfalskested.dk/>",
     "Andrzej Bistram <andrzej.bistram@gmail.com>",
     "Daniel Lipsitt <danlipsitt@gmail.com>",
+    "Florian Anceau <flow.gunso@gmail.com>"
 ]
 
 
@@ -103,6 +104,7 @@ class ModelGraph:
             self.app_labels = app_labels
         self.rankdir = kwargs.get("rankdir")
         self.display_field_choices = kwargs.get("display_field_choices", False)
+        self.ordering = kwargs.get("ordering")
 
     def generate_graph_data(self):
         self.process_apps()
@@ -128,6 +130,7 @@ class ModelGraph:
             'display_field_choices': self.display_field_choices,
             'use_subgraph': self.use_subgraph,
             'rankdir': self.rankdir,
+            'ordering': self.ordering,
         }
 
         if as_json:

--- a/django_extensions/templates/django_extensions/graph_models/django2018/digraph.dot
+++ b/django_extensions/templates/django_extensions/graph_models/django2018/digraph.dot
@@ -6,7 +6,8 @@
   {% block digraph_options %}fontname = "Roboto"
   fontsize = 8
   splines  = true
-  rankdir = "{{ rankdir }}"{% endblock %}
+  rankdir = "{{ rankdir }}"
+  {% if ordering %}ordering = "{{ ordering }}"{% endif %}{% endblock %}
 
   node [{% block node_options %}
     fontname = "Roboto"

--- a/django_extensions/templates/django_extensions/graph_models/original/digraph.dot
+++ b/django_extensions/templates/django_extensions/graph_models/original/digraph.dot
@@ -6,7 +6,8 @@
   {% block digraph_options %}fontname = "Helvetica"
   fontsize = 8
   splines  = true
-  rankdir = "{{ rankdir }}"{% endblock %}
+  rankdir = "{{ rankdir }}"
+  {% if ordering %}ordering = "{{ ordering }}"{% endif %}{% endblock %}
 
   node [{% block node_options %}
     fontname = "Helvetica"

--- a/docs/graph_models.rst
+++ b/docs/graph_models.rst
@@ -144,6 +144,11 @@ image by using the *graph_models* command::
   # supported directions: "TB", "LR", "BT", "RL"
   $ ./manage.py graph_models -a --rankdir BT -o my_project_sans_foo_bar.png
 
+::
+
+  # Create a graph with different edges ordering,
+  # supported orders: "in", "out"
+  $ ./manage.py graph_models -a --ordering in -o my_project_sans_foo_bar.png
 
 
 .. _GraphViz: https://www.graphviz.org/


### PR DESCRIPTION
Add support for https://graphviz.org/docs/attrs/ordering/.

Default to `None`, restricted choices to _in_ and _out_ as the documentation state. Limited the `--ordering` option to pydot/dot/graphviz.

I've added a basic documentation similar to `--rankdir`.

I did not update the changelog, as I did not know how it's usually handled.