### PR TITLE
Add Spatialite support to reset_db

### DIFF
--- a/django_extensions/collision_resolvers.py
+++ b/django_extensions/collision_resolvers.py
@@ -45,7 +45,7 @@ class LegacyCR(BaseCR):
 
 
 class AppsOrderCR(LegacyCR, metaclass=ABCMeta):
-    APP_PRIORITIES = None  # type: List[str]
+    APP_PRIORITIES = None  # type: Optional[List[str]]
 
     def resolve_collisions(self, namespace):
         assert self.APP_PRIORITIES is not None, (
@@ -59,11 +59,13 @@ class AppsOrderCR(LegacyCR, metaclass=ABCMeta):
         return result
 
     def _sort_models_depending_on_priorities(self, models):  # type: (List[str]) -> List[Tuple[int, str]]
+        app_priorities = self.APP_PRIORITIES
+        assert app_priorities is not None
         models_with_priorities = []
         for model in models:
             try:
                 app_name, _ = self.get_app_name_and_model(model)
-                position = self.APP_PRIORITIES.index(app_name)
+                position = app_priorities.index(app_name)
             except (ImportError, ValueError):
                 position = sys.maxsize
             models_with_priorities.append((position, model))

--- a/django_extensions/db/fields/__init__.py
+++ b/django_extensions/db/fields/__init__.py
@@ -88,7 +88,9 @@ class UniqueFieldMixin:
         kwargs[self.attname] = new
         while True:
             matching = queryset.filter(query, **kwargs)
-            has_match = matching.exists() if hasattr(matching, "exists") else bool(matching)
+            has_match = (
+                matching.exists() if hasattr(matching, "exists") else bool(matching)
+            )
             if new and not has_match:
                 break
             new = next(iterator)

--- a/django_extensions/settings.py
+++ b/django_extensions/settings.py
@@ -8,6 +8,7 @@ REPLACEMENTS = getattr(settings, "EXTENSIONS_REPLACEMENTS", {})
 DEFAULT_SQLITE_ENGINES = (
     "django.db.backends.sqlite3",
     "django.db.backends.spatialite",
+    "django.contrib.gis.db.backends.spatialite",
     "django_prometheus.db.backends.sqlite3",
 )
 DEFAULT_MYSQL_ENGINES = (

--- a/docs/reset_db.rst
+++ b/docs/reset_db.rst
@@ -19,6 +19,7 @@ by looking up your Django database engine in the following lists.
   DEFAULT_SQLITE_ENGINES = (
       'django.db.backends.sqlite3',
       'django.db.backends.spatialite',
+      'django.contrib.gis.db.backends.spatialite',
   )
   DEFAULT_MYSQL_ENGINES = (
       'django.db.backends.mysql',

--- a/tests/management/commands/test_reset_db.py
+++ b/tests/management/commands/test_reset_db.py
@@ -75,6 +75,22 @@ class ResetDbSqlite3Tests(TestCase):
         self.assertEqual("Reset successful.\n", m_stdout.getvalue())
         m_unlink.assert_called_once_with("test_db.sqlite3")
 
+    @override_settings(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.contrib.gis.db.backends.spatialite",
+                "NAME": "test_db.sqlite3",
+            }
+        }
+    )
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    @mock.patch.object(os, "unlink")
+    def test_should_unlink_spatialite_database(self, m_unlink, m_stdout):
+        call_command("reset_db", "--noinput", verbosity=2)
+
+        self.assertEqual("Reset successful.\n", m_stdout.getvalue())
+        m_unlink.assert_called_once_with("test_db.sqlite3")
+
     @mock.patch("sys.stdout", new_callable=StringIO)
     @mock.patch.object(
         os,

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -180,9 +180,17 @@ class PostWithUniqField(models.Model):
             ),
             models.CheckConstraint(
                 **(
-                    {"condition": ~models.Q(common_field=models.F("another_common_field"))}
+                    {
+                        "condition": ~models.Q(
+                            common_field=models.F("another_common_field")
+                        )
+                    }
                     if django.VERSION >= (5, 2)
-                    else {"check": ~models.Q(common_field=models.F("another_common_field"))}
+                    else {
+                        "check": ~models.Q(
+                            common_field=models.F("another_common_field")
+                        )
+                    }
                 ),
                 name="common_and_another_common_differ",
             ),


### PR DESCRIPTION
## Summary

- recognize Django's Spatialite backend as a SQLite engine
- reset Spatialite databases by unlinking the database file
- document the supported backend and add regression coverage

Closes #1985.

## Tests

- `.venv/bin/pytest tests/management/commands/test_reset_db.py -q`
- `.venv/bin/ruff check django_extensions/settings.py tests/management/commands/test_reset_db.py`
