### PR TITLE
Allow setting runserver_plus address/port via env var

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -480,6 +480,8 @@ class Command(BaseCommand):
                 "RUNSERVER_PLUS_SERVER_ADDRESS_PORT",
                 getattr(settings, "RUNSERVERPLUS_SERVER_ADDRESS_PORT", None),
             )
+            addrport = os.environ.get("RUNSERVERPLUS_SERVER_ADDRESS_PORT") or addrport
+
         if not addrport:
             self.addr = ""
             self.port = DEFAULT_PORT

--- a/tests/management/commands/test_runserver_plus.py
+++ b/tests/management/commands/test_runserver_plus.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from django.core.management import call_command
 
@@ -11,3 +12,15 @@ def test_initialize_runserver_plus():
     ) as run_simple:
         call_command("runserver_plus")
         assert run_simple.called, "werkzeug.run_simple was not called"
+
+
+@pytest.mark.django_db
+def test_initialize_runserver_plus_with_addrport_via_env_var():
+    with mock.patch(
+        "django_extensions.management.commands.runserver_plus.run_simple"
+    ) as run_simple:
+        os.environ["RUNSERVERPLUS_SERVER_ADDRESS_PORT"] = "1.1.1.1:8001"
+        call_command("runserver_plus")
+        assert run_simple.called, "werkzeug.run_simple was not called"
+        assert run_simple.call_args[0][0] == "1.1.1.1"
+        assert run_simple.call_args[0][1] == 8001


### PR DESCRIPTION
This lets an environment variable take priority over the setting.