### PR TITLE
Fix list_signals AttributeError when receiver sender is not a model instance (#1893)

### DIFF
--- a/django_extensions/management/commands/list_signals.py
+++ b/django_extensions/management/commands/list_signals.py
@@ -79,10 +79,15 @@ class Command(BaseCommand):
 
         output = []
         for key in sorted(models.keys(), key=str):
-            verbose_name = force_str(key._meta.verbose_name)
-            output.append(
-                "{}.{} ({})".format(key.__module__, key.__name__, verbose_name)
-            )
+            if hasattr(key, "_meta"):
+                verbose_name = force_str(key._meta.verbose_name)
+                output.append(
+                    "{}.{} ({})".format(key.__module__, key.__name__, verbose_name)
+                )
+            elif hasattr(key, "__module__") and hasattr(key, "__name__"):
+                output.append("{}.{}".format(key.__module__, key.__name__))
+            else:
+                output.append("{}".format(key))
             for signal_name in sorted(models[key].keys()):
                 lines = models[key][signal_name]
                 output.append("    {}".format(signal_name))

--- a/tests/management/commands/test_list_signals.py
+++ b/tests/management/commands/test_list_signals.py
@@ -27,3 +27,18 @@ tests.testapp.models.HasOwnerModel (has owner model)
         # Strip line numbers to make the test less brittle
         out = re.sub(r"(?<=#)\d+", "", self.out.getvalue(), flags=re.M)
         self.assertIn(expected_result, out)
+
+    def test_should_handle_non_model_sender(self):
+        from django.db.models.signals import pre_save
+
+        def dummy_custom_signal_handler(sender, **kwargs):
+            pass
+
+        pre_save.connect(dummy_custom_signal_handler, sender=None)
+        try:
+            call_command("list_signals", stdout=self.out)
+            out = self.out.getvalue()
+            self.assertIn("_unknown_", out)
+            self.assertIn("dummy_custom_signal_handler", out)
+        finally:
+            pre_save.disconnect(dummy_custom_signal_handler, sender=None)


### PR DESCRIPTION
## Summary
Fixes #1893

When signal receivers are connected without a model `sender` (e.g. `sender=None`) or with a non-model sender, `model_lookup.get(sender_id, "_unknown_")` returns the fallback string `"_unknown_"`.

During output formatting in `list_signals.py`:
```python
for key in sorted(models.keys(), key=str):
    verbose_name = force_str(key._meta.verbose_name)
```
Accessing `key._meta` raised `AttributeError: 'str' object has no attribute '_meta'`.

## Changes
- Check `hasattr(key, "_meta")` before accessing `key._meta.verbose_name`.
- Fall back gracefully to `f"{key.__module__}.{key.__name__}"` or `str(key)` for non-model keys like `"_unknown_"`.
- Added unit test `test_should_handle_non_model_sender` in `tests/management/commands/test_list_signals.py`.

## Validation
Ran unit tests:
- `pytest tests/management/commands/test_list_signals.py` -> 2 passed.