### PR TITLE
Add a RUNSERVER_PLUS_PRINT_SQL setting

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -497,10 +497,13 @@ class Command(BaseCommand):
             self.addr = "::1" if self.use_ipv6 else "127.0.0.1"
             self._raw_ipv6 = True
 
+        print_sql = (
+            getattr(settings, "RUNSERVER_PLUS_PRINT_SQL", False) or options["print_sql"]
+        )
         truncate = None if options["truncate_sql"] == 0 else options["truncate_sql"]
 
         with monkey_patch_cursordebugwrapper(
-            print_sql=options["print_sql"],
+            print_sql=print_sql,
             print_sql_location=options["print_sql_location"],
             truncate=truncate,
             logger=logger.info,

--- a/docs/runserver_plus.rst
+++ b/docs/runserver_plus.rst
@@ -201,6 +201,8 @@ to your settings::
 Other configuration options and their defaults include:
 
 ::
+  # Print SQL queries as they're executed
+  RUNSERVER_PLUS_PRINT_SQL = False
 
   # Truncate SQL queries to this many characters (None means no truncation)
   RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = 1000


### PR DESCRIPTION
This provides an alternative to `runserver_plus --print-sql` and provides symmetry with the `SHELL_PLUS_PRINT_SQL` setting.