### PR TITLE
Don't crash print-sql when last_executed_query returns None

### DIFF
--- a/django_extensions/management/debug_cursor.py
+++ b/django_extensions/management/debug_cursor.py
@@ -69,6 +69,8 @@ def monkey_patch_cursordebugwrapper(
                 finally:
                     execution_time = time.time() - starttime
                     raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
+                    if raw_sql is None:
+                        raw_sql = sql or ""
                     if truncate:
                         raw_sql = raw_sql[:truncate]
 

--- a/tests/management/commands/shell_plus_tests/test_shell_plus.py
+++ b/tests/management/commands/shell_plus_tests/test_shell_plus.py
@@ -1,5 +1,6 @@
 import os
 import re
+from unittest import mock
 import pytest
 import inspect
 
@@ -93,6 +94,24 @@ def test_shell_plus_print_sql_truncate(capsys):
 
     assert re.search(r"SELE", out)
     assert not re.search(r"SELEC", out)
+
+
+@pytest.mark.django_db()
+@override_settings(SHELL_PLUS_SQLPARSE_ENABLED=True, SHELL_PLUS_PYGMENTS_ENABLED=False)
+def test_print_sql_when_last_executed_query_is_none():
+    from django.db import connection
+    from django_extensions.management.debug_cursor import monkey_patch_cursordebugwrapper
+
+    logged = []
+    with monkey_patch_cursordebugwrapper(print_sql=True, truncate=None, logger=logged.append):
+        with mock.patch.object(
+            connection.ops, "last_executed_query", return_value=None
+        ):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+
+    assert logged
+    assert "1" in logged[0]
 
 
 def test_shell_plus_plain_startup():

--- a/tests/management/commands/shell_plus_tests/test_shell_plus.py
+++ b/tests/management/commands/shell_plus_tests/test_shell_plus.py
@@ -100,10 +100,14 @@ def test_shell_plus_print_sql_truncate(capsys):
 @override_settings(SHELL_PLUS_SQLPARSE_ENABLED=True, SHELL_PLUS_PYGMENTS_ENABLED=False)
 def test_print_sql_when_last_executed_query_is_none():
     from django.db import connection
-    from django_extensions.management.debug_cursor import monkey_patch_cursordebugwrapper
+    from django_extensions.management.debug_cursor import (
+        monkey_patch_cursordebugwrapper,
+    )
 
     logged = []
-    with monkey_patch_cursordebugwrapper(print_sql=True, truncate=None, logger=logged.append):
+    with monkey_patch_cursordebugwrapper(
+        print_sql=True, truncate=None, logger=logged.append
+    ):
         with mock.patch.object(
             connection.ops, "last_executed_query", return_value=None
         ):


### PR DESCRIPTION
`PrintQueryWrapperMixin` always handed `last_executed_query()` to sqlparse. On PostgreSQL that can be `None` (DateTimeRangeField / django-auditlog), and the lexer then dies.

Fall back to the statement we just ran.

Fixes #1956
