### PR TITLE
docs: Remove broken badge for deleted security workflow (fixes #1959)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,6 @@
 .. image:: https://github.com/django-extensions/django-extensions/actions/workflows/pytest.yml/badge.svg
     :target: https://github.com/django-extensions/django-extensions/actions
 
-.. image:: https://github.com/django-extensions/django-extensions/actions/workflows/security.yml/badge.svg
-    :target: https://github.com/django-extensions/django-extensions/actions
-
 .. image:: https://img.shields.io/pypi/v/django-extensions.svg
     :target: https://pypi.python.org/pypi/django-extensions/
     :alt: Latest PyPI version


### PR DESCRIPTION
This pull request removes the badge for the `security.yml` workflow from the README.

The underlying workflow was deleted in a previous commit, causing the badge to show a 404 error.

Fixes #1959