### PR TITLE
Update list of default fields for list_model_info command

### DIFF
--- a/django_extensions/management/commands/list_model_info.py
+++ b/django_extensions/management/commands/list_model_info.py
@@ -86,6 +86,9 @@ class Command(BaseCommand):
         )
 
         default_methods = [
+            "adelete",
+            "arefresh_from_db",
+            "asave",
             "check",
             "clean",
             "clean_fields",
@@ -94,6 +97,7 @@ class Command(BaseCommand):
             "from_db",
             "full_clean",
             "get_absolute_url",
+            "get_constraints",
             "get_deferred_fields",
             "prepare_database_save",
             "refresh_from_db",
@@ -101,6 +105,7 @@ class Command(BaseCommand):
             "save_base",
             "serializable_value",
             "unique_error_message",
+            "validate_constraints",
             "validate_unique",
         ]
 


### PR DESCRIPTION
Add a few methods that have been added in newer Django versions to the `default_methods` list for the `list_model_info` command. This prevents them from being listed under every model in the project.

Method names added to the list:

- adelete
- arefresh_from_db
- asave
- get_constraints
- validate_constraints