### PR TITLE
feat: add support to multi-line "replaces =" to remove

### DIFF
--- a/django_extensions/management/commands/delete_squashed_migrations.py
+++ b/django_extensions/management/commands/delete_squashed_migrations.py
@@ -154,7 +154,7 @@ class Command(BaseCommand):
 
         if (
             self.verbosity > 0 or self.interactive
-        ) and cleaned_migration_content == squashed_migration_content:
+        ) and cleaned_migration_content != squashed_migration_content:
             # Print the differences between the original and new content
             diff = difflib.unified_diff(
                 squashed_migration_content.splitlines(),

--- a/django_extensions/management/commands/delete_squashed_migrations.py
+++ b/django_extensions/management/commands/delete_squashed_migrations.py
@@ -151,10 +151,16 @@ class Command(BaseCommand):
         cleaned_migration_content = re.sub(
             REPLACES_REGEX, "", squashed_migration_content
         )
+        if cleaned_migration_content == squashed_migration_content:
+            raise CommandError(
+                (
+                    "Couldn't find 'replaces =' lines in file %s. "
+                    "Please finish cleaning up manually."
+                )
+                % (squashed_migration_fn,)
+            )
 
-        if (
-            self.verbosity > 0 or self.interactive
-        ) and cleaned_migration_content != squashed_migration_content:
+        if self.verbosity > 0 or self.interactive:
             # Print the differences between the original and new content
             diff = difflib.unified_diff(
                 squashed_migration_content.splitlines(),
@@ -163,10 +169,14 @@ class Command(BaseCommand):
                 fromfile="Original",
                 tofile="Modified",
             )
+
             self.stdout.write(
                 self.style.MIGRATE_HEADING(
                     "The squashed migrations file %s will be modified like this :\n\n%s"
-                    % (squashed_migration_fn, "\n".join(diff))
+                    % (
+                        squashed_migration_fn,
+                        "\n".join(diff),
+                    )
                 )
             )
 


### PR DESCRIPTION
**delete_squashed_migrations** command currently fail if the "replaces = ..." line in squashed migration is not on a single line.

When using a formatting tool, it is common that the line is rewrote on many lines.

ex:
```py
    replaces = [("projects", "0044_fix_tags_bug_squashed_0054_auto_20200603_1545"), ("projects", "0045_auto_20210521_1615")]
```
formatted to:

```py
    replaces = [
        ("projects", "0044_fix_tags_bug_squashed_0054_auto_20200603_1545"),
        ("projects", "0045_auto_20210521_1615"),
    ]
```

The PR is updating the REGEX so it handle many lines. It also modify how user control what will be modifier in the squashed migration file. Before it indicated line numbers that will be deleted. Now it display a *diff*.

Ex:
```
$ python manage.py delete_squashed_migrations projects
Will delete the following files:
 - /app/django/projects/migrations/0044_fix_tags_bug_squashed_0054_auto_20200603_1545.py
 - /app/django/projects/migrations/0045_auto_20210521_1615.py
Do you wish to proceed? [yN] y
The squashed migrations file /app/django/projects/migrations/0044_squashed_0045_auto_20210521_1615.py will be modified like this :

--- Original
+++ Modified
@@ -24,10 +24,6 @@

 class Migration(migrations.Migration):

-    replaces = [
-        ("projects", "0044_fix_tags_bug_squashed_0054_auto_20200603_1545"),
-        ("projects", "0045_auto_20210521_1615"),
-    ]

     dependencies = [
         ("contracts", "0001_squashed_0014_auto_20201012_1634"),
Do you wish to proceed? [yN] y
```