### PR TITLE
Document reset_schema command

### DIFF
--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -21,6 +21,7 @@ Command Extensions
    merge_model_instances
    print_settings
    reset_db
+   reset_schema
    runprofileserver
    runserver_plus
    sync_s3
@@ -109,6 +110,8 @@ Command Extensions
 * *raise_test_exception* - Raises a test exception via command. Useful for debugging error reporters such as Sentry.
 
 * :doc:`reset_db` - Resets a database (currently sqlite3, mysql, postgres). Uses "DROP DATABASE" and "CREATE DATABASE".
+
+* :doc:`reset_schema` - Resets a schema in database (postgres only). Uses "DROP SCHEMA" and "CREATE SCHEMA".
 
 * *runjob* - Run a single maintenance job.  Part of the jobs system.
 

--- a/docs/reset_schema.rst
+++ b/docs/reset_schema.rst
@@ -1,0 +1,78 @@
+reset_schema
+========
+
+:synopsis: Fully resets your database by running DROP SCHEMA and CREATE SCHEMA
+
+Django command that resets your Django database, removing all data from all
+tables. This allows you to run all migrations again.
+
+By default the command will prompt you to confirm that all data will be
+deleted. This can be turned off with the ``--noinput``-argument.
+
+Supported engines
+-----------------
+The command supports only Postgres database.
+
+Example Usage
+-------------
+
+::
+
+  # Reset the public schema so that database contains no data and migrations can be run again
+  $ ./manage.py reset_schema 
+
+::
+
+  # Don't ask for a confirmation before doing the reset
+  $ ./manage.py reset_schema --noinput
+
+::
+
+  # Use a specific database router
+  $ ./manage.py reset_schema --router my_router
+
+::
+
+  # Run command for a specific database
+  $ ./manage.py reset_schema --database secondary_db
+
+::
+
+  # Drop a different schema instead of "public"
+  $ ./manage.py reset_schema --schema custom_schema
+
+::
+
+  # Run with increased verbosity level
+  $ ./manage.py reset_schema --verbosity 2
+
+::
+
+  # Use a specific settings module
+  $ ./manage.py reset_schema --settings myproject.settings.local
+
+::
+
+  # Add a directory to Python path
+  $ ./manage.py reset_schema --pythonpath "/home/djangoprojects/myproject"
+
+::
+
+  # Show full traceback on errors
+  $ ./manage.py reset_schema --traceback
+
+::
+
+  # Run without colored output
+  $ ./manage.py reset_schema --no-color
+
+::
+
+  # Force colored output
+  $ ./manage.py reset_schema --force-color
+
+::
+
+  # Skip system checks
+  $ ./manage.py reset_schema --skip-checks
+


### PR DESCRIPTION
The `reset_schema` was introduced in 2.0.0 https://github.com/django-extensions/django-extensions/blob/2edf65b7eb5ed7ddc00f4834962d6225d3bf5911/CHANGELOG.md?plain=1#L575 but wasn't documented. It complicates finding the command by docs users and AI assistants. 