### PR TITLE
fix: serialize non-JSON settings via str default in print_settings --format=json

### DIFF
--- a/django_extensions/management/commands/print_settings.py
+++ b/django_extensions/management/commands/print_settings.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
         indent = options["indent"]
 
         if output_format == "json":
-            print(json.dumps(settings_dct, indent=indent))
+            print(json.dumps(settings_dct, indent=indent, default=str))
         elif output_format == "yaml":
             import yaml  # requires PyYAML
 

--- a/tests/management/commands/test_print_settings.py
+++ b/tests/management/commands/test_print_settings.py
@@ -1,5 +1,9 @@
+import json
+from pathlib import Path
+
 import pytest
 from django.core.management import CommandError, call_command
+from django.test.utils import override_settings
 
 
 def test_without_args(capsys):
@@ -70,3 +74,16 @@ def test_format_json_without_indent(capsys):
     expected = '{\n"DEBUG": false\n}\n'
     out, err = capsys.readouterr()
     assert expected == out
+
+
+@override_settings(BASE_DIR=Path("/tmp/example"))
+def test_format_json_serializes_path(capsys):
+    call_command(
+        "print_settings",
+        "BASE_DIR",
+        "--format=json",
+    )
+
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    assert data == {"BASE_DIR": str(Path("/tmp/example"))}


### PR DESCRIPTION
`print_settings --format=json` crashes with `TypeError: Object of type PosixPath is not JSON serializable` because modern Django projects (3.1+) set `BASE_DIR = Path(__file__)...`. Passing `default=str` to `json.dumps` falls back to `str()` for any non-JSON value (Path, Decimal, datetime, etc.) instead of failing.

Closes #1905