### PR TITLE
fix: Use utf8mb4 charset in reset_db command

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -180,7 +180,7 @@ Type 'yes' to continue, or 'no' to cancel: """
 
             connection = Database.connect(**kwargs)
             drop_query = "DROP DATABASE IF EXISTS `%s`" % database_name
-            utf8_support = "" if options["no_utf8_support"] else "CHARACTER SET utf8"
+            utf8_support = "" if options["no_utf8_support"] else "CHARACTER SET utf8mb4"
             create_query = "CREATE DATABASE `%s` %s" % (database_name, utf8_support)
             logging.info('Executing... "%s"', drop_query)
             connection.query(drop_query)

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -85,10 +85,10 @@ The envisioned use case is something like this:
         elif engine in MYSQL_ENGINES:
             sys.stderr.write(
                 """-- WARNING!: https://docs.djangoproject.com/en/dev/ref/databases/#collation-settings
--- Please read this carefully! Collation will be set to utf8_bin to have case-sensitive data.
+-- Please read this carefully! Collation will be set to utf8mb4_bin to have case-sensitive data.
 """  # noqa: E501
             )
-            print("CREATE DATABASE %s CHARACTER SET utf8 COLLATE utf8_bin;" % dbname)
+            print("CREATE DATABASE %s CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;" % dbname)
             print(
                 "GRANT ALL PRIVILEGES ON %s.* to '%s'@'%s' identified by '%s';"
                 % (dbname, dbuser, dbclient, dbpass)

--- a/django_extensions/management/commands/sqlcreate.py
+++ b/django_extensions/management/commands/sqlcreate.py
@@ -88,7 +88,9 @@ The envisioned use case is something like this:
 -- Please read this carefully! Collation will be set to utf8mb4_bin to have case-sensitive data.
 """  # noqa: E501
             )
-            print("CREATE DATABASE %s CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;" % dbname)
+            print(
+                "CREATE DATABASE %s CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;" % dbname
+            )
             print(
                 "GRANT ALL PRIVILEGES ON %s.* to '%s'@'%s' identified by '%s';"
                 % (dbname, dbuser, dbclient, dbpass)

--- a/tests/management/commands/test_reset_db.py
+++ b/tests/management/commands/test_reset_db.py
@@ -128,7 +128,7 @@ class ResetDbMysqlTests(TestCase):
         m_database.connect.return_value = m_connection
         expected_calls = [
             mock.call("DROP DATABASE IF EXISTS `test_db`"),
-            mock.call("CREATE DATABASE `test_db` CHARACTER SET utf8"),
+            mock.call("CREATE DATABASE `test_db` CHARACTER SET utf8mb4"),
         ]
 
         with mock.patch.dict("sys.modules", MySQLdb=m_database):


### PR DESCRIPTION
# Fix: Use utf8mb4 charset in reset_db command

This change updates the default charset to `utf8mb4`, aligning with Django's modern defaults and restoring full Unicode support.

- Updates `reset_db` command to use `utf8mb4`.
- Updates the related `sqlcreate` command for consistency and adds the `utf8mb4_bin` collation for case-sensitive behavior.
- Updates unit tests to assert the correct charset is used.