### PR TITLE
Add optional prefix and postfix support to RandomCharField

### DIFF
--- a/docs/field_extensions.rst
+++ b/docs/field_extensions.rst
@@ -80,7 +80,12 @@ AutoRandomCharField will automatically create a
 unique random character field with the specified length. By default
 upper/lower case and digits are included as possible characters. Given
 a length of 8 that yields 3.4 million possible combinations. A 12
-character field would yield about 2 billion. Below are some examples::
+character field would yield about 2 billion.
+
+Optional `prefix` and `postfix` arguments allow you to prepend or append
+fixed strings to the generated value. The total length of prefix + postfix
+must be **less than** the field's `length`.
+Below are some examples::
 
     >>> RandomCharField(length=8, unique=True)
     BVm9GEaE
@@ -93,6 +98,15 @@ character field would yield about 2 billion. Below are some examples::
 
     >>> RandomCharField(length=12, lowercase=True, include_digits=False)
     pzolbemetmok
+
+    >>> RandomCharField(length=10, prefix='u-')
+    u-P6gOMeRg
+
+    >>> RandomCharField(length=10, postfix='-x')
+    QpP0lkct-x
+
+    >>> RandomCharField(length=10, prefix='t-', postfix='-y')
+    t-QpP0lkct-y
 
 CreationDateTimeField
 ---------------------

--- a/tests/test_randomchar_field.py
+++ b/tests/test_randomchar_field.py
@@ -17,6 +17,7 @@ from .testapp.models import (
     RandomCharTestModelPunctuation,
     RandomCharTestModelLowercaseAlphaDigits,
     RandomCharTestModelUppercaseAlphaDigits,
+    RandomCharTestModelPrefixAndPostFix,
 )
 from .testapp.models import RandomCharTestModelUniqueTogether
 
@@ -108,3 +109,35 @@ class RandomCharFieldTest(TestCase):
             m.common_field = "bbb"
             with pytest.raises(RuntimeError):
                 m.save()
+
+    def testRandomCharFieldPrefix(self):
+        m = RandomCharTestModelPrefixAndPostFix()
+        m.save()
+        assert len(m.random_char_field_with_prefix) == 10
+        assert m.random_char_field_with_prefix.startswith("u-")
+
+    def testRandomCharFieldPostfix(self):
+        m = RandomCharTestModelPrefixAndPostFix()
+        m.save()
+        assert len(m.random_char_field_with_postfix) == 10
+        assert m.random_char_field_with_postfix.endswith("-k")
+
+    def testRandomCharFieldPostfixAndPrefixTogether(self):
+        m = RandomCharTestModelPrefixAndPostFix()
+        m.save()
+        assert len(m.random_char_field_with_postfix) == 10
+        assert m.combine_prefix_and_post_field.startswith("a-")
+        assert m.combine_prefix_and_post_field.endswith("-b")
+
+    def testPrefixPostfixExceedsLength(self):
+        with self.assertRaises(ValueError) as cm:
+            from django.db import models
+
+            class InvalidModel(models.Model):
+                from django_extensions.db.fields import RandomCharField
+
+                field = RandomCharField(length=5, prefix="abc", postfix="def")
+
+        self.assertIn(
+            "length of prefix + postfix should be less than 'length'", str(cm.exception)
+        )

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -461,6 +461,17 @@ class RandomCharTestModelUniqueTogether(models.Model):
         unique_together = ("random_char_field", "common_field")
 
 
+class RandomCharTestModelPrefixAndPostFix(models.Model):
+    random_char_field_with_prefix = RandomCharField(length=10, prefix="u-")
+    random_char_field_with_postfix = RandomCharField(length=10, postfix="-k")
+    combine_prefix_and_post_field = RandomCharField(
+        length=10, prefix="a-", postfix="-b"
+    )
+
+    class Meta:
+        app_label = "django_extensions"
+
+
 class TimestampedTestModel(TimeStampedModel):
     class Meta:
         app_label = "django_extensions"


### PR DESCRIPTION
- Added `prefix` and `postfix` arguments to RandomCharField
- Validates that prefix + postfix length is less than field length
- Updated random character generation to include prefix and postfix
- Added tests for prefix, postfix, and prefix+postfix scenarios
- Updated documentation with usage examples

This PR addresses #1918 