### PR TITLE
fix: pass self to _orig_log fallback in runserver_plus werk_log

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -745,7 +745,7 @@ def set_werkzeug_log_color():
             )
             http_code = str(args[1])
         except Exception:
-            return _orig_log(type, message, *args)
+            return _orig_log(self, type, message, *args)
 
         # Utilize terminal colors, if available
         if http_code[0] == "2":

--- a/tests/management/commands/test_runserver_plus.py
+++ b/tests/management/commands/test_runserver_plus.py
@@ -3,6 +3,10 @@ from django.core.management import call_command
 
 from unittest import mock
 
+from werkzeug.serving import WSGIRequestHandler
+
+from django_extensions.management.commands import runserver_plus
+
 
 @pytest.mark.django_db
 def test_initialize_runserver_plus():
@@ -11,3 +15,22 @@ def test_initialize_runserver_plus():
     ) as run_simple:
         call_command("runserver_plus")
         assert run_simple.called, "werkzeug.run_simple was not called"
+
+
+def test_werk_log_fallback_passes_self_to_orig_log():
+    orig_log = mock.Mock(name="orig_log")
+    saved = WSGIRequestHandler.log
+    WSGIRequestHandler.log = orig_log
+    try:
+        runserver_plus.set_werkzeug_log_color()
+        werk_log = WSGIRequestHandler.log
+
+        class FakeHandler:
+            pass
+
+        handler = FakeHandler()
+        werk_log(handler, "error", "boom %s", "x")
+
+        orig_log.assert_called_once_with(handler, "error", "boom %s", "x")
+    finally:
+        WSGIRequestHandler.log = saved


### PR DESCRIPTION
In `set_werkzeug_log_color`, the `werk_log` exception fallback calls `_orig_log(type, message, *args)` without `self`, so Werkzeug's unbound `log` function takes the `type` string as `self` and crashes with `AttributeError: 'str' object has no attribute 'address_string'` on SSL errors.

Closes #1971