### PR TITLE
move extract_views_from_urlpatterns to utils

### DIFF
--- a/django_extensions/management/commands/show_urls.py
+++ b/django_extensions/management/commands/show_urls.py
@@ -9,7 +9,9 @@ from django.utils import translation
 
 from django_extensions.management.color import color_style, no_style
 from django_extensions.management.utils import signalcommand
-from django_extensions.utils.extract_views_from_urlpatterns import extract_views_from_urlpatterns
+from django_extensions.utils.extract_views_from_urlpatterns import (
+    extract_views_from_urlpatterns,
+)
 
 
 FMTR = {
@@ -118,7 +120,9 @@ class Command(BaseCommand):
                 % (getattr(settings, urlconf), str(e))
             )
 
-        view_functions = extract_views_from_urlpatterns(urlconf.urlpatterns, self.LANGUAGES)
+        view_functions = extract_views_from_urlpatterns(
+            urlconf.urlpatterns, self.LANGUAGES
+        )
         for func, regex, url_name in view_functions:
             if hasattr(func, "__globals__"):
                 func_globals = func.__globals__

--- a/django_extensions/management/commands/verify_named_urls.py
+++ b/django_extensions/management/commands/verify_named_urls.py
@@ -8,7 +8,6 @@ from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.template.loader import get_template
-from django.urls import URLResolver
 
 from django_extensions.compat import get_template_setting
 from django_extensions.management.color import color_style, no_style

--- a/django_extensions/management/commands/verify_named_urls.py
+++ b/django_extensions/management/commands/verify_named_urls.py
@@ -13,7 +13,9 @@ from django.urls import URLResolver
 from django_extensions.compat import get_template_setting
 from django_extensions.management.color import color_style, no_style
 from django_extensions.management.utils import signalcommand
-from django_extensions.utils.extract_views_from_urlpatterns import extract_views_from_urlpatterns
+from django_extensions.utils.extract_views_from_urlpatterns import (
+    extract_views_from_urlpatterns,
+)
 
 
 class Command(BaseCommand):

--- a/django_extensions/management/commands/verify_named_urls.py
+++ b/django_extensions/management/commands/verify_named_urls.py
@@ -6,27 +6,14 @@ import os
 
 from django.apps import apps
 from django.conf import settings
-from django.core.exceptions import ViewDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.template.loader import get_template
-from django.urls import URLPattern, URLResolver
-from django.utils import translation
+from django.urls import URLResolver
 
 from django_extensions.compat import get_template_setting
 from django_extensions.management.color import color_style, no_style
 from django_extensions.management.utils import signalcommand
-
-
-class RegexURLPattern:
-    pass
-
-
-class RegexURLResolver:
-    pass
-
-
-class LocaleRegexURLResolver:
-    pass
+from django_extensions.utils.extract_views_from_urlpatterns import extract_views_from_urlpatterns
 
 
 class Command(BaseCommand):
@@ -135,7 +122,7 @@ class Command(BaseCommand):
                 % (getattr(settings, urlconf), str(e))
             )
 
-        view_functions = self.extract_views_from_urlpatterns(urlconf.urlpatterns)
+        view_functions = extract_views_from_urlpatterns(urlconf.urlpatterns)
         for func, regex, view in view_functions:
             if view is not None:
                 if isinstance(func, functools.partial):
@@ -164,73 +151,3 @@ class Command(BaseCommand):
                 for match in self.names_re.findall(line):
                     self.names[match].append((filepath, lineno))
                 lineno += 1
-
-    # copied from show_urls.py
-    def extract_views_from_urlpatterns(self, urlpatterns, base="", namespace=None):
-        """
-        Return a list of views from a list of urlpatterns.
-
-        Each object in the returned list is a three-tuple: (view_func, regex, name)
-        """
-        views = []
-        for p in urlpatterns:
-            if isinstance(p, (URLPattern, RegexURLPattern)):
-                try:
-                    if not p.name:
-                        name = p.name
-                    elif namespace:
-                        name = "{0}:{1}".format(namespace, p.name)
-                    else:
-                        name = p.name
-                    pattern = describe_pattern(p)
-                    views.append((p.callback, base + pattern, name))
-                except ViewDoesNotExist:
-                    continue
-            elif isinstance(p, (URLResolver, RegexURLResolver)):
-                try:
-                    patterns = p.url_patterns
-                except ImportError:
-                    continue
-                if namespace and p.namespace:
-                    _namespace = "{0}:{1}".format(namespace, p.namespace)
-                else:
-                    _namespace = p.namespace or namespace
-                pattern = describe_pattern(p)
-                if isinstance(p, LocaleRegexURLResolver):
-                    for language in self.LANGUAGES:
-                        with translation.override(language[0]):
-                            views.extend(
-                                self.extract_views_from_urlpatterns(
-                                    patterns, base + pattern, namespace=_namespace
-                                )
-                            )
-                else:
-                    views.extend(
-                        self.extract_views_from_urlpatterns(
-                            patterns, base + pattern, namespace=_namespace
-                        )
-                    )
-            elif hasattr(p, "_get_callback"):
-                try:
-                    views.append(
-                        (p._get_callback(), base + describe_pattern(p), p.name)
-                    )
-                except ViewDoesNotExist:
-                    continue
-            elif hasattr(p, "url_patterns") or hasattr(p, "_get_url_patterns"):
-                try:
-                    patterns = p.url_patterns
-                except ImportError:
-                    continue
-                views.extend(
-                    self.extract_views_from_urlpatterns(
-                        patterns, base + describe_pattern(p), namespace=namespace
-                    )
-                )
-            else:
-                raise TypeError("%s does not appear to be a urlpattern object" % p)
-        return views
-
-
-def describe_pattern(p):
-    return str(p.pattern)

--- a/django_extensions/utils/extract_views_from_urlpatterns.py
+++ b/django_extensions/utils/extract_views_from_urlpatterns.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ViewDoesNotExist
 from django.urls import URLPattern, URLResolver
-
+from django.utils import translation
 
 class RegexURLPattern:  # type: ignore
     pass

--- a/django_extensions/utils/extract_views_from_urlpatterns.py
+++ b/django_extensions/utils/extract_views_from_urlpatterns.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ViewDoesNotExist
 from django.urls import URLPattern, URLResolver
 from django.utils import translation
 
+
 class RegexURLPattern:  # type: ignore
     pass
 

--- a/django_extensions/utils/extract_views_from_urlpatterns.py
+++ b/django_extensions/utils/extract_views_from_urlpatterns.py
@@ -1,0 +1,80 @@
+
+from django.core.exceptions import ViewDoesNotExist
+from django.urls import URLPattern, URLResolver
+
+class RegexURLPattern:  # type: ignore
+    pass
+
+class RegexURLResolver:  # type: ignore
+    pass
+
+class LocaleRegexURLResolver:  # type: ignore
+    pass
+
+def extract_views_from_urlpatterns(urlpatterns, languages=((None, None),), base="", namespace=None):
+    """
+    Return a list of views from a list of urlpatterns.
+
+    Each object in the returned list is a three-tuple: (view_func, regex, name)
+    """
+    views = []
+    for p in urlpatterns:
+        if isinstance(p, (URLPattern, RegexURLPattern)):
+            try:
+                if not p.name:
+                    name = p.name
+                elif namespace:
+                    name = "{0}:{1}".format(namespace, p.name)
+                else:
+                    name = p.name
+                pattern = describe_pattern(p)
+                views.append((p.callback, base + pattern, name))
+            except ViewDoesNotExist:
+                continue
+        elif isinstance(p, (URLResolver, RegexURLResolver)):
+            try:
+                patterns = p.url_patterns
+            except ImportError:
+                continue
+            if namespace and p.namespace:
+                _namespace = "{0}:{1}".format(namespace, p.namespace)
+            else:
+                _namespace = p.namespace or namespace
+            pattern = describe_pattern(p)
+            if isinstance(p, LocaleRegexURLResolver):
+                for language in languages:
+                    with translation.override(language[0]):
+                        views.extend(
+                            extract_views_from_urlpatterns(
+                                patterns, languages, base + pattern, namespace=_namespace
+                            )
+                        )
+            else:
+                views.extend(
+                    extract_views_from_urlpatterns(
+                        patterns, languages, base + pattern, namespace=_namespace
+                    )
+                )
+        elif hasattr(p, "_get_callback"):
+            try:
+                views.append(
+                    (p._get_callback(), base + describe_pattern(p), p.name)
+                )
+            except ViewDoesNotExist:
+                continue
+        elif hasattr(p, "url_patterns") or hasattr(p, "_get_url_patterns"):
+            try:
+                patterns = p.url_patterns
+            except ImportError:
+                continue
+            views.extend(
+                extract_views_from_urlpatterns(
+                    patterns, languages, base + describe_pattern(p), namespace=namespace
+                )
+            )
+        else:
+            raise TypeError("%s does not appear to be a urlpattern object" % p)
+    return views
+
+def describe_pattern(p):
+    return str(p.pattern)

--- a/django_extensions/utils/extract_views_from_urlpatterns.py
+++ b/django_extensions/utils/extract_views_from_urlpatterns.py
@@ -1,17 +1,22 @@
-
 from django.core.exceptions import ViewDoesNotExist
 from django.urls import URLPattern, URLResolver
+
 
 class RegexURLPattern:  # type: ignore
     pass
 
+
 class RegexURLResolver:  # type: ignore
     pass
+
 
 class LocaleRegexURLResolver:  # type: ignore
     pass
 
-def extract_views_from_urlpatterns(urlpatterns, languages=((None, None),), base="", namespace=None):
+
+def extract_views_from_urlpatterns(
+    urlpatterns, languages=((None, None),), base="", namespace=None
+):
     """
     Return a list of views from a list of urlpatterns.
 
@@ -46,7 +51,10 @@ def extract_views_from_urlpatterns(urlpatterns, languages=((None, None),), base=
                     with translation.override(language[0]):
                         views.extend(
                             extract_views_from_urlpatterns(
-                                patterns, languages, base + pattern, namespace=_namespace
+                                patterns,
+                                languages,
+                                base + pattern,
+                                namespace=_namespace,
                             )
                         )
             else:
@@ -57,9 +65,7 @@ def extract_views_from_urlpatterns(urlpatterns, languages=((None, None),), base=
                 )
         elif hasattr(p, "_get_callback"):
             try:
-                views.append(
-                    (p._get_callback(), base + describe_pattern(p), p.name)
-                )
+                views.append((p._get_callback(), base + describe_pattern(p), p.name))
             except ViewDoesNotExist:
                 continue
         elif hasattr(p, "url_patterns") or hasattr(p, "_get_url_patterns"):
@@ -75,6 +81,7 @@ def extract_views_from_urlpatterns(urlpatterns, languages=((None, None),), base=
         else:
             raise TypeError("%s does not appear to be a urlpattern object" % p)
     return views
+
 
 def describe_pattern(p):
     return str(p.pattern)


### PR DESCRIPTION
This PR deduplicates `extract_views_from_urlpatterns()` into `utils` as per the comment https://github.com/django-extensions/django-extensions/pull/1927#issuecomment-2806801268 