### PR TITLE
Update reset_db command to use DROP DATABASE IF EXISTS for Postgres

### DIFF
--- a/django_extensions/management/commands/notes.py
+++ b/django_extensions/management/commands/notes.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # don't add django internal code
         apps = [
-            app.replace(".", "/")
+            app.replace(".", os.path.sep)
             for app in filter(
                 lambda app: not app.startswith("django.contrib"),
                 settings.INSTALLED_APPS,
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                     if os.path.splitext(fn)[1] in (".py", ".html"):
                         fpath = os.path.join(top, fn)
                         annotation_lines = []
-                        with open(fpath, "r") as fd:
+                        with open(fpath, "r", encoding="utf-8") as fd:
                             i = 0
                             for line in fd.readlines():
                                 i += 1

--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -225,7 +225,7 @@ Type 'yes' to continue, or 'no' to cancel: """
                 except Database.ProgrammingError as e:
                     logging.exception("Error: %s", str(e))
 
-            drop_query = 'DROP DATABASE "%s";' % database_name
+            drop_query = 'DROP DATABASE IF EXISTS "%s";' % database_name
             logging.info('Executing... "%s"', drop_query)
             try:
                 cursor.execute(drop_query)

--- a/tests/management/commands/test_create_command.py
+++ b/tests/management/commands/test_create_command.py
@@ -8,7 +8,6 @@ from io import StringIO
 
 from unittest.mock import patch
 
-
 TEST_APP = "testapp_with_appconfig"
 
 
@@ -17,16 +16,16 @@ class CreateCommandTests(TestCase):
 
     def setUp(self):  # noqa
         self.management_command_path = os.path.join(
-            settings.BASE_DIR, "tests/{}/management".format(TEST_APP)
+            settings.BASE_DIR, "tests", TEST_APP, "management"
         )
         self.command_template_path = os.path.join(
-            settings.BASE_DIR, "django_extensions/conf/command_template"
+            settings.BASE_DIR, "django_extensions", "conf", "command_template"
         )
 
         self.files = [
             "__init__.py",
-            "commands/__init__.py",
-            "commands/sample.py",
+            os.path.join("commands", "__init__.py"),
+            os.path.join("commands", "sample.py"),
         ]
 
     def tearDown(self):  # noqa

--- a/tests/management/commands/test_create_jobs.py
+++ b/tests/management/commands/test_create_jobs.py
@@ -8,7 +8,6 @@ from tests import testapp_with_no_models_file
 
 from unittest.mock import patch
 
-
 JOBS_DIR = os.path.join(testapp_with_no_models_file.__path__[0], "jobs")
 TIME_PERIODS = ["hourly", "daily", "weekly", "monthly", "yearly"]
 
@@ -52,7 +51,9 @@ class CreateJobsTests(CreateJobsTestsMixin, TestCase):
         self.assertTrue(os.path.exists(JOBS_DIR))
         for time_period in TIME_PERIODS:
             self.assertIn(
-                "testapp_with_no_models_file/jobs/{}/__init__.py".format(time_period),
+                os.path.join(
+                    "testapp_with_no_models_file", "jobs", time_period, "__init__.py"
+                ),
                 m_stdout.getvalue(),
             )
 
@@ -72,8 +73,11 @@ class CreateJobsTests(CreateJobsTestsMixin, TestCase):
         self.assertIn(TEST_COMMENT, open(sample_file_path).read())
         for time_period in TIME_PERIODS:
             self.assertIn(
-                "testapp_with_no_models_file/jobs/{}/__init__.py already exists".format(
-                    time_period
+                os.path.join(
+                    "testapp_with_no_models_file",
+                    "jobs",
+                    time_period,
+                    "__init__.py already exists",
                 ),
                 m_stdout.getvalue(),
             )

--- a/tests/management/commands/test_notes.py
+++ b/tests/management/commands/test_notes.py
@@ -9,7 +9,9 @@ def test_without_args(capsys, settings):
     out, err = capsys.readouterr()
     print([out])
     assert (
-        "tests/testapp/file_without_utf8_notes.py:\n  * [  1] TODO  this is a test todo\n\n"
+        "{}:\n  * [  1] TODO  this is a test todo\n\n".format(
+            os.path.join("tests", "testapp", "file_without_utf8_notes.py")
+        )
         in out
     )
 
@@ -19,7 +21,9 @@ def test_with_utf8(capsys, settings):
 
     out, err = capsys.readouterr()
     assert (
-        "tests/testapp/file_with_utf8_notes.py:\n  * [  1] TODO  Russian text followed: Это техт на кириллице\n\n"
+        "{}:\n  * [  1] TODO  Russian text followed: Это техт на кириллице\n\n".format(
+            os.path.join("tests", "testapp", "file_with_utf8_notes.py")
+        )
         in out
     )
 

--- a/tests/management/commands/test_reset_db.py
+++ b/tests/management/commands/test_reset_db.py
@@ -209,7 +209,7 @@ class ResetDbPostgresqlTests(TestCase):
         m_cursor = mock.Mock()
         m_database.connect.return_value.cursor.return_value = m_cursor
         expected_calls = [
-            mock.call('DROP DATABASE "test_db";'),
+            mock.call('DROP DATABASE IF EXISTS "test_db";'),
             mock.call(
                 'CREATE DATABASE "test_db" WITH OWNER = "foo"  ENCODING = \'UTF8\';'
             ),
@@ -246,7 +246,7 @@ class ResetDbPostgresqlTests(TestCase):
             mock.call(
                 "\n                    SELECT pg_terminate_backend(pg_stat_activity.pid)\n                    FROM pg_stat_activity\n                    WHERE pg_stat_activity.datname = 'test_db';\n                "
             ),
-            mock.call('DROP DATABASE "test_db";'),
+            mock.call('DROP DATABASE IF EXISTS "test_db";'),
             mock.call(
                 'CREATE DATABASE "test_db" WITH OWNER = "foo"  ENCODING = \'UTF8\' TABLESPACE = TEST_TABLESPACE;'
             ),

--- a/tests/management/commands/test_syncdata.py
+++ b/tests/management/commands/test_syncdata.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 from django.contrib.auth.models import User
@@ -8,7 +9,6 @@ from django.test.utils import override_settings
 from io import StringIO
 
 from unittest.mock import patch
-
 
 TEST_FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
@@ -50,8 +50,10 @@ class SyncDataExceptionsTests(TestCase):
     def test_should_return_SyncDataError_when_multiple_fixtures(self):
         with pytest.raises(
             CommandError,
-            match="Multiple fixtures named 'users' in '{}'. Aborting.".format(
-                TEST_FIXTURE_DIR
+            match=re.escape(
+                "Multiple fixtures named 'users' in '{}'. Aborting.".format(
+                    TEST_FIXTURE_DIR
+                )
             ),
         ):
             call_command("syncdata", "users", verbosity=2)


### PR DESCRIPTION
# Description

The `reset_db` command unconditionally attempts to drop the target database in Postgres resulting in an "InvalidCatalogName" error being logged if the command is called when the database does not yet exist. The exception is logged to the terminal, but does not impede the subsequent creation of the database.

This PR aims to handle this scenario gracefully without any modifying the existing behavior.

# Changes

- Add `IF EXISTS` clause to the drop query for Postgres in `reset_db`
- Update assorted paths to properly resolve regardless of OS (mostly test-related)


# Considerations

The `IF EXISTS` clause has been valid Postgres syntax since [Postgres 8.2](https://www.postgresql.org/docs/8.2/release-8-2.html) (2006-12-05). Acknowledging that some stacks may be locked to old versions for various reasons, I feel it's reasonable and safe to make this change. That having been said, this change is largely cosmetic in nature, and could break compatibility with versions prior to Postgres 8.2.