### PR TITLE
fix: replace bare except with except Exception in dumpscript save_or_locate

### DIFF
--- a/django_extensions/management/commands/dumpscript.py
+++ b/django_extensions/management/commands/dumpscript.py
@@ -664,7 +664,7 @@ class BasicImportHelper:
         # Change this if you want to locate the object in the database
         try:
             the_obj.save()
-        except:
+        except Exception:
             print("---------------")
             print("Error saving the following object:")
             print(the_obj.__class__)


### PR DESCRIPTION
Replace the bare `except:` in `save_or_locate()` with `except Exception:` — same intended behavior (print the object that failed to save), but KeyboardInterrupt/SystemExit are no longer intercepted first. Verified: `python -m py_compile` passes.