### PR TITLE
standardise runserver_plus settings

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -85,10 +85,14 @@ ansi_escape = re.compile(
 )
 DEFAULT_PORT = "8000"
 DEFAULT_POLLER_RELOADER_INTERVAL = getattr(
-    settings, "RUNSERVERPLUS_POLLER_RELOADER_INTERVAL", 1
+    settings,
+    "RUNSERVER_PLUS_POLLER_RELOADER_INTERVAL",
+    getattr(settings, "RUNSERVERPLUS_POLLER_RELOADER_INTERVAL", 1),
 )
 DEFAULT_POLLER_RELOADER_TYPE = getattr(
-    settings, "RUNSERVERPLUS_POLLER_RELOADER_TYPE", "auto"
+    settings,
+    "RUNSERVER_PLUS_POLLER_RELOADER_TYPE",
+    getattr(settings, "RUNSERVERPLUS_POLLER_RELOADER_TYPE", "auto"),
 )
 
 logger = logging.getLogger(__name__)
@@ -470,10 +474,11 @@ class Command(BaseCommand):
             raise CommandError("Your Python does not support IPv6.")
         self._raw_ipv6 = False
         if not addrport:
-            try:
-                addrport = settings.RUNSERVERPLUS_SERVER_ADDRESS_PORT
-            except AttributeError:
-                pass
+            addrport = getattr(
+                settings,
+                "RUNSERVER_PLUS_SERVER_ADDRESS_PORT",
+                getattr(settings, "RUNSERVERPLUS_SERVER_ADDRESS_PORT", None),
+            )
         if not addrport:
             self.addr = ""
             self.port = DEFAULT_PORT
@@ -654,10 +659,11 @@ class Command(BaseCommand):
                 os.environ["WERKZEUG_DEBUG_PIN"] = "off"
             handler = DebuggedApplication(handler, True)
             # Set trusted_hosts (for Werkzeug 3.0.3+)
-            try:
-                handler.trusted_hosts = settings.RUNSERVERPLUS_TRUSTED_HOSTS
-            except AttributeError:
-                pass
+            handler.trusted_hosts = getattr(
+                settings,
+                "RUNSERVERPLUS_SERVER_ADDRESS_PORT",
+                getattr(settings, "RUNSERVERPLUS_TRUSTED_HOSTS", None),
+            )
 
         runserver_plus_started.send(sender=self)
         run_simple(

--- a/docs/runserver_plus.rst
+++ b/docs/runserver_plus.rst
@@ -96,7 +96,7 @@ environment parameter coming into the function.
 
     If you're using Werkzeug 3.0.3 or later, by default, the debugger will only
     be enabled if the hostname is one of ``[localhost, .localhost, 127.0.0.1]``.
-    You may allow more host names by setting the ``RUNSERVERPLUS_TRUSTED_HOSTS``.
+    You may allow more host names by setting the ``RUNSERVER_PLUS_TRUSTED_HOSTS``.
 
 .. _`Werkzeug WSGI utilities`: https://werkzeug.palletsprojects.com/
 
@@ -165,7 +165,7 @@ Proper files with this name and .crt and .key extensions will be created.
 Configuration
 ^^^^^^^^^^^^^
 
-The `RUNSERVERPLUS_SERVER_ADDRESS_PORT` setting can be configured to specify
+The `RUNSERVER_PLUS_SERVER_ADDRESS_PORT` setting can be configured to specify
 which address and port the development server should bind to.
 
 If you find yourself frequently starting the server with::
@@ -174,7 +174,7 @@ If you find yourself frequently starting the server with::
 
 You can use settings to automatically default your development to an address/port::
 
-    RUNSERVERPLUS_SERVER_ADDRESS_PORT = '0.0.0.0:8000'
+    RUNSERVER_PLUS_SERVER_ADDRESS_PORT = '0.0.0.0:8000'
 
 To ensure Werkzeug can log to the console, you may need to add the following
 to your settings::
@@ -206,10 +206,10 @@ Other configuration options and their defaults include:
   RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = 1000
 
   # After how many seconds auto-reload should scan for updates in poller-mode
-  RUNSERVERPLUS_POLLER_RELOADER_INTERVAL = 1
+  RUNSERVER_PLUS_POLLER_RELOADER_INTERVAL = 1
 
   # Werkzeug reloader type [auto, watchdog, or stat]
-  RUNSERVERPLUS_POLLER_RELOADER_TYPE = 'auto'
+  RUNSERVER_PLUS_POLLER_RELOADER_TYPE = 'auto'
 
   # Add extra files to watch
   RUNSERVER_PLUS_EXTRA_FILES = []
@@ -218,7 +218,7 @@ Other configuration options and their defaults include:
   RUNSERVER_PLUS_EXCLUDE_PATTERNS = []
 
   # List of domains to allow requests to the debugger from
-  RUNSERVERPLUS_TRUSTED_HOSTS = [".localhost", "127.0.0.1"]
+  RUNSERVER_PLUS_TRUSTED_HOSTS = [".localhost", "127.0.0.1"]
 
 
 IO Calls and CPU Usage
@@ -243,7 +243,7 @@ will decrease the CPU load at the expense of file edits taking longer to pick up
 
 This can be set two ways, in the django settings file::
 
-    RUNSERVERPLUS_POLLER_RELOADER_INTERVAL = 5
+    RUNSERVER_PLUS_POLLER_RELOADER_INTERVAL = 5
 
 or as a commad line argument::
 


### PR DESCRIPTION
There's a mixture of runserver_plus settings:
RUNSERVER_PLUS_...
RUNSERVERPLUS_...

This PR makes it possible to specify both variants in all cases, where currently `RUNSERVER_PLUS_...` is set. It shouldn't be backwards incompatible