### PR TITLE
fix(shell_plus): fallback to ipykernel launch_new_instance for IPython 9 compatibility

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -191,7 +191,12 @@ class Command(BaseCommand):
                     self.style.ERROR("--kernel requires at least IPython version 2.0")
                 )
                 return
-            from IPython import start_kernel
+            try:
+                from IPython import start_kernel
+            except ImportError:
+                from ipykernel.kernelapp import (
+                    launch_new_instance as start_kernel,
+                )
         except ImportError:
             return traceback.format_exc()
 

--- a/tests/management/commands/shell_plus_tests/test_shell_plus.py
+++ b/tests/management/commands/shell_plus_tests/test_shell_plus.py
@@ -209,3 +209,43 @@ def test_shell_plus_skipping_models_import_cli():
 @override_settings(SHELL_PLUS_DONT_LOAD=["*"])
 def test_shell_plus_skipping_models_import_settings():
     assert_should_models_be_imported(False)
+
+
+def test_shell_plus_get_kernel():
+    command = shell_plus.Command()
+    with mock.patch("ipykernel.kernelapp.launch_new_instance") as mock_launch:
+        run_kernel = command.get_kernel({"connection_file": None})
+        assert callable(run_kernel)
+        run_kernel()
+        mock_launch.assert_called_once()
+        kwargs = mock_launch.call_args[1]
+        assert kwargs["argv"] == []
+        assert "User" in kwargs["user_ns"]
+
+
+def test_shell_plus_get_kernel_legacy_ipython():
+    command = shell_plus.Command()
+    mock_start_kernel = mock.MagicMock()
+    with mock.patch.dict("sys.modules", {"IPython.start_kernel": mock_start_kernel}):
+        with mock.patch("IPython.start_kernel", mock_start_kernel, create=True):
+            run_kernel = command.get_kernel({"connection_file": None})
+            assert callable(run_kernel)
+            run_kernel()
+            mock_start_kernel.assert_called_once()
+            kwargs = mock_start_kernel.call_args[1]
+            assert kwargs["argv"] == []
+            assert "User" in kwargs["user_ns"]
+
+
+def test_shell_plus_get_kernel_with_connection_file():
+    command = shell_plus.Command()
+    with mock.patch("ipykernel.kernelapp.launch_new_instance") as mock_launch:
+        run_kernel = command.get_kernel({"connection_file": "test_connection.json"})
+        assert callable(run_kernel)
+        run_kernel()
+        mock_launch.assert_called_once()
+        kwargs = mock_launch.call_args[1]
+        assert kwargs["argv"] == []
+        assert kwargs["connection_file"] == "test_connection.json"
+
+


### PR DESCRIPTION
## Description

In IPython 9.0+, \IPython.start_kernel\ was removed after having been deprecated in favor of \ipykernel.kernelapp.launch_new_instance\. As reported in #1917, running \shell_plus --kernel\ on environments with IPython >= 9.0 raises:
\\\
ImportError: cannot import name 'start_kernel' from 'IPython'
\\\

This PR updates \get_kernel\ in \django_extensions/management/commands/shell_plus.py\ to attempt importing \start_kernel\ from \IPython\, and if that fails with an \ImportError\ (e.g. on IPython 9+), gracefully falls back to \rom ipykernel.kernelapp import launch_new_instance as start_kernel\.

## Changes
- In \django_extensions/management/commands/shell_plus.py\: catch \ImportError\ when importing \start_kernel\ from \IPython\ and fall back to importing \launch_new_instance\ from \ipykernel.kernelapp\.
- In \	ests/management/commands/shell_plus_tests/test_shell_plus.py\: added unit tests verifying \get_kernel\ initializes and starts the kernel properly via \ipykernel.kernelapp.launch_new_instance\, supports legacy \IPython.start_kernel\, and respects \--connection-file\.

Closes #1917