### PR TITLE
fix: Notebook v7 breaks shell_plus import

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -339,19 +339,22 @@ class Command(BaseCommand):
         try:
             from notebook.notebookapp import NotebookApp
         except ImportError:
-            if release.version_info[0] >= 7:
-                return traceback.format_exc()
             try:
-                from IPython.html.notebookapp import NotebookApp
+                from notebook.app import JupyterNotebookApp as NotebookApp
             except ImportError:
-                if release.version_info[0] >= 3:
+                if release.version_info[0] >= 7:
                     return traceback.format_exc()
                 try:
-                    from IPython.frontend.html.notebook import notebookapp
-
-                    NotebookApp = notebookapp.NotebookApp
+                    from IPython.html.notebookapp import NotebookApp
                 except ImportError:
-                    return traceback.format_exc()
+                    if release.version_info[0] >= 3:
+                        return traceback.format_exc()
+                    try:
+                        from IPython.frontend.html.notebook import notebookapp
+
+                        NotebookApp = notebookapp.NotebookApp
+                    except ImportError:
+                        return traceback.format_exc()
 
         use_kernel_specs = release.version_info[0] >= 3
 


### PR DESCRIPTION
Fixes #1830

### Root cause

See the linked issue #1830 for the failure report and reproduction.

### Summary

See the diff. The change is minimal and localized.

### Changed files

- `django_extensions/management/commands/shell_plus.py`

### Verification

- `pytest -q --tb=long --no-header`
- Target test passes after the fix
- Full regression suite passes

Low risk. Changes are localized and covered by tests.
