### PR TITLE
Fix KeyError on runserver_plus --noreload with Werkzeug 3.x

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -393,7 +393,9 @@ class Command(BaseCommand):
         addrport = options["addrport"]
         startup_messages = options["startup_messages"]
         if startup_messages == "reload":
-            self.show_startup_messages = os.environ.get("RUNSERVER_PLUS_SHOW_MESSAGES")
+            self.show_startup_messages = (
+                not options["use_reloader"]
+            ) or os.environ.get("RUNSERVER_PLUS_SHOW_MESSAGES")
         elif startup_messages == "once":
             self.show_startup_messages = not os.environ.get(
                 "RUNSERVER_PLUS_SHOW_MESSAGES"
@@ -531,6 +533,34 @@ class Command(BaseCommand):
 
         return application
 
+    @staticmethod
+    def is_werkzeug_reloader_process():
+        return os.environ.get("WERKZEUG_RUN_MAIN") == "true"
+
+    @staticmethod
+    def log_debugger_startup(debugger):
+        _log("warning", " * Debugger is active!")
+        if debugger.pin is None:
+            _log("warning", " * Debugger PIN disabled. DEBUGGER UNSECURED!")
+        else:
+            _log("info", " * Debugger PIN: %s", debugger.pin)
+
+    def wrap_handler_with_debugger(self, handler):
+        debugger = DebuggedApplication(handler, True)
+        trusted_hosts = getattr(
+            settings,
+            "RUNSERVER_PLUS_TRUSTED_HOSTS",
+            getattr(settings, "RUNSERVERPLUS_TRUSTED_HOSTS", None),
+        )
+        if trusted_hosts is not None:
+            if isinstance(trusted_hosts, str):
+                debugger.trusted_hosts = [trusted_hosts]
+            else:
+                debugger.trusted_hosts = list(trusted_hosts)
+        if self.addr not in debugger.trusted_hosts:
+            debugger.trusted_hosts.append(self.addr)
+        return debugger
+
     def inner_run(self, options):
         if not HAS_WERKZEUG:
             raise CommandError(
@@ -650,24 +680,21 @@ class Command(BaseCommand):
             getattr(settings, "RUNSERVER_PLUS_EXCLUDE_PATTERNS", [])
         )
 
-        # Werkzeug needs to be clued in its the main instance if running
-        # without reloader or else it won't show key.
-        # https://git.io/vVIgo
+        # Werkzeug treats WERKZEUG_RUN_MAIN as the reloader child marker.
+        # Forcing it in --noreload mode makes run_simple() expect
+        # WERKZEUG_SERVER_FD and crash before the server starts.
         if not use_reloader:
-            os.environ["WERKZEUG_RUN_MAIN"] = "true"
+            os.environ.pop("WERKZEUG_RUN_MAIN", None)
 
-        # Don't run a second instance of the debugger / reloader
-        # See also: https://github.com/django-extensions/django-extensions/issues/832
-        if os.environ.get("WERKZEUG_RUN_MAIN") != "true":
-            if self.nopin:
-                os.environ["WERKZEUG_DEBUG_PIN"] = "off"
-            handler = DebuggedApplication(handler, True)
-            # Set trusted_hosts (for Werkzeug 3.0.3+)
-            handler.trusted_hosts = getattr(
-                settings,
-                "RUNSERVERPLUS_SERVER_ADDRESS_PORT",
-                getattr(settings, "RUNSERVERPLUS_TRUSTED_HOSTS", None),
-            )
+        if self.nopin:
+            os.environ["WERKZEUG_DEBUG_PIN"] = "off"
+
+        # Only the single-process server or the reloader child should wrap the
+        # app with the debugger. The reloader parent never serves requests.
+        if not use_reloader or self.is_werkzeug_reloader_process():
+            handler = self.wrap_handler_with_debugger(handler)
+            if not self.is_werkzeug_reloader_process():
+                self.log_debugger_startup(handler)
 
         runserver_plus_started.send(sender=self)
         run_simple(
@@ -675,7 +702,7 @@ class Command(BaseCommand):
             int(self.port),
             handler,
             use_reloader=use_reloader,
-            use_debugger=True,
+            use_debugger=False,  # Debugger already wrapped.
             extra_files=self.extra_files,
             exclude_patterns=exclude_patterns,
             reloader_interval=reloader_interval,

--- a/tests/management/commands/test_runserver_plus.py
+++ b/tests/management/commands/test_runserver_plus.py
@@ -1,7 +1,18 @@
+import os
+
 import pytest
 from django.core.management import call_command
+from django.test.utils import override_settings
 
 from unittest import mock
+
+
+class FakeDebuggedApplication:
+    def __init__(self, app, evalex):
+        self.app = app
+        self.evalex = evalex
+        self.pin = "123-456-789"
+        self.trusted_hosts = [".localhost", "127.0.0.1"]
 
 
 @pytest.mark.django_db
@@ -11,3 +22,105 @@ def test_initialize_runserver_plus():
     ) as run_simple:
         call_command("runserver_plus")
         assert run_simple.called, "werkzeug.run_simple was not called"
+
+
+@pytest.mark.django_db
+def test_runserver_plus_shows_startup_messages_without_reloader(monkeypatch, capsys):
+    monkeypatch.delenv("RUNSERVER_PLUS_SHOW_MESSAGES", raising=False)
+    monkeypatch.delenv("WERKZEUG_RUN_MAIN", raising=False)
+
+    with (
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.DebuggedApplication",
+            FakeDebuggedApplication,
+        ),
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.run_simple"
+        ),
+        mock.patch("django_extensions.management.commands.runserver_plus._log"),
+    ):
+        call_command("runserver_plus", use_reloader=False)
+
+    output = capsys.readouterr().out
+    assert "Using the Werkzeug debugger (https://werkzeug.palletsprojects.com/)" in output
+
+
+@pytest.mark.django_db
+@override_settings(RUNSERVER_PLUS_TRUSTED_HOSTS=["debug.example"])
+def test_runserver_plus_wraps_debugger_without_reloader(monkeypatch):
+    monkeypatch.delenv("WERKZEUG_RUN_MAIN", raising=False)
+    monkeypatch.delenv("WERKZEUG_DEBUG_PIN", raising=False)
+
+    with (
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.DebuggedApplication",
+            FakeDebuggedApplication,
+        ),
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.run_simple"
+        ) as run_simple,
+        mock.patch("django_extensions.management.commands.runserver_plus._log") as log,
+    ):
+        call_command("runserver_plus", use_reloader=False, startup_messages="never")
+
+    app = run_simple.call_args.args[2]
+    assert isinstance(app, FakeDebuggedApplication)
+    assert "WERKZEUG_RUN_MAIN" not in os.environ
+    assert run_simple.call_args.kwargs["use_debugger"] is False
+    assert app.trusted_hosts == ["debug.example", "127.0.0.1"]
+    log.assert_any_call("warning", " * Debugger is active!")
+    log.assert_any_call("info", " * Debugger PIN: %s", "123-456-789")
+
+
+@pytest.mark.django_db
+def test_runserver_plus_sets_nopin_before_reloader_parent(monkeypatch):
+    monkeypatch.delenv("WERKZEUG_RUN_MAIN", raising=False)
+    monkeypatch.delenv("WERKZEUG_DEBUG_PIN", raising=False)
+
+    with (
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.DebuggedApplication"
+        ) as debugged_application,
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.run_simple"
+        ) as run_simple,
+    ):
+        call_command(
+            "runserver_plus",
+            use_reloader=True,
+            nopin=True,
+            startup_messages="never",
+        )
+
+    debugged_application.assert_not_called()
+    assert os.environ["WERKZEUG_DEBUG_PIN"] == "off"
+    assert run_simple.call_args.kwargs["use_debugger"] is False
+
+
+@pytest.mark.django_db
+@override_settings(RUNSERVER_PLUS_TRUSTED_HOSTS=["debug.example"])
+def test_runserver_plus_wraps_debugger_in_reloader_child(monkeypatch):
+    monkeypatch.setenv("WERKZEUG_RUN_MAIN", "true")
+    monkeypatch.delenv("WERKZEUG_DEBUG_PIN", raising=False)
+
+    with (
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.DebuggedApplication",
+            FakeDebuggedApplication,
+        ),
+        mock.patch(
+            "django_extensions.management.commands.runserver_plus.run_simple"
+        ) as run_simple,
+        mock.patch("django_extensions.management.commands.runserver_plus._log") as log,
+    ):
+        call_command(
+            "runserver_plus",
+            use_reloader=True,
+            startup_messages="never",
+        )
+
+    app = run_simple.call_args.args[2]
+    assert isinstance(app, FakeDebuggedApplication)
+    assert run_simple.call_args.kwargs["use_debugger"] is False
+    assert app.trusted_hosts == ["debug.example", "127.0.0.1"]
+    log.assert_not_called()


### PR DESCRIPTION
Refs #1886

**Setup**
- Python 3.13
- Django 5.2.12
- Werkzeug 3.1.6

**Problem**
- `runserver_plus --noreload` forced `WERKZEUG_RUN_MAIN="true"`, but Werkzeug uses that flag to identify the real reloader child through [`is_running_from_reloader()`](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/serving.py#L951-L957). Because of that, [`run_simple()`](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/serving.py#L1088-L1092) tried to read `WERKZEUG_SERVER_FD` in no-reload mode, where no reloader parent had created it yet, causing `KeyError: 'WERKZEUG_SERVER_FD'`.
- Debugger setup was also split between `runserver_plus` and Werkzeug, which made ownership unclear and led to inconsistent behavior across reloader and no-reload paths.

**Solution**
- In `inner_run()`, `runserver_plus` no longer forces `WERKZEUG_RUN_MAIN`; it clears it in `--noreload` mode so Werkzeug follows its normal no-reload path.
- Debugger wrapping is now handled explicitly by `runserver_plus` in `wrap_handler_with_debugger()`, and the final Werkzeug call uses `use_debugger=False` to avoid double wrapping. `use_debugger=False` does not disable the debugger: the application is already wrapped with `DebuggedApplication`, so this only prevents Werkzeug from creating a second debugger layer inside [`run_simple()`](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/serving.py#L1080-L1086).
- The debugger is applied only in processes that actually serve requests: the single-process no-reload case and the true reloader child, matching Werkzeug’s reloader flow in [`run_with_reloader()`](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/_reloader.py#L436-L465).
- A follow-up adjustment keeps startup messages visible in `--noreload` and avoids duplicate debugger/PIN logs in reloader mode, where Werkzeug already logs them from [`DebuggedApplication`](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/debug/__init__.py#L293-L301).
