### PR TITLE
resolve regex library warnings

### DIFF
--- a/tests/management/commands/test_list_signals.py
+++ b/tests/management/commands/test_list_signals.py
@@ -25,5 +25,5 @@ tests.testapp.models.HasOwnerModel (has owner model)
         call_command("list_signals", stdout=self.out)
 
         # Strip line numbers to make the test less brittle
-        out = re.sub(r"(?<=#)\d+", "", self.out.getvalue(), re.M)
+        out = re.sub(r"(?<=#)\d+", "", self.out.getvalue(), flags=re.M)
         self.assertIn(expected_result, out)


### PR DESCRIPTION
# PR Summary
This small PR resolves the regex library warnings showing starting Python3.11 which you can find in the [CI logs](https://github.com/django-extensions/django-extensions/actions/runs/15051350854/job/42306674111#step:5:165):
```python
  /home/runner/work/django-extensions/django-extensions/tests/management/commands/test_list_signals.py:28: DeprecationWarning: 'count' is passed as positional argument
    out = re.sub(r"(?<=#)\d+", "", self.out.getvalue(), re.M)
```