### PR TITLE
Fix: Use stricter exception handling in foreignkey_autocomplete

### DIFF
--- a/django_extensions/admin/__init__.py
+++ b/django_extensions/admin/__init__.py
@@ -125,7 +125,7 @@ class ForeignKeyAutocompleteAdminMixin:
             elif object_pk:
                 try:
                     obj = queryset.get(pk=object_pk)
-                except Exception:  # FIXME: use stricter exception checking
+                except (model.DoesNotExist, model.MultipleObjectsReturned):
                     pass
                 else:
                     data = to_string_function(obj)


### PR DESCRIPTION
This PR addresses the FIXME comment in `django_extensions/admin/__init__.py` by replacing the bare `Exception` catch with specific Django model exceptions (`model.DoesNotExist`, `model.MultipleObjectsReturned`).

This follows Django best practices for exception handling and makes the code more explicit about which exceptions are being handled.

**Changes:**
- Replace `except Exception:` with `except (model.DoesNotExist, model.MultipleObjectsReturned):`
- Remove FIXME comment

**Testing:**
- All admin tests pass successfully
- No linting errors introduced