### PR TITLE
Fix typos in docstrings, comments, and documentation

### DIFF
--- a/django_extensions/management/commands/graph_models.py
+++ b/django_extensions/management/commands/graph_models.py
@@ -132,7 +132,7 @@ class Command(BaseCommand):
                 "action": "store",
                 "dest": "outputfile",
                 "help": (
-                    "Render output file. Type of output dependend on file extensions. "
+                    "Render output file. Type of output dependent on file extensions. "
                     "Use png or jpg to render graph to image."
                 ),
             },

--- a/django_extensions/management/commands/print_user_for_session.py
+++ b/django_extensions/management/commands/print_user_for_session.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             print("No user associated with that id.")
             return
 
-        # use django standrd api for reporting
+        # use django standard api for reporting
         print("full name: %s" % user.get_full_name())
         print("short name: %s" % user.get_short_name())
         print("username: %s" % user.get_username())

--- a/django_extensions/management/commands/runjob.py
+++ b/django_extensions/management/commands/runjob.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         try:
             job().execute()
         except Exception:
-            logger.exception("ERROR OCCURED IN JOB: %s (APP: %s)", job_name, app_name)
+            logger.exception("ERROR OCCURRED IN JOB: %s (APP: %s)", job_name, app_name)
 
     @signalcommand
     def handle(self, *args, **options):

--- a/django_extensions/management/commands/runjobs.py
+++ b/django_extensions/management/commands/runjobs.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
                 job().execute()
             except Exception:
                 logger.exception(
-                    "ERROR OCCURED IN JOB: %s (APP: %s)", job_name, app_name
+                    "ERROR OCCURRED IN JOB: %s (APP: %s)", job_name, app_name
                 )
 
     def runjobs_by_signals(self, when, options):

--- a/django_extensions/templatetags/highlighting.py
+++ b/django_extensions/templatetags/highlighting.py
@@ -78,7 +78,7 @@ class CodeNode(Node):
 def highlight(parser, token):
     """
     Tag to put a highlighted source code <pre> block in your code.
-    This takes two arguments, the language and a little explaination message
+    This takes two arguments, the language and a little explanation message
     that will be generated before the code.  The second argument is optional.
 
     Your code will be fed through pygments so you can use any language it

--- a/django_extensions/templatetags/indent_text.py
+++ b/django_extensions/templatetags/indent_text.py
@@ -39,7 +39,7 @@ def indentby(parser, token):
 
     Arguments:
       indent_level - Number of spaces to indent text with.
-      statement - Only apply indent_level if the boolean statement evalutates to True.
+      statement - Only apply indent_level if the boolean statement evaluates to True.
     """
     args = token.split_contents()
     largs = len(args)

--- a/docs/command_extensions.rst
+++ b/docs/command_extensions.rst
@@ -100,7 +100,7 @@ Command Extensions
   It seems this works only if setting ``SESSION_ENGINE`` is
   ``'django.contrib.sessions.backends.db'`` (default value).
 
-* *drop_test_database* - Drops the test database. Usefull when running Django
+* *drop_test_database* - Drops the test database. Useful when running Django
   test via some automated system (BuildBot, Jenkins, etc) and making sure that
   the test database is always dropped at the end.
 

--- a/docs/generate_password.rst
+++ b/docs/generate_password.rst
@@ -12,7 +12,7 @@ This uses Python's secret module `Recipes and best practices`_ to generate a pas
 There are two options.
 
 You can specify the length of password with the option ``--length``. If you don't specify ``--length``, a default value of 16 is applied.
-Using ``--complex`` will add punctuation to the aphabet of characters which the password will be generated from.
+Using ``--complex`` will add punctuation to the alphabet of characters which the password will be generated from.
 
 
 Usage

--- a/docs/reset_db.rst
+++ b/docs/reset_db.rst
@@ -61,7 +61,7 @@ Optional settings
 -----------------
 
 It is possible to use a Django DB engine not in the lists above -- to do that add
-the approriate setting as shown below to your Django settings file::
+the appropriate setting as shown below to your Django settings file::
 
   # settings.py
   DJANGO_EXTENSIONS_RESET_DB_SQLITE_ENGINES = ['your_custom_sqlite_engine']

--- a/docs/runserver_plus.rst
+++ b/docs/runserver_plus.rst
@@ -232,7 +232,7 @@ I/O when idle.
 This is due to the way Werkzeug_ has implemented the auto reload capability.
 It supports two ways of doing auto reloading either via `stat polling` or `file system events`.
 
-The `stat polling` approach is pretty brute force and continously issues `stat` system calls which
+The `stat polling` approach is pretty brute force and continuously issues `stat` system calls which
 causes the CPU and IO load.
 
 If possible try to install the Watchdog_ package, this should automatically cause Werkzeug_ to use
@@ -247,7 +247,7 @@ This can be set two ways, in the django settings file::
 
     RUNSERVER_PLUS_POLLER_RELOADER_INTERVAL = 5
 
-or as a commad line argument::
+or as a command line argument::
 
   $ python manage.py runserver_plus --reloader-interval 5
 

--- a/docs/verify_named_urls.rst
+++ b/docs/verify_named_urls.rst
@@ -45,7 +45,7 @@ Example output, where the first named URL is defined, the second is missing:
 
 ::
 
-    Name: entry-detail (1 occurences, handled in EntryDetailView, blog/<slug:slug>)
+    Name: entry-detail (1 occurrences, handled in EntryDetailView, blog/<slug:slug>)
     * /home/myuser/django/blog/templates/blog/entry-list.html:9
-    Name: this-view-is-removed-by-now (1 occurences, UNKNOWN VIEW)
+    Name: this-view-is-removed-by-now (1 occurrences, UNKNOWN VIEW)
     * /home/myuser/django/blog/templates/blog/reference.html:6


### PR DESCRIPTION
## Summary

Fix several spelling mistakes found via codespell across source code and documentation:

**Source code (docstrings, comments, log messages):**
- `explaination` -> `explanation` in `django_extensions/templatetags/highlighting.py`
- `evalutates` -> `evaluates` in `django_extensions/templatetags/indent_text.py`
- `dependend` -> `dependent` in `django_extensions/management/commands/graph_models.py`
- `standrd` -> `standard` in `django_extensions/management/commands/print_user_for_session.py`
- `OCCURED` -> `OCCURRED` in `django_extensions/management/commands/runjob.py` and `runjobs.py`

**Documentation (.rst files):**
- `Usefull` -> `Useful` in `docs/command_extensions.rst`
- `aphabet` -> `alphabet` in `docs/generate_password.rst`
- `approriate` -> `appropriate` in `docs/reset_db.rst`
- `continously` -> `continuously` in `docs/runserver_plus.rst`
- `commad` -> `command` in `docs/runserver_plus.rst`
- `occurences` -> `occurrences` in `docs/verify_named_urls.rst`

No functional changes - only spelling corrections in non-code text.