### PR TITLE
Add show_permissions management command

### DIFF
--- a/django_extensions/management/commands/show_permissions.py
+++ b/django_extensions/management/commands/show_permissions.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = (
+        "List all permissions for models. "
+        "By default, excludes admin, auth, contenttypes, and sessions apps."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "app_label_model",
+            nargs="*",
+            help="[app_label.]model(s) to show permissions for."
+        )
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Include results for admin, auth, contenttypes, and sessions."
+        )
+        parser.add_argument(
+            "--app-label",
+            help="App label to dump permissions for."
+        )
+
+    def handle(self, *args, **options):
+        app_label_models = options["app_label_model"]
+        include_all = options["all"]
+        app_label_filter = options["app_label"]
+
+        if include_all:
+            content_types = ContentType.objects.order_by("app_label", "model")
+        elif app_label_filter:
+            content_types = ContentType.objects.filter(
+                app_label=app_label_filter.lower()
+            ).order_by("app_label", "model")
+            if not content_types:
+                raise CommandError(
+                    f'No content types found for app label "{app_label_filter}".'
+                )
+        elif not app_label_models:
+            excluded = ["admin", "auth", "contenttypes", "sessions"]
+            content_types = ContentType.objects.exclude(
+                app_label__in=excluded
+            ).order_by("app_label", "model")
+        else:
+            content_types = []
+            for value in app_label_models:
+                if "." in value:
+                    app_label, model = value.split(".")
+                    qs = ContentType.objects.filter(
+                        app_label=app_label, model=model
+                    )
+                else:
+                    qs = ContentType.objects.filter(model=value)
+
+                if not qs:
+                    raise CommandError(f"Content type not found for '{value}'.")
+                content_types.extend(qs)
+
+        for ct in content_types:
+            self.stdout.write(f"Permissions for {ct}")
+            for perm in ct.permission_set.all():
+                self.stdout.write(
+                    f"    {ct.app_label}.{perm.codename} | {perm.name}"
+                )

--- a/tests/management/commands/test_show_permissions.py
+++ b/tests/management/commands/test_show_permissions.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+import sys
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class ShowPermissionsTests(TestCase):
+    def _run_command(self, *args, **kwargs):
+        """
+        Utility to run the command and return captured output.
+        """
+        out = StringIO()
+        sys_stdout = sys.stdout
+        sys.stdout = out
+        try:
+            call_command("show_permissions", *args, **kwargs)
+        finally:
+            sys.stdout = sys_stdout
+        return out.getvalue()
+
+    def test_should_list_permissions_for_all_apps_excluding_defaults(self):
+        output = self._run_command(verbosity=3)
+
+        # Should not include default apps like 'auth' unless explicitly allowed
+        self.assertNotIn("Permissions for Authentication and Authorization", output)
+        self.assertNotIn("auth.add_user", output)
+
+    def test_should_include_all_apps_with_flag(self):
+        output = self._run_command("--all", verbosity=3)
+
+        # Should include default apps like 'auth' and 'admin'
+        self.assertIn("Permissions for Authentication and Authorization", output)
+        self.assertIn("auth.add_user", output)
+        self.assertIn("admin", output)
+
+    def test_should_filter_by_app_label(self):
+        output = self._run_command("--app-label", "auth", verbosity=3)
+
+        self.assertIn("Permissions for Authentication and Authorization", output)
+        self.assertIn("auth.change_user", output)
+
+    def test_should_filter_by_app_and_model(self):
+        output = self._run_command("auth.user", verbosity=3)
+
+        self.assertIn("Permissions for Authentication and Authorization | user", output)
+        self.assertIn("auth.change_user", output)
+
+    def test_should_raise_error_for_invalid_model(self):
+        with self.assertRaisesMessage(
+            Exception, "Content type not found for 'fakeapp.nosuchmodel'"
+        ):
+            self._run_command("fakeapp.nosuchmodel", verbosity=3)


### PR DESCRIPTION
## Summary

This PR adds a new management command `show_permissions` that allows developers to list model-level permissions in their project.

It supports:
- Filtering by app or model (e.g., `auth.user`)
- An `--all` flag to include default Django apps like `auth`, `admin`, etc.
- Clean CLI output

## Motivation

This is based on an idea and implementation shared by @kagee . Many thanks to him for the logic and inspiration behind this feature.

## Related Issue

Fixes #1916 

## Labels

This PR falls under:
- `feature request`
- `need patch`
